### PR TITLE
Added failing test for possible regression.

### DIFF
--- a/src/NRules/Tests/NRules.IntegrationTests/TryRetractRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TryRetractRuleTest.cs
@@ -1,0 +1,81 @@
+﻿using NRules.Fluent.Dsl;
+using NRules.IntegrationTests.TestAssets;
+using Xunit;
+using System.Linq;
+
+namespace NRules.IntegrationTests
+{
+    public class TryRetractRuleTest : BaseRuleTestFixture
+    {
+        [Fact]
+        public void Fire_OneMatchingFact_FiresOnceAndRetractsFact()
+        {
+            //Arrange
+            var fact1 = new FactType { TestProperty = "Valid Value 1" };
+            var facts = new[] { fact1 };
+            Session.InsertAll(facts);
+
+            //Act
+            Session.Fire();
+
+            //Assert
+            AssertFiredOnce();
+            Assert.Equal(0, Session.Query<FactType>().Count());
+        }
+
+        [Fact]
+        public void Fire_NoMatchingFact_DoesNotFire()
+        {
+            //Arrange
+            var fact1 = new FactType { TestProperty = "Invalid Value 1" };
+            var facts = new[] { fact1 };
+            Session.InsertAll(facts);
+
+            //Act
+            Session.Fire();
+
+            //Assert
+            AssertDidNotFire();
+        }
+
+        [Fact]
+        public void Fire_TwoMatchingFacts_FiresTwiceAndRetractsFacts()
+        {
+            //Arrange
+            var fact1 = new FactType { TestProperty = "Valid Value 1" };
+            var fact2 = new FactType { TestProperty = "Valid Value 2" };
+            var facts = new[] { fact1, fact2 };
+            Session.InsertAll(facts);
+
+            //Act
+            Session.Fire();
+
+            //Assert
+            AssertFiredTwice();
+            Assert.Equal(0, Session.Query<FactType>().Count());
+        }
+
+        protected override void SetUpRules()
+        {
+            SetUpRule<TestRule>();
+        }
+
+        public class FactType
+        {
+            public string TestProperty { get; set; }
+        }
+
+        public class TestRule : Rule
+        {
+            public override void Define()
+            {
+                FactType fact = null;
+
+                When()
+                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
+                Then()
+                    .Do(ctx => ctx.TryRetract(fact));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Today I've updated my code base from NRules 0.5.3 to 0.7.1. After doing this I stumbled upon an issue while running my test suite. It happens during the compilation of Rules.
Here's a pull request that adds a failing test for the new issue. I haven't had the time to dig into the problem (yet), so I'm not sure if it actually is a regression, or intended.

```
Message: NRules.RuleCompilationException : Failed to compile rule
NRules.IntegrationTests.TryRetractRuleTest+TestRule
---- System.InvalidOperationException : No coercion operator is defined between types 'System.Boolean' and 'System.Object[]'.
```

The issue is happens when an action called in the `.Do(ctx => )`  has a return value. 
`.Do(ctx => ctx.Retract(fact))` works, while `.Do(ctx => ctx.TryRetract(fact))` does not.


By the way: I'm really happy to see the Let and Calculate methods you added in 0.7. Thanks alot for this.
