### PR TITLE
Fix dotnet-install.ps1 url

### DIFF
--- a/tools/build/buildutils.ps1
+++ b/tools/build/buildutils.ps1
@@ -129,7 +129,7 @@ function Install-DotNetCli([string] $location, [string] $version) {
     }
 
     if (!(Test-Path $location\dotnet-install.ps1)) {
-        $url = "https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.ps1"
+        $url = "https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1"
         Invoke-WebRequest $url -OutFile "$location\dotnet-install.ps1"
     }
 


### PR DESCRIPTION
Provided correct URL for `dotnet-install.ps1`