### PR TITLE
Add test cases for static field/property and extension method. See issue #50

### DIFF
--- a/src/NRules/NRules/Utilities/ExpressionComparer.cs
+++ b/src/NRules/NRules/Utilities/ExpressionComparer.cs
@@ -81,6 +81,12 @@ namespace NRules.Utilities
 
         private static bool MemberExpressionsEqual(MemberExpression x, MemberExpression y, LambdaExpression rootX, LambdaExpression rootY)
         {
+            // Special case for static field and static property
+            if (x.Expression == null)
+            {
+                return Equals(x.Member, y.Member);
+            }
+
             if (x.Expression.NodeType != y.Expression.NodeType)
                 return false;
             switch (x.Expression.NodeType)
@@ -90,6 +96,7 @@ namespace NRules.Utilities
                     var consty = GetValueOfConstantExpression(y);
                     return Equals(constx, consty);
                 case ExpressionType.Parameter:
+                case ExpressionType.MemberAccess:
                     return Equals(x.Member, y.Member) && ExpressionEqual(x.Expression, y.Expression, rootX, rootY);
                 default:
                     throw new NotImplementedException(x.ToString());

--- a/src/NRules/Tests/NRules.Tests/Utilities/ExpressionComparerTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Utilities/ExpressionComparerTest.cs
@@ -32,7 +32,7 @@ namespace NRules.Tests.Utilities
             Expression<Func<int, int, bool>> first = (i1, i2) => i1 == i2;
             Expression<Func<int, int, bool>> second = (ii1, ii2) => ii1 != ii2;
 
-            AssertEqual(first, second, false);
+            AssertNotEqual(first, second);
         }
         
         [Test]
@@ -66,7 +66,7 @@ namespace NRules.Tests.Utilities
         }
 
         [Test]
-        public void AreEqual_EquivalentMember_StaticField()
+        public void AreEqual_EquivalentMember_StaticField_True()
         {
             //Arrange
             Expression<Func<SomeFact, bool>> first = f => f.Value == StaticField;
@@ -76,7 +76,7 @@ namespace NRules.Tests.Utilities
         }
 
         [Test]
-        public void AreEqual_EquivalentMember_StaticProperty()
+        public void AreEqual_EquivalentMember_StaticProperty_True()
         {
             //Arrange
             Expression<Func<SomeFact, bool>> first = f => f.Value == StaticProperty;
@@ -86,7 +86,7 @@ namespace NRules.Tests.Utilities
         }
 
         [Test]
-        public void AreEqual_EquivalentMember_StaticMethod()
+        public void AreEqual_EquivalentMember_StaticMethod_True()
         {
             //Arrange
             Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod();
@@ -96,7 +96,7 @@ namespace NRules.Tests.Utilities
         }
 
         [Test]
-        public void AreEqual_EquivalentMember_StaticMethodWithArguments()
+        public void AreEqual_EquivalentMember_StaticMethodWithArguments_True()
         {
             //Arrange
             Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod("one");
@@ -112,11 +112,11 @@ namespace NRules.Tests.Utilities
             Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod("one");
             Expression<Func<SomeFact, bool>> second = f => f.Value == StaticMethod("two");
 
-            AssertEqual(first, second, false);
+            AssertNotEqual(first, second);
         }
 
         [Test]
-        public void AreEqual_EquivalentMember_MemberAccessExtension()
+        public void AreEqual_EquivalentMember_MemberAccessExtension_True()
         {
             //Arrange
             Expression<Func<SomeFact, bool>> first = f => f.Child.Values.Contains("sdlkjf");
@@ -126,7 +126,7 @@ namespace NRules.Tests.Utilities
         }
 
         [Test]
-        public void AreEqual_EquivalentMember_MemberAccess()
+        public void AreEqual_EquivalentMember_MemberAccess_True()
         {
             //Arrange
             Expression<Func<SomeFact, bool>> first = f => f.Child.Values.GetLength(0) == 0;
@@ -136,7 +136,7 @@ namespace NRules.Tests.Utilities
         }
 
         [Test]
-        public void AreEqual_EquivalentMember_MemberAccessIndexer()
+        public void AreEqual_EquivalentMember_MemberAccessIndexer_True()
         {
             //Arrange
             Expression<Func<SomeFact, bool>> first = f => f.Child.Values[0] == "1";
@@ -152,16 +152,25 @@ namespace NRules.Tests.Utilities
             Expression<Func<SomeFact, bool>> first = f => f.Child.Values[0] == "1";
             Expression<Func<SomeFact, bool>> second = f => f.Child.Values[1] == "1";
 
-            AssertEqual(first, second, false);
+            AssertNotEqual(first, second);
         }
 
-        private static void AssertEqual(Expression first, Expression second, bool expected = true)
+        private static void AssertEqual(Expression first, Expression second)
         {
             //Act
             bool result = ExpressionComparer.AreEqual(first, second);
 
             //Assert
-            Assert.That(result, Is.EqualTo(expected));
+            Assert.That(result, Is.True);
+        }
+
+        private static void AssertNotEqual(Expression first, Expression second)
+        {
+            //Act
+            bool result = ExpressionComparer.AreEqual(first, second);
+
+            //Assert
+            Assert.That(result, Is.False);
         }
 
         // A few fields and classes for some more advanced tests.

--- a/src/NRules/Tests/NRules.Tests/Utilities/ExpressionComparerTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Utilities/ExpressionComparerTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Linq.Expressions;
 using NRules.Utilities;
 using NUnit.Framework;
@@ -11,11 +12,7 @@ namespace NRules.Tests.Utilities
         [Test]
         public void AreEqual_BothNull_True()
         {
-            //Arrange - Act
-            bool result = ExpressionComparer.AreEqual(null, null);
-
-            //Assert
-            Assert.True(result);
+            AssertEqual(null, null);
         }
 
         [Test]
@@ -25,11 +22,7 @@ namespace NRules.Tests.Utilities
             Expression<Func<int, int, bool>> first = (i1, i2) => i1 == i2;
             Expression<Func<int, int, bool>> second = (ii1, ii2) => ii1 == ii2;
 
-            //Act
-            bool result = ExpressionComparer.AreEqual(first, second);
-
-            //Assert
-            Assert.True(result);
+            AssertEqual(first, second);
         }
         
         [Test]
@@ -39,11 +32,7 @@ namespace NRules.Tests.Utilities
             Expression<Func<int, int, bool>> first = (i1, i2) => i1 == i2;
             Expression<Func<int, int, bool>> second = (ii1, ii2) => ii1 != ii2;
 
-            //Act
-            bool result = ExpressionComparer.AreEqual(first, second);
-
-            //Assert
-            Assert.False(result);
+            AssertEqual(first, second, false);
         }
         
         [Test]
@@ -53,11 +42,7 @@ namespace NRules.Tests.Utilities
             Expression<Func<int, int>> first = i => -i;
             Expression<Func<int, int>> second = i => -i;
 
-            //Act
-            bool result = ExpressionComparer.AreEqual(first, second);
-
-            //Assert
-            Assert.True(result);
+            AssertEqual(first, second);
         }
         
         [Test]
@@ -67,11 +52,7 @@ namespace NRules.Tests.Utilities
             Expression<Func<DateTime, DayOfWeek>> first = d => d.DayOfWeek;
             Expression<Func<DateTime, DayOfWeek>> second = d => d.DayOfWeek;
 
-            //Act
-            bool result = ExpressionComparer.AreEqual(first, second);
-
-            //Assert
-            Assert.True(result);
+            AssertEqual(first, second);
         }
 
         [Test]
@@ -81,11 +62,136 @@ namespace NRules.Tests.Utilities
             Expression<Func<DateTime, DateTime>> first = d => d.ToLocalTime();
             Expression<Func<DateTime, DateTime>> second = d => d.ToLocalTime();
 
+            AssertEqual(first, second);
+        }
+
+        [Test]
+        public void AreEqual_EquivalentMember_StaticField()
+        {
+            //Arrange
+            Expression<Func<SomeFact, bool>> first = f => f.Value == StaticField;
+            Expression<Func<SomeFact, bool>> second = f => f.Value == StaticField;
+
+            AssertEqual(first, second);
+        }
+
+        [Test]
+        public void AreEqual_EquivalentMember_StaticProperty()
+        {
+            //Arrange
+            Expression<Func<SomeFact, bool>> first = f => f.Value == StaticProperty;
+            Expression<Func<SomeFact, bool>> second = f => f.Value == StaticProperty;
+
+            AssertEqual(first, second);
+        }
+
+        [Test]
+        public void AreEqual_EquivalentMember_StaticMethod()
+        {
+            //Arrange
+            Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod();
+            Expression<Func<SomeFact, bool>> second = f => f.Value == StaticMethod();
+
+            AssertEqual(first, second);
+        }
+
+        [Test]
+        public void AreEqual_EquivalentMember_StaticMethodWithArguments()
+        {
+            //Arrange
+            Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod("one");
+            Expression<Func<SomeFact, bool>> second = f => f.Value == StaticMethod("one");
+
+            AssertEqual(first, second);
+        }
+
+        [Test]
+        public void AreEqual_EquivalentMember_StaticMethodWithArguments_False()
+        {
+            //Arrange
+            Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod("one");
+            Expression<Func<SomeFact, bool>> second = f => f.Value == StaticMethod("two");
+
+            AssertEqual(first, second, false);
+        }
+
+        [Test]
+        public void AreEqual_EquivalentMember_MemberAccessExtension()
+        {
+            //Arrange
+            Expression<Func<SomeFact, bool>> first = f => f.Child.Values.Contains("sdlkjf");
+            Expression<Func<SomeFact, bool>> second = f => f.Child.Values.Contains("sdlkjf");
+            
+            AssertEqual(first, second);
+        }
+
+        [Test]
+        public void AreEqual_EquivalentMember_MemberAccess()
+        {
+            //Arrange
+            Expression<Func<SomeFact, bool>> first = f => f.Child.Values.GetLength(0) == 0;
+            Expression<Func<SomeFact, bool>> second = f => f.Child.Values.GetLength(0) == 0;
+
+            AssertEqual(first, second);
+        }
+
+        [Test]
+        public void AreEqual_EquivalentMember_MemberAccessIndexer()
+        {
+            //Arrange
+            Expression<Func<SomeFact, bool>> first = f => f.Child.Values[0] == "1";
+            Expression<Func<SomeFact, bool>> second = f => f.Child.Values[0] == "1";
+
+            AssertEqual(first, second);
+        }
+
+        [Test]
+        public void AreEqual_EquivalentMember_MemberAccessIndexer_False()
+        {
+            //Arrange
+            Expression<Func<SomeFact, bool>> first = f => f.Child.Values[0] == "1";
+            Expression<Func<SomeFact, bool>> second = f => f.Child.Values[1] == "1";
+
+            AssertEqual(first, second, false);
+        }
+
+        private static void AssertEqual(Expression first, Expression second, bool expected = true)
+        {
             //Act
             bool result = ExpressionComparer.AreEqual(first, second);
 
             //Assert
-            Assert.True(result);
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        // A few fields and classes for some more advanced tests.
+        public static int StaticField = 1;
+
+        public static int StaticProperty
+        {
+            get { return 1; }
+        }
+
+        public static int StaticMethod()
+        {
+            return 1;
+        }
+
+        public static int StaticMethod(string param1)
+        {
+            return param1.GetHashCode();
+        }
+
+        public class SomeFact
+        {
+            public int Value = 1;
+
+            public SomeClass Child = new SomeClass();
+        }
+
+        public class SomeClass
+        {
+            public string[] Values = { "blop" };
         }
     }
 }


### PR DESCRIPTION
#50

Adds a few new tests and modifies the existing ExpressionComparer to support static fields and properties.

Also add supports for calling extension methods on nested properties.