### PR TITLE
Fix V3031 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/src/NRules/NRules/Agenda.cs
+++ b/src/NRules/NRules/Agenda.cs
@@ -73,8 +73,8 @@ namespace NRules
             if (!Accept(activation)) return;
             _activationQueue.Enqueue(activation.CompiledRule.Priority, activation);
         }
-
-        public void Modify(IExecutionContext context, Activation activation)
+        //I apologize, but the analyzer issued a warning here. Methods Add and Modify Implement the same code, is this normal behavior? Unfortunately I can not go deep into the project to find out.
+        public void Modify(IExecutionContext context, Activation activation) 
         {
             if (!Accept(activation)) return;
             _activationQueue.Enqueue(activation.CompiledRule.Priority, activation);


### PR DESCRIPTION
Hello. I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warnings with medium priority:

[V3013](https://www.viva64.com/en/w/v3013/) It is odd that the body of 'Add' function is fully equivalent to the body of 'Modify' function (71, line 77). Agenda.cs 71

I apologize, but the analyzer issued a warning here. Methods Add and Modify Implement the same code, is this normal behavior? Unfortunately I can not go deep into the project to find out.

Sorry my english, I use google translate.