### PR TITLE
Use file-scoped namespaces

### DIFF
--- a/bench/NRules.Benchmark/NRules.Benchmark/Expressions/BenchmarkBase.cs
+++ b/bench/NRules.Benchmark/NRules.Benchmark/Expressions/BenchmarkBase.cs
@@ -2,29 +2,28 @@
 using NRules.Diagnostics;
 using NRules.Rete;
 
-namespace NRules.Benchmark.Expressions
+namespace NRules.Benchmark.Expressions;
+
+[MemoryDiagnoser]
+public abstract class BenchmarkBase
 {
-    [MemoryDiagnoser]
-    public abstract class BenchmarkBase
+    internal IExecutionContext Context;
+
+    protected BenchmarkBase()
     {
-        internal IExecutionContext Context;
+        Context = new ExecutionContext(null, null, null, new EventAggregator(), null, null);
+    }
 
-        protected BenchmarkBase()
+    internal static Tuple ToTuple(params object[] values)
+    {
+        int i = 0;
+        var tuple = new Tuple(i);
+
+        foreach (var value in values)
         {
-            Context = new ExecutionContext(null, null, null, new EventAggregator(), null, null);
+            tuple = new Tuple(++i, tuple, new Fact(value));
         }
 
-        internal static Tuple ToTuple(params object[] values)
-        {
-            int i = 0;
-            var tuple = new Tuple(i);
-
-            foreach (var value in values)
-            {
-                tuple = new Tuple(++i, tuple, new Fact(value));
-            }
-
-            return tuple;
-        }
+        return tuple;
     }
 }

--- a/bench/NRules.Benchmark/NRules.Benchmark/Expressions/BenchmarkLhsExpression.cs
+++ b/bench/NRules.Benchmark/NRules.Benchmark/Expressions/BenchmarkLhsExpression.cs
@@ -8,41 +8,40 @@ using NRules.RuleModel.Builders;
 using NRules.Utilities;
 using Tuple = NRules.Rete.Tuple;
 
-namespace NRules.Benchmark.Expressions
+namespace NRules.Benchmark.Expressions;
+
+[BenchmarkCategory("Micro", "Expressions")]
+public class BenchmarkLhsExpression : BenchmarkBase
 {
-    [BenchmarkCategory("Micro", "Expressions")]
-    public class BenchmarkLhsExpression : BenchmarkBase
+    private readonly NodeInfo _nodeInfo;
+    private readonly ILhsExpression<bool> _lhsExpression;
+    private readonly ILhsTupleExpression<bool> _lhsTupleExpression;
+    private readonly ILhsFactExpression<bool> _lhsFactExpression;
+    private readonly Tuple _tuple;
+    private readonly Fact _fact;
+
+    public BenchmarkLhsExpression()
     {
-        private readonly NodeInfo _nodeInfo;
-        private readonly ILhsExpression<bool> _lhsExpression;
-        private readonly ILhsTupleExpression<bool> _lhsTupleExpression;
-        private readonly ILhsFactExpression<bool> _lhsFactExpression;
-        private readonly Tuple _tuple;
-        private readonly Fact _fact;
+        _nodeInfo = new NodeInfo();
+        var ruleExpressionCompiler = new RuleExpressionCompiler();
+        Expression<Func<string, int, decimal, bool>> betaExpression = (s, i, d) => s.Length == i;
+        var betaElement = Element.Condition(betaExpression);
+        _lhsExpression = ruleExpressionCompiler.CompileLhsTupleFactExpression<bool>(betaElement, betaElement.Imports.ToList());
+        _lhsTupleExpression = ruleExpressionCompiler.CompileLhsTupleExpression<bool>(betaElement, betaElement.Imports.ToList());
+        _tuple = ToTuple("abcd", 4, 1.0m);
 
-        public BenchmarkLhsExpression()
-        {
-            _nodeInfo = new NodeInfo();
-            var ruleExpressionCompiler = new RuleExpressionCompiler();
-            Expression<Func<string, int, decimal, bool>> betaExpression = (s, i, d) => s.Length == i;
-            var betaElement = Element.Condition(betaExpression);
-            _lhsExpression = ruleExpressionCompiler.CompileLhsTupleFactExpression<bool>(betaElement, betaElement.Imports.ToList());
-            _lhsTupleExpression = ruleExpressionCompiler.CompileLhsTupleExpression<bool>(betaElement, betaElement.Imports.ToList());
-            _tuple = ToTuple("abcd", 4, 1.0m);
-
-            Expression<Func<string, bool>> alphaExpression = s => s.Length == 1;
-            var alphaElement = Element.Condition(alphaExpression);
-            _lhsFactExpression = ruleExpressionCompiler.CompileLhsFactExpression<bool>(alphaElement);
-            _fact = new Fact("abcd");
-        }
-
-        [Benchmark]
-        public bool EvaluateTupleFactExpression() => _lhsExpression.Invoke(Context, _nodeInfo, _tuple.LeftTuple, _tuple.RightFact);
-  
-        [Benchmark]
-        public bool EvaluateTupleExpression() => _lhsTupleExpression.Invoke(Context, _nodeInfo, _tuple); 
-        
-        [Benchmark]
-        public bool EvaluateFactExpression() => _lhsFactExpression.Invoke(Context, _nodeInfo, _fact);
+        Expression<Func<string, bool>> alphaExpression = s => s.Length == 1;
+        var alphaElement = Element.Condition(alphaExpression);
+        _lhsFactExpression = ruleExpressionCompiler.CompileLhsFactExpression<bool>(alphaElement);
+        _fact = new Fact("abcd");
     }
+
+    [Benchmark]
+    public bool EvaluateTupleFactExpression() => _lhsExpression.Invoke(Context, _nodeInfo, _tuple.LeftTuple, _tuple.RightFact);
+
+    [Benchmark]
+    public bool EvaluateTupleExpression() => _lhsTupleExpression.Invoke(Context, _nodeInfo, _tuple); 
+    
+    [Benchmark]
+    public bool EvaluateFactExpression() => _lhsFactExpression.Invoke(Context, _nodeInfo, _fact);
 }

--- a/bench/NRules.Benchmark/NRules.Benchmark/Expressions/BenchmarkRuleAction.cs
+++ b/bench/NRules.Benchmark/NRules.Benchmark/Expressions/BenchmarkRuleAction.cs
@@ -10,37 +10,36 @@ using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 using NRules.Utilities;
 
-namespace NRules.Benchmark.Expressions
+namespace NRules.Benchmark.Expressions;
+
+[BenchmarkCategory("Micro", "Expressions")]
+public class BenchmarkRuleAction : BenchmarkBase
 {
-    [BenchmarkCategory("Micro", "Expressions")]
-    public class BenchmarkRuleAction : BenchmarkBase
+    private readonly IActionContext _actionContext;
+    private readonly IRuleAction _ruleAction;
+
+    public BenchmarkRuleAction()
     {
-        private readonly IActionContext _actionContext;
-        private readonly IRuleAction _ruleAction;
+        var ruleExpressionCompiler = new RuleExpressionCompiler();
+        Expression<Action<IContext, string, int, decimal>> expression = (c, s, i, d) => PerformAction(c, s, i, d);
+        var element = Element.Action(expression);
+        var map = IndexMap.CreateMap(element.Imports, element.Imports);
+        _ruleAction = ruleExpressionCompiler.CompileAction(element, element.Imports.ToList(), new List<DependencyElement>(), map);
 
-        public BenchmarkRuleAction()
-        {
-            var ruleExpressionCompiler = new RuleExpressionCompiler();
-            Expression<Action<IContext, string, int, decimal>> expression = (c, s, i, d) => PerformAction(c, s, i, d);
-            var element = Element.Action(expression);
-            var map = IndexMap.CreateMap(element.Imports, element.Imports);
-            _ruleAction = ruleExpressionCompiler.CompileAction(element, element.Imports.ToList(), new List<DependencyElement>(), map);
+        var compiledRule = new CompiledRule(null, element.Imports, new []{_ruleAction}, null, map);
+        var tuple = ToTuple("abcd", 4, 1.0m);
+        var activation = new Activation(compiledRule, tuple);
+        _actionContext = new ActionContext(Context.Session, activation, CancellationToken.None);
+    }
 
-            var compiledRule = new CompiledRule(null, element.Imports, new []{_ruleAction}, null, map);
-            var tuple = ToTuple("abcd", 4, 1.0m);
-            var activation = new Activation(compiledRule, tuple);
-            _actionContext = new ActionContext(Context.Session, activation, CancellationToken.None);
-        }
+    [Benchmark]
+    public void EvaluateExpression()
+    {
+        _ruleAction.Invoke(Context, _actionContext);
+    }
 
-        [Benchmark]
-        public void EvaluateExpression()
-        {
-            _ruleAction.Invoke(Context, _actionContext);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void PerformAction(IContext context, string value1, int value2, decimal value3)
-        {
-        }
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void PerformAction(IContext context, string value1, int value2, decimal value3)
+    {
     }
 }

--- a/bench/NRules.Benchmark/NRules.Benchmark/Meta/BenchmarkBase.cs
+++ b/bench/NRules.Benchmark/NRules.Benchmark/Meta/BenchmarkBase.cs
@@ -2,20 +2,19 @@
 using NRules.Fluent;
 using NRules.Fluent.Dsl;
 
-namespace NRules.Benchmark.Meta
+namespace NRules.Benchmark.Meta;
+
+[MemoryDiagnoser]
+[ShortRunJob, WarmupCount(1)]
+public abstract class BenchmarkBase
 {
-    [MemoryDiagnoser]
-    [ShortRunJob, WarmupCount(1)]
-    public abstract class BenchmarkBase
+    protected ISessionFactory Factory { get; set; }
+
+    protected void SetupRule<T>() where T : Rule
     {
-        protected ISessionFactory Factory { get; set; }
+        var repository = new RuleRepository();
+        repository.Load(x => x.NestedTypes().PrivateTypes().From(xx => xx.Type(typeof(T))));
 
-        protected void SetupRule<T>() where T : Rule
-        {
-            var repository = new RuleRepository();
-            repository.Load(x => x.NestedTypes().PrivateTypes().From(xx => xx.Type(typeof(T))));
-
-            Factory = repository.Compile();
-        }
+        Factory = repository.Compile();
     }
 }

--- a/bench/NRules.Benchmark/NRules.Benchmark/Meta/BenchmarkMultipleRules.cs
+++ b/bench/NRules.Benchmark/NRules.Benchmark/Meta/BenchmarkMultipleRules.cs
@@ -5,89 +5,88 @@ using BenchmarkDotNet.Attributes;
 using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 
-namespace NRules.Benchmark.Meta
+namespace NRules.Benchmark.Meta;
+
+[BenchmarkCategory("Meta")]
+public class BenchmarkMultipleRules : BenchmarkBase
 {
-    [BenchmarkCategory("Meta")]
-    public class BenchmarkMultipleRules : BenchmarkBase
+    private TestFact1[] _facts1;
+
+    [GlobalSetup]
+    public void Setup()
     {
-        private TestFact1[] _facts1;
-
-        [GlobalSetup]
-        public void Setup()
+        var rules = new List<IRuleDefinition>();
+        for (int i = 1; i <= RuleCount; i++)
         {
-            var rules = new List<IRuleDefinition>();
-            for (int i = 1; i <= RuleCount; i++)
-            {
-                var rule = BuildRule(i);
-                rules.Add(rule);
-            }
-
-            var compiler = new RuleCompiler();
-            Factory = compiler.Compile(rules);
-
-            _facts1 = new TestFact1[FactCount];
-            for (int i = 0; i < FactCount; i++)
-            {
-                _facts1[i] = new TestFact1{IntProperty = i};
-            }
+            var rule = BuildRule(i);
+            rules.Add(rule);
         }
 
-        [Params(10, 100, 1000)]
-        public int RuleCount { get; set; }
+        var compiler = new RuleCompiler();
+        Factory = compiler.Compile(rules);
 
-        [Params(100)]
-        public int FactCount { get; set; }
-
-        [Benchmark]
-        public int Insert()
+        _facts1 = new TestFact1[FactCount];
+        for (int i = 0; i < FactCount; i++)
         {
-            var session = Factory.CreateSession();
-            session.InsertAll(_facts1);
-            return session.Fire();
+            _facts1[i] = new TestFact1{IntProperty = i};
         }
+    }
 
-        [Benchmark]
-        public int InsertUpdate()
-        {
-            var session = Factory.CreateSession();
-            session.InsertAll(_facts1);
-            session.UpdateAll(_facts1);
-            return session.Fire();
-        }
+    [Params(10, 100, 1000)]
+    public int RuleCount { get; set; }
 
-        [Benchmark]
-        public int InsertRetract()
-        {
-            var session = Factory.CreateSession();
-            session.InsertAll(_facts1);
-            session.RetractAll(_facts1);
-            return session.Fire();
-        }
+    [Params(100)]
+    public int FactCount { get; set; }
 
-        private class TestFact1
-        {
-            public int IntProperty { get; set; }
-        }
+    [Benchmark]
+    public int Insert()
+    {
+        var session = Factory.CreateSession();
+        session.InsertAll(_facts1);
+        return session.Fire();
+    }
 
-        private IRuleDefinition BuildRule(int index)
-        {
-            var builder = new RuleBuilder();
-            builder.Name($"TestRule{index}");
+    [Benchmark]
+    public int InsertUpdate()
+    {
+        var session = Factory.CreateSession();
+        session.InsertAll(_facts1);
+        session.UpdateAll(_facts1);
+        return session.Fire();
+    }
 
-            var group = builder.LeftHandSide();
-            var pattern = group.Pattern(typeof(TestFact1), "fact1");
-            Expression<Func<TestFact1, bool>> condition = fact1 => fact1.IntProperty % index == 0;
-            pattern.Condition(condition);
+    [Benchmark]
+    public int InsertRetract()
+    {
+        var session = Factory.CreateSession();
+        session.InsertAll(_facts1);
+        session.RetractAll(_facts1);
+        return session.Fire();
+    }
 
-            var actions = builder.RightHandSide();
-            Expression<Action<IContext>> action = ctx => Nothing();
-            actions.Action(action);
+    private class TestFact1
+    {
+        public int IntProperty { get; set; }
+    }
 
-            return builder.Build();
-        }
+    private IRuleDefinition BuildRule(int index)
+    {
+        var builder = new RuleBuilder();
+        builder.Name($"TestRule{index}");
 
-        private static void Nothing()
-        {
-        }
+        var group = builder.LeftHandSide();
+        var pattern = group.Pattern(typeof(TestFact1), "fact1");
+        Expression<Func<TestFact1, bool>> condition = fact1 => fact1.IntProperty % index == 0;
+        pattern.Condition(condition);
+
+        var actions = builder.RightHandSide();
+        Expression<Action<IContext>> action = ctx => Nothing();
+        actions.Action(action);
+
+        return builder.Build();
+    }
+
+    private static void Nothing()
+    {
     }
 }

--- a/bench/NRules.Benchmark/NRules.Benchmark/Meta/BenchmarkOneFactRule.cs
+++ b/bench/NRules.Benchmark/NRules.Benchmark/Meta/BenchmarkOneFactRule.cs
@@ -1,76 +1,75 @@
 ﻿using BenchmarkDotNet.Attributes;
 using NRules.Fluent.Dsl;
 
-namespace NRules.Benchmark.Meta
+namespace NRules.Benchmark.Meta;
+
+[BenchmarkCategory("Meta")]
+public class BenchmarkOneFactRule : BenchmarkBase
 {
-    [BenchmarkCategory("Meta")]
-    public class BenchmarkOneFactRule : BenchmarkBase
+    private TestFact[] _facts;
+
+    [GlobalSetup]
+    public void Setup()
     {
-        private TestFact[] _facts;
+        SetupRule<TestRule>();
 
-        [GlobalSetup]
-        public void Setup()
+        _facts = new TestFact[FactCount];
+        for (int i = 0; i < FactCount; i++)
         {
-            SetupRule<TestRule>();
+            _facts[i] = new TestFact{IntProperty = i};
+        }
+    }
 
-            _facts = new TestFact[FactCount];
-            for (int i = 0; i < FactCount; i++)
-            {
-                _facts[i] = new TestFact{IntProperty = i};
-            }
+    [Params(10, 100, 1000)]
+    public int FactCount { get; set; }
+
+    [Benchmark]
+    public int Insert()
+    {
+        var session = Factory.CreateSession();
+        session.InsertAll(_facts);
+        return session.Fire();
+    }
+
+    [Benchmark]
+    public int InsertUpdate()
+    {
+        var session = Factory.CreateSession();
+        session.InsertAll(_facts);
+        session.UpdateAll(_facts);
+        return session.Fire();
+    }
+
+    [Benchmark]
+    public int InsertRetract()
+    {
+        var session = Factory.CreateSession();
+        session.InsertAll(_facts);
+        session.RetractAll(_facts);
+        return session.Fire();
+    }
+
+    private class TestFact
+    {
+        public int IntProperty { get; set; }
+    }
+
+    private class TestRule : Rule
+    {
+        public override void Define()
+        {
+            TestFact fact = null;
+
+            When()
+                .Match(() => fact, 
+                    x => x.IntProperty % 2 == 0);
+
+            Then()
+                .Do(_ => Nothing());
         }
 
-        [Params(10, 100, 1000)]
-        public int FactCount { get; set; }
-
-        [Benchmark]
-        public int Insert()
+        private void Nothing()
         {
-            var session = Factory.CreateSession();
-            session.InsertAll(_facts);
-            return session.Fire();
-        }
-
-        [Benchmark]
-        public int InsertUpdate()
-        {
-            var session = Factory.CreateSession();
-            session.InsertAll(_facts);
-            session.UpdateAll(_facts);
-            return session.Fire();
-        }
-
-        [Benchmark]
-        public int InsertRetract()
-        {
-            var session = Factory.CreateSession();
-            session.InsertAll(_facts);
-            session.RetractAll(_facts);
-            return session.Fire();
-        }
-
-        private class TestFact
-        {
-            public int IntProperty { get; set; }
-        }
-
-        private class TestRule : Rule
-        {
-            public override void Define()
-            {
-                TestFact fact = null;
-
-                When()
-                    .Match(() => fact, 
-                        x => x.IntProperty % 2 == 0);
-
-                Then()
-                    .Do(_ => Nothing());
-            }
-
-            private void Nothing()
-            {
-            }
         }
     }
 }

--- a/bench/NRules.Benchmark/NRules.Benchmark/Meta/BenchmarkTwoFactAggregateRule.cs
+++ b/bench/NRules.Benchmark/NRules.Benchmark/Meta/BenchmarkTwoFactAggregateRule.cs
@@ -2,102 +2,101 @@
 using BenchmarkDotNet.Attributes;
 using NRules.Fluent.Dsl;
 
-namespace NRules.Benchmark.Meta
+namespace NRules.Benchmark.Meta;
+
+[BenchmarkCategory("Meta")]
+public class BenchmarkTwoFactAggregateRule : BenchmarkBase
 {
-    [BenchmarkCategory("Meta")]
-    public class BenchmarkTwoFactAggregateRule : BenchmarkBase
+    private TestFact1[] _facts1;
+    private TestFact2[] _facts2;
+
+    [GlobalSetup]
+    public void Setup()
     {
-        private TestFact1[] _facts1;
-        private TestFact2[] _facts2;
+        SetupRule<TestRule>();
 
-        [GlobalSetup]
-        public void Setup()
+        _facts1 = new TestFact1[Fact1Count];
+        for (int i = 0; i < Fact1Count; i++)
         {
-            SetupRule<TestRule>();
-
-            _facts1 = new TestFact1[Fact1Count];
-            for (int i = 0; i < Fact1Count; i++)
-            {
-                _facts1[i] = new TestFact1{IntProperty = i};
-            }
-
-            _facts2 = new TestFact2[Fact2Count];
-            for (int i = 0; i < Fact2Count; i++)
-            {
-                _facts2[i] = new TestFact2{IntProperty = i};
-            }
+            _facts1[i] = new TestFact1{IntProperty = i};
         }
 
-        [Params(10, 100, 1000)]
-        public int Fact1Count { get; set; }
-
-        [Params(10, 100, 1000)]
-        public int Fact2Count { get; set; }
-
-        [Benchmark]
-        public int Insert()
+        _facts2 = new TestFact2[Fact2Count];
+        for (int i = 0; i < Fact2Count; i++)
         {
-            var session = Factory.CreateSession();
-            session.InsertAll(_facts1);
-            session.InsertAll(_facts2);
-            return session.Fire();
+            _facts2[i] = new TestFact2{IntProperty = i};
         }
+    }
 
-        [Benchmark]
-        public int InsertUpdate()
+    [Params(10, 100, 1000)]
+    public int Fact1Count { get; set; }
+
+    [Params(10, 100, 1000)]
+    public int Fact2Count { get; set; }
+
+    [Benchmark]
+    public int Insert()
+    {
+        var session = Factory.CreateSession();
+        session.InsertAll(_facts1);
+        session.InsertAll(_facts2);
+        return session.Fire();
+    }
+
+    [Benchmark]
+    public int InsertUpdate()
+    {
+        var session = Factory.CreateSession();
+        session.InsertAll(_facts1);
+        session.InsertAll(_facts2);
+        session.UpdateAll(_facts1);
+        session.UpdateAll(_facts2);
+        return session.Fire();
+    }
+
+    [Benchmark]
+    public int InsertRetract()
+    {
+        var session = Factory.CreateSession();
+        session.InsertAll(_facts1);
+        session.InsertAll(_facts2);
+        session.RetractAll(_facts1);
+        session.RetractAll(_facts2);
+        return session.Fire();
+    }
+
+    private class TestFact1
+    {
+        public int IntProperty { get; set; }
+    }
+
+    private class TestFact2
+    {
+        public int IntProperty { get; set; }
+    }
+
+    private class TestRule : Rule
+    {
+        public override void Define()
         {
-            var session = Factory.CreateSession();
-            session.InsertAll(_facts1);
-            session.InsertAll(_facts2);
-            session.UpdateAll(_facts1);
-            session.UpdateAll(_facts2);
-            return session.Fire();
-        }
+            TestFact1 fact1 = null;
+            IEnumerable<TestFact2> group = null;
 
-        [Benchmark]
-        public int InsertRetract()
-        {
-            var session = Factory.CreateSession();
-            session.InsertAll(_facts1);
-            session.InsertAll(_facts2);
-            session.RetractAll(_facts1);
-            session.RetractAll(_facts2);
-            return session.Fire();
-        }
-
-        private class TestFact1
-        {
-            public int IntProperty { get; set; }
-        }
-
-        private class TestFact2
-        {
-            public int IntProperty { get; set; }
-        }
-
-        private class TestRule : Rule
-        {
-            public override void Define()
-            {
-                TestFact1 fact1 = null;
-                IEnumerable<TestFact2> group = null;
-
-                When()
-                    .Match(() => fact1,
+            When()
+                .Match(() => fact1,
+                    x => x.IntProperty % 2 == 0)
+                .Query(() => group, q => q
+                    .Match<TestFact2>(
                         x => x.IntProperty % 2 == 0)
-                    .Query(() => group, q => q
-                        .Match<TestFact2>(
-                            x => x.IntProperty % 2 == 0)
-                        .Where(x => x.IntProperty % 2 == fact1.IntProperty % 4)
-                        .GroupBy(x => x.IntProperty % 10));
+                    .Where(x => x.IntProperty % 2 == fact1.IntProperty % 4)
+                    .GroupBy(x => x.IntProperty % 10));
 
-                Then()
-                    .Do(_ => Nothing());
-            }
+            Then()
+                .Do(_ => Nothing());
+        }
 
-            private void Nothing()
-            {
-            }
+        private void Nothing()
+        {
         }
     }
 }

--- a/bench/NRules.Benchmark/NRules.Benchmark/Meta/BenchmarkTwoFactJoinRule.cs
+++ b/bench/NRules.Benchmark/NRules.Benchmark/Meta/BenchmarkTwoFactJoinRule.cs
@@ -1,100 +1,99 @@
 ﻿using BenchmarkDotNet.Attributes;
 using NRules.Fluent.Dsl;
 
-namespace NRules.Benchmark.Meta
+namespace NRules.Benchmark.Meta;
+
+[BenchmarkCategory("Meta")]
+public class BenchmarkTwoFactJoinRule : BenchmarkBase
 {
-    [BenchmarkCategory("Meta")]
-    public class BenchmarkTwoFactJoinRule : BenchmarkBase
+    private TestFact1[] _facts1;
+    private TestFact2[] _facts2;
+
+    [GlobalSetup]
+    public void Setup()
     {
-        private TestFact1[] _facts1;
-        private TestFact2[] _facts2;
+        SetupRule<TestRule>();
 
-        [GlobalSetup]
-        public void Setup()
+        _facts1 = new TestFact1[Fact1Count];
+        for (int i = 0; i < Fact1Count; i++)
         {
-            SetupRule<TestRule>();
-
-            _facts1 = new TestFact1[Fact1Count];
-            for (int i = 0; i < Fact1Count; i++)
-            {
-                _facts1[i] = new TestFact1{IntProperty = i};
-            }
-
-            _facts2 = new TestFact2[Fact2Count];
-            for (int i = 0; i < Fact2Count; i++)
-            {
-                _facts2[i] = new TestFact2{IntProperty = i};
-            }
+            _facts1[i] = new TestFact1{IntProperty = i};
         }
 
-        [Params(10, 100, 1000)]
-        public int Fact1Count { get; set; }
-
-        [Params(10, 100, 1000)]
-        public int Fact2Count { get; set; }
-
-        [Benchmark]
-        public int Insert()
+        _facts2 = new TestFact2[Fact2Count];
+        for (int i = 0; i < Fact2Count; i++)
         {
-            var session = Factory.CreateSession();
-            session.InsertAll(_facts1);
-            session.InsertAll(_facts2);
-            return session.Fire();
+            _facts2[i] = new TestFact2{IntProperty = i};
+        }
+    }
+
+    [Params(10, 100, 1000)]
+    public int Fact1Count { get; set; }
+
+    [Params(10, 100, 1000)]
+    public int Fact2Count { get; set; }
+
+    [Benchmark]
+    public int Insert()
+    {
+        var session = Factory.CreateSession();
+        session.InsertAll(_facts1);
+        session.InsertAll(_facts2);
+        return session.Fire();
+    }
+
+    [Benchmark]
+    public int InsertUpdate()
+    {
+        var session = Factory.CreateSession();
+        session.InsertAll(_facts1);
+        session.InsertAll(_facts2);
+        session.UpdateAll(_facts1);
+        session.UpdateAll(_facts2);
+        return session.Fire();
+    }
+
+    [Benchmark]
+    public int InsertRetract()
+    {
+        var session = Factory.CreateSession();
+        session.InsertAll(_facts1);
+        session.InsertAll(_facts2);
+        session.RetractAll(_facts1);
+        session.RetractAll(_facts2);
+        return session.Fire();
+    }
+
+    private class TestFact1
+    {
+        public int IntProperty { get; set; }
+    }
+
+    private class TestFact2
+    {
+        public int IntProperty { get; set; }
+    }
+
+    private class TestRule : Rule
+    {
+        public override void Define()
+        {
+            TestFact1 fact1 = null;
+            TestFact2 fact2 = null;
+
+            When()
+                .Match(() => fact1, 
+                    x => x.IntProperty % 2 == 0)
+                .Match(() => fact2, 
+                    x => x.IntProperty % 2 == 0,
+                    x => x.IntProperty % 2 == fact1.IntProperty % 4);
+
+            Then()
+                .Do(_ => Nothing());
         }
 
-        [Benchmark]
-        public int InsertUpdate()
+        private void Nothing()
         {
-            var session = Factory.CreateSession();
-            session.InsertAll(_facts1);
-            session.InsertAll(_facts2);
-            session.UpdateAll(_facts1);
-            session.UpdateAll(_facts2);
-            return session.Fire();
-        }
-
-        [Benchmark]
-        public int InsertRetract()
-        {
-            var session = Factory.CreateSession();
-            session.InsertAll(_facts1);
-            session.InsertAll(_facts2);
-            session.RetractAll(_facts1);
-            session.RetractAll(_facts2);
-            return session.Fire();
-        }
-
-        private class TestFact1
-        {
-            public int IntProperty { get; set; }
-        }
-
-        private class TestFact2
-        {
-            public int IntProperty { get; set; }
-        }
-
-        private class TestRule : Rule
-        {
-            public override void Define()
-            {
-                TestFact1 fact1 = null;
-                TestFact2 fact2 = null;
-
-                When()
-                    .Match(() => fact1, 
-                        x => x.IntProperty % 2 == 0)
-                    .Match(() => fact2, 
-                        x => x.IntProperty % 2 == 0,
-                        x => x.IntProperty % 2 == fact1.IntProperty % 4);
-
-                Then()
-                    .Do(_ => Nothing());
-            }
-
-            private void Nothing()
-            {
-            }
         }
     }
 }

--- a/bench/NRules.Benchmark/NRules.Benchmark/NRules.Benchmark.csproj
+++ b/bench/NRules.Benchmark/NRules.Benchmark/NRules.Benchmark.csproj
@@ -9,7 +9,7 @@
     <DebugSymbols>true</DebugSymbols>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/bench/NRules.Benchmark/NRules.Benchmark/Program.cs
+++ b/bench/NRules.Benchmark/NRules.Benchmark/Program.cs
@@ -1,12 +1,11 @@
 ﻿using BenchmarkDotNet.Running;
 
-namespace NRules.Benchmark
+namespace NRules.Benchmark;
+
+public class Program
 {
-    public class Program
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
-        {
-            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
-        }
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
     }
 }

--- a/samples/MissManners/Domain/Chosen.cs
+++ b/samples/MissManners/Domain/Chosen.cs
@@ -1,21 +1,20 @@
-﻿namespace NRules.Samples.MissManners.Domain
+﻿namespace NRules.Samples.MissManners.Domain;
+
+public class Chosen
 {
-    public class Chosen
+    public int Id { get; }
+    public string GuestName { get; }
+    public Hobby Hobby { get; }
+
+    public Chosen(int id, string guestName, Hobby hobby)
     {
-        public int Id { get; }
-        public string GuestName { get; }
-        public Hobby Hobby { get; }
+        Id = id;
+        GuestName = guestName;
+        Hobby = hobby;
+    }
 
-        public Chosen(int id, string guestName, Hobby hobby)
-        {
-            Id = id;
-            GuestName = guestName;
-            Hobby = hobby;
-        }
-
-        public override string ToString()
-        {
-            return $"Chosen={Id}|{GuestName}|{Hobby.Name}";
-        }
+    public override string ToString()
+    {
+        return $"Chosen={Id}|{GuestName}|{Hobby.Name}";
     }
 }

--- a/samples/MissManners/Domain/Context.cs
+++ b/samples/MissManners/Domain/Context.cs
@@ -1,31 +1,30 @@
-﻿namespace NRules.Samples.MissManners.Domain
+﻿namespace NRules.Samples.MissManners.Domain;
+
+public enum ContextState
 {
-    public enum ContextState
+    StartUp = 0,
+    AssignSeats = 1,
+    MakePath = 2,
+    CheckDone = 3,
+    PrintResults = 4,
+}
+
+public class Context
+{
+    public Context()
     {
-        StartUp = 0,
-        AssignSeats = 1,
-        MakePath = 2,
-        CheckDone = 3,
-        PrintResults = 4,
+        State = ContextState.StartUp;
     }
 
-    public class Context
+    public ContextState State { get; private set; }
+
+    public void SetState(ContextState state)
     {
-        public Context()
-        {
-            State = ContextState.StartUp;
-        }
+        State = state;
+    }
 
-        public ContextState State { get; private set; }
-
-        public void SetState(ContextState state)
-        {
-            State = state;
-        }
-
-        public override string ToString()
-        {
-            return State.ToString();
-        }
+    public override string ToString()
+    {
+        return State.ToString();
     }
 }

--- a/samples/MissManners/Domain/Count.cs
+++ b/samples/MissManners/Domain/Count.cs
@@ -1,22 +1,21 @@
-﻿namespace NRules.Samples.MissManners.Domain
+﻿namespace NRules.Samples.MissManners.Domain;
+
+public class Count
 {
-    public class Count
+    public Count(int value)
     {
-        public Count(int value)
-        {
-            Value = value;
-        }
+        Value = value;
+    }
 
-        public int Value { get; private set; }
+    public int Value { get; private set; }
 
-        public void Increment()
-        {
-            Value++;
-        }
+    public void Increment()
+    {
+        Value++;
+    }
 
-        public override string ToString()
-        {
-            return $"[Count={Value}]";
-        }
+    public override string ToString()
+    {
+        return $"[Count={Value}]";
     }
 }

--- a/samples/MissManners/Domain/Guest.cs
+++ b/samples/MissManners/Domain/Guest.cs
@@ -1,27 +1,26 @@
-namespace NRules.Samples.MissManners.Domain
+namespace NRules.Samples.MissManners.Domain;
+
+public enum Gender
 {
-    public enum Gender
+    Male,
+    Female,
+}
+
+public class Guest
+{
+    public Guest(string name, Gender sex, Hobby hobby)
     {
-        Male,
-        Female,
+        Name = name;
+        Sex = sex;
+        Hobby = hobby;
     }
 
-    public class Guest
+    public string Name { get; }
+    public Gender Sex { get; }
+    public Hobby Hobby { get; }
+
+    public override string ToString()
     {
-        public Guest(string name, Gender sex, Hobby hobby)
-        {
-            Name = name;
-            Sex = sex;
-            Hobby = hobby;
-        }
-
-        public string Name { get; }
-        public Gender Sex { get; }
-        public Hobby Hobby { get; }
-
-        public override string ToString()
-        {
-            return $"[G={Name}{(Sex == Gender.Male ? "M" : "F")}{Hobby.Name}]";
-        }
+        return $"[G={Name}{(Sex == Gender.Male ? "M" : "F")}{Hobby.Name}]";
     }
 }

--- a/samples/MissManners/Domain/Hobby.cs
+++ b/samples/MissManners/Domain/Hobby.cs
@@ -1,44 +1,43 @@
 using System;
 
-namespace NRules.Samples.MissManners.Domain
+namespace NRules.Samples.MissManners.Domain;
+
+public class Hobby : IEquatable<Hobby>
 {
-    public class Hobby : IEquatable<Hobby>
+    public string Name { get; }
+
+    public Hobby(string name)
     {
-        public string Name { get; }
+        Name = name;
+    }
 
-        public Hobby(string name)
-        {
-            Name = name;
-        }
+    public bool Equals(Hobby other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return string.Equals(Name, other.Name);
+    }
 
-        public bool Equals(Hobby other)
-        {
-            if (ReferenceEquals(null, other)) return false;
-            if (ReferenceEquals(this, other)) return true;
-            return string.Equals(Name, other.Name);
-        }
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != this.GetType()) return false;
+        return Equals((Hobby) obj);
+    }
 
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((Hobby) obj);
-        }
+    public override int GetHashCode()
+    {
+        return Name.GetHashCode();
+    }
 
-        public override int GetHashCode()
-        {
-            return Name.GetHashCode();
-        }
+    public static bool operator ==(Hobby left, Hobby right)
+    {
+        return Equals(left, right);
+    }
 
-        public static bool operator ==(Hobby left, Hobby right)
-        {
-            return Equals(left, right);
-        }
-
-        public static bool operator !=(Hobby left, Hobby right)
-        {
-            return !Equals(left, right);
-        }
+    public static bool operator !=(Hobby left, Hobby right)
+    {
+        return !Equals(left, right);
     }
 }

--- a/samples/MissManners/Domain/LastSeat.cs
+++ b/samples/MissManners/Domain/LastSeat.cs
@@ -1,17 +1,16 @@
-﻿namespace NRules.Samples.MissManners.Domain
+﻿namespace NRules.Samples.MissManners.Domain;
+
+public class LastSeat
 {
-    public class LastSeat
+    public int SeatId { get; }
+
+    public LastSeat(int seatId)
     {
-        public int SeatId { get; }
+        SeatId = seatId;
+    }
 
-        public LastSeat(int seatId)
-        {
-            SeatId = seatId;
-        }
-
-        public override string ToString()
-        {
-            return $"LastSeat={SeatId}";
-        }
+    public override string ToString()
+    {
+        return $"LastSeat={SeatId}";
     }
 }

--- a/samples/MissManners/Domain/Path.cs
+++ b/samples/MissManners/Domain/Path.cs
@@ -1,21 +1,20 @@
-namespace NRules.Samples.MissManners.Domain
+namespace NRules.Samples.MissManners.Domain;
+
+public class Path
 {
-    public class Path
+    public int Id { get; }
+    public int SeatId { get; }
+    public string GuestName { get; }
+
+    public Path(int id, int seatId, string guestName)
     {
-        public int Id { get; }
-        public int SeatId { get; }
-        public string GuestName { get; }
+        Id = id;
+        SeatId = seatId;
+        GuestName = guestName;
+    }
 
-        public Path(int id, int seatId, string guestName)
-        {
-            Id = id;
-            SeatId = seatId;
-            GuestName = guestName;
-        }
-
-        public override string ToString()
-        {
-            return $"[Path={Id}|{GuestName}->{SeatId}]";
-        }
+    public override string ToString()
+    {
+        return $"[Path={Id}|{GuestName}->{SeatId}]";
     }
 }

--- a/samples/MissManners/Domain/Seating.cs
+++ b/samples/MissManners/Domain/Seating.cs
@@ -1,34 +1,33 @@
-﻿namespace NRules.Samples.MissManners.Domain
+﻿namespace NRules.Samples.MissManners.Domain;
+
+public class Seating
 {
-    public class Seating
+    public int Id { get; }
+    public int Pid { get; }
+    public bool PathDone { get; private set; }
+    public int LeftSeatId { get; }
+    public string LeftGuestName { get; }
+    public int RightSeatId { get; }
+    public string RightGuestName { get; }
+
+    public Seating(int id, int pid, bool pathDone, int leftSeatId, string leftGuestName, int rightSeatId, string rightGuestName)
     {
-        public int Id { get; }
-        public int Pid { get; }
-        public bool PathDone { get; private set; }
-        public int LeftSeatId { get; }
-        public string LeftGuestName { get; }
-        public int RightSeatId { get; }
-        public string RightGuestName { get; }
+        Id = id;
+        Pid = pid;
+        PathDone = pathDone;
+        LeftSeatId = leftSeatId;
+        LeftGuestName = leftGuestName;
+        RightSeatId = rightSeatId;
+        RightGuestName = rightGuestName;
+    }
 
-        public Seating(int id, int pid, bool pathDone, int leftSeatId, string leftGuestName, int rightSeatId, string rightGuestName)
-        {
-            Id = id;
-            Pid = pid;
-            PathDone = pathDone;
-            LeftSeatId = leftSeatId;
-            LeftGuestName = leftGuestName;
-            RightSeatId = rightSeatId;
-            RightGuestName = rightGuestName;
-        }
+    public void SetPathDone()
+    {
+        PathDone = true;
+    }
 
-        public void SetPathDone()
-        {
-            PathDone = true;
-        }
-
-        public override string ToString()
-        {
-            return $"[Seating={Id}|{Pid}|L({LeftGuestName}->{LeftSeatId})R({RightGuestName}->{RightSeatId})|?{(PathDone ? "Y" : "N")}]";
-        }
+    public override string ToString()
+    {
+        return $"[Seating={Id}|{Pid}|L({LeftGuestName}->{LeftSeatId})R({RightGuestName}->{RightSeatId})|?{(PathDone ? "Y" : "N")}]";
     }
 }

--- a/samples/MissManners/MissManners.csproj
+++ b/samples/MissManners/MissManners.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace>NRules.Samples.MissManners</RootNamespace>
     <AssemblyName>NRules.Samples.MissManners</AssemblyName>
   </PropertyGroup>

--- a/samples/MissManners/Program.cs
+++ b/samples/MissManners/Program.cs
@@ -5,76 +5,75 @@ using NRules.Fluent;
 using NRules.Samples.MissManners.Domain;
 using NRules.Samples.MissManners.Rules;
 
-namespace NRules.Samples.MissManners
+namespace NRules.Samples.MissManners;
+
+public class Program
 {
-    public class Program
+    static void Main()
     {
-        static void Main(string[] args)
-        {
-            var repository = new RuleRepository();
-            repository.Load(x => x.From(typeof(AssignFirstSeat).Assembly));
+        var repository = new RuleRepository();
+        repository.Load(x => x.From(typeof(AssignFirstSeat).Assembly));
 
-            var factory = repository.Compile();
-            var session = factory.CreateSession();
-            session.Events.FactInsertingEvent += EventProviderOnFactInsertingEvent;
-            session.Events.FactUpdatingEvent += EventProviderOnFactUpdatingEvent;
-            session.Events.FactRetractingEvent += EventProviderOnFactRetractingEvent;
-            session.Events.ActivationCreatedEvent += EventProviderOnActivationCreatedEvent;
-            session.Events.ActivationUpdatedEvent += EventProviderOnActivationUpdatedEvent;
-            session.Events.ActivationDeletedEvent += EventProviderOnActivationDeletedEvent;
-            session.Events.RuleFiringEvent += EventProviderOnRuleFiringEvent;
+        var factory = repository.Compile();
+        var session = factory.CreateSession();
+        session.Events.FactInsertingEvent += EventProviderOnFactInsertingEvent;
+        session.Events.FactUpdatingEvent += EventProviderOnFactUpdatingEvent;
+        session.Events.FactRetractingEvent += EventProviderOnFactRetractingEvent;
+        session.Events.ActivationCreatedEvent += EventProviderOnActivationCreatedEvent;
+        session.Events.ActivationUpdatedEvent += EventProviderOnActivationUpdatedEvent;
+        session.Events.ActivationDeletedEvent += EventProviderOnActivationDeletedEvent;
+        session.Events.RuleFiringEvent += EventProviderOnRuleFiringEvent;
 
-            session.Insert(new Guest("N1", Gender.Male, new Hobby("H1")));
-            session.Insert(new Guest("N2", Gender.Female, new Hobby("H1")));
-            session.Insert(new Guest("N2", Gender.Female, new Hobby("H3")));
-            session.Insert(new Guest("N3", Gender.Male, new Hobby("H3")));
-            session.Insert(new Guest("N3", Gender.Male, new Hobby("H1")));
-            session.Insert(new Guest("N4", Gender.Female, new Hobby("H2")));
-            session.Insert(new Guest("N4", Gender.Female, new Hobby("H3")));
-            session.Insert(new Guest("N5", Gender.Female, new Hobby("H2")));
-            session.Insert(new Guest("N5", Gender.Female, new Hobby("H1")));
-            session.Insert(new Count(1));
-            session.Insert(new LastSeat(5));
+        session.Insert(new Guest("N1", Gender.Male, new Hobby("H1")));
+        session.Insert(new Guest("N2", Gender.Female, new Hobby("H1")));
+        session.Insert(new Guest("N2", Gender.Female, new Hobby("H3")));
+        session.Insert(new Guest("N3", Gender.Male, new Hobby("H3")));
+        session.Insert(new Guest("N3", Gender.Male, new Hobby("H1")));
+        session.Insert(new Guest("N4", Gender.Female, new Hobby("H2")));
+        session.Insert(new Guest("N4", Gender.Female, new Hobby("H3")));
+        session.Insert(new Guest("N5", Gender.Female, new Hobby("H2")));
+        session.Insert(new Guest("N5", Gender.Female, new Hobby("H1")));
+        session.Insert(new Count(1));
+        session.Insert(new LastSeat(5));
 
-            var context = new Context();
-            session.Insert(context);
+        var context = new Context();
+        session.Insert(context);
 
-            session.Fire();
-        }
+        session.Fire();
+    }
 
-        private static void EventProviderOnFactInsertingEvent(object sender, WorkingMemoryEventArgs e)
-        {
-            Console.WriteLine("Insert: {0}", e.Fact.Value);
-        }
+    private static void EventProviderOnFactInsertingEvent(object sender, WorkingMemoryEventArgs e)
+    {
+        Console.WriteLine("Insert: {0}", e.Fact.Value);
+    }
 
-        private static void EventProviderOnFactUpdatingEvent(object sender, WorkingMemoryEventArgs e)
-        {
-            Console.WriteLine("Update: {0}", e.Fact.Value);
-        }
+    private static void EventProviderOnFactUpdatingEvent(object sender, WorkingMemoryEventArgs e)
+    {
+        Console.WriteLine("Update: {0}", e.Fact.Value);
+    }
 
-        private static void EventProviderOnFactRetractingEvent(object sender, WorkingMemoryEventArgs e)
-        {
-            Console.WriteLine("Retract: {0}", e.Fact.Value);
-        }
+    private static void EventProviderOnFactRetractingEvent(object sender, WorkingMemoryEventArgs e)
+    {
+        Console.WriteLine("Retract: {0}", e.Fact.Value);
+    }
 
-        private static void EventProviderOnRuleFiringEvent(object sender, AgendaEventArgs e)
-        {
-            Console.WriteLine("Fire({0}): {1}", e.Rule.Name, string.Join(",", e.Facts.Select(f => f.Value).ToArray()));
-        }
+    private static void EventProviderOnRuleFiringEvent(object sender, AgendaEventArgs e)
+    {
+        Console.WriteLine("Fire({0}): {1}", e.Rule.Name, string.Join(",", e.Facts.Select(f => f.Value).ToArray()));
+    }
 
-        private static void EventProviderOnActivationDeletedEvent(object sender, AgendaEventArgs e)
-        {
-            Console.WriteLine("-A({0}): {1}", e.Rule.Name, string.Join(",", e.Facts.Select(f => f.Value).ToArray()));
-        }
+    private static void EventProviderOnActivationDeletedEvent(object sender, AgendaEventArgs e)
+    {
+        Console.WriteLine("-A({0}): {1}", e.Rule.Name, string.Join(",", e.Facts.Select(f => f.Value).ToArray()));
+    }
 
-        private static void EventProviderOnActivationUpdatedEvent(object sender, AgendaEventArgs e)
-        {
-            Console.WriteLine("=A({0}): {1}", e.Rule.Name, string.Join(",", e.Facts.Select(f => f.Value).ToArray()));
-        }
-        
-        private static void EventProviderOnActivationCreatedEvent(object sender, AgendaEventArgs e)
-        {
-            Console.WriteLine("+A({0}): {1}", e.Rule.Name, string.Join(",", e.Facts.Select(f => f.Value).ToArray()));
-        }
+    private static void EventProviderOnActivationUpdatedEvent(object sender, AgendaEventArgs e)
+    {
+        Console.WriteLine("=A({0}): {1}", e.Rule.Name, string.Join(",", e.Facts.Select(f => f.Value).ToArray()));
+    }
+
+    private static void EventProviderOnActivationCreatedEvent(object sender, AgendaEventArgs e)
+    {
+        Console.WriteLine("+A({0}): {1}", e.Rule.Name, string.Join(",", e.Facts.Select(f => f.Value).ToArray()));
     }
 }

--- a/samples/MissManners/Rules/AreWeDone.cs
+++ b/samples/MissManners/Rules/AreWeDone.cs
@@ -1,26 +1,25 @@
 using NRules.Fluent.Dsl;
 using NRules.Samples.MissManners.Domain;
 
-namespace NRules.Samples.MissManners.Rules
+namespace NRules.Samples.MissManners.Rules;
+
+[Name("AreWeDone")]
+[Priority(1)]
+public class AreWeDone : Rule
 {
-    [Name("AreWeDone")]
-    [Priority(1)]
-    public class AreWeDone : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Context context = default;
-            LastSeat lastSeat = default;
-            Seating seating = default;
+        Context context = default;
+        LastSeat lastSeat = default;
+        Seating seating = default;
 
-            When()
-                .Match(() => context, c => c.State == ContextState.CheckDone)
-                .Match(() => lastSeat)
-                .Match(() => seating, s => s.RightSeatId == lastSeat.SeatId);
+        When()
+            .Match(() => context, c => c.State == ContextState.CheckDone)
+            .Match(() => lastSeat)
+            .Match(() => seating, s => s.RightSeatId == lastSeat.SeatId);
 
-            Then()
-                .Do(ctx => context.SetState(ContextState.PrintResults))
-                .Do(ctx => ctx.Update(context));
-        }
+        Then()
+            .Do(ctx => context.SetState(ContextState.PrintResults))
+            .Do(ctx => ctx.Update(context));
     }
 }

--- a/samples/MissManners/Rules/AssignFirstSeat.cs
+++ b/samples/MissManners/Rules/AssignFirstSeat.cs
@@ -2,40 +2,39 @@
 using NRules.RuleModel;
 using NRules.Samples.MissManners.Domain;
 
-namespace NRules.Samples.MissManners.Rules
+namespace NRules.Samples.MissManners.Rules;
+
+[Name("AssignFirstSeat")]
+public class AssignFirstSeat : Rule
 {
-    [Name("AssignFirstSeat")]
-    public class AssignFirstSeat : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Context context = default;
-            Guest guest = default;
-            Count count = default;
+        Context context = default;
+        Guest guest = default;
+        Count count = default;
 
-            When()
-                .Match(() => context, c => c.State == ContextState.StartUp)
-                .Match(() => guest)
-                .Match(() => count);
-            Then()
-                .Do(ctx => AssignSeat(ctx, context, guest, count));
-        }
+        When()
+            .Match(() => context, c => c.State == ContextState.StartUp)
+            .Match(() => guest)
+            .Match(() => count);
+        Then()
+            .Do(ctx => AssignSeat(ctx, context, guest, count));
+    }
 
-        private void AssignSeat(IContext ctx, Context context, Guest guest, Count count)
-        {
-            var cnt = count.Value;
+    private void AssignSeat(IContext ctx, Context context, Guest guest, Count count)
+    {
+        var cnt = count.Value;
 
-            var seating = new Seating(cnt, 0, true, 1, guest.Name, 1, guest.Name);
-            ctx.Insert(seating);
+        var seating = new Seating(cnt, 0, true, 1, guest.Name, 1, guest.Name);
+        ctx.Insert(seating);
 
-            var path = new Path(cnt, 1, guest.Name);
-            ctx.Insert(path);
+        var path = new Path(cnt, 1, guest.Name);
+        ctx.Insert(path);
 
-            count.Increment();
-            ctx.Update(count);
+        count.Increment();
+        ctx.Update(count);
 
-            context.SetState(ContextState.AssignSeats);
-            ctx.Update(context);
-        }
+        context.SetState(ContextState.AssignSeats);
+        ctx.Update(context);
     }
 }

--- a/samples/MissManners/Rules/Continue.cs
+++ b/samples/MissManners/Rules/Continue.cs
@@ -1,21 +1,20 @@
 using NRules.Fluent.Dsl;
 using NRules.Samples.MissManners.Domain;
 
-namespace NRules.Samples.MissManners.Rules
+namespace NRules.Samples.MissManners.Rules;
+
+[Name("Continue")]
+public class Continue : Rule
 {
-    [Name("Continue")]
-    public class Continue : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Context context = default;
+        Context context = default;
 
-            When()
-                .Match(() => context, c => c.State == ContextState.CheckDone);
+        When()
+            .Match(() => context, c => c.State == ContextState.CheckDone);
 
-            Then()
-                .Do(ctx => context.SetState(ContextState.AssignSeats))
-                .Do(ctx => ctx.Update(context));
-        }
+        Then()
+            .Do(ctx => context.SetState(ContextState.AssignSeats))
+            .Do(ctx => ctx.Update(context));
     }
 }

--- a/samples/MissManners/Rules/FindSeating.cs
+++ b/samples/MissManners/Rules/FindSeating.cs
@@ -2,52 +2,51 @@
 using NRules.RuleModel;
 using NRules.Samples.MissManners.Domain;
 
-namespace NRules.Samples.MissManners.Rules
+namespace NRules.Samples.MissManners.Rules;
+
+[Name("FindSeating")]
+public class FindSeating : Rule
 {
-    [Name("FindSeating")]
-    public class FindSeating : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Context context = default;
-            Seating seating = default;
-            Guest guest1 = default;
-            Guest guest2 = default;
-            Count count = default;
+        Context context = default;
+        Seating seating = default;
+        Guest guest1 = default;
+        Guest guest2 = default;
+        Count count = default;
 
-            When()
-                .Match(() => context, c => c.State == ContextState.AssignSeats)
-                .Match(() => seating, s => s.PathDone)
-                .Match(() => guest1, g1 => g1.Name == seating.RightGuestName)
-                .Match(() => guest2, g2 => g2.Sex != guest1.Sex, g2 => g2.Hobby == guest1.Hobby)
-                .Match(() => count)
-                .Not<Path>(p => p.Id == seating.Id, p => p.GuestName == guest2.Name)
-                .Not<Chosen>(c => c.Id == seating.Id, c => c.GuestName == guest2.Name, c => c.Hobby == guest1.Hobby);
+        When()
+            .Match(() => context, c => c.State == ContextState.AssignSeats)
+            .Match(() => seating, s => s.PathDone)
+            .Match(() => guest1, g1 => g1.Name == seating.RightGuestName)
+            .Match(() => guest2, g2 => g2.Sex != guest1.Sex, g2 => g2.Hobby == guest1.Hobby)
+            .Match(() => count)
+            .Not<Path>(p => p.Id == seating.Id, p => p.GuestName == guest2.Name)
+            .Not<Chosen>(c => c.Id == seating.Id, c => c.GuestName == guest2.Name, c => c.Hobby == guest1.Hobby);
 
-            Then()
-                .Do(ctx => AssignSeat(ctx, context, seating, guest1, guest2, count));
-        }
+        Then()
+            .Do(ctx => AssignSeat(ctx, context, seating, guest1, guest2, count));
+    }
 
-        private void AssignSeat(IContext ctx, Context context, Seating seating, Guest guest1, Guest guest2, Count count)
-        {
-            int rightSeat = seating.RightSeatId;
-            int seatId = seating.Id;
-            int cnt = count.Value;
+    private void AssignSeat(IContext ctx, Context context, Seating seating, Guest guest1, Guest guest2, Count count)
+    {
+        int rightSeat = seating.RightSeatId;
+        int seatId = seating.Id;
+        int cnt = count.Value;
 
-            var newSeating = new Seating(cnt, seatId, false, rightSeat, seating.RightGuestName, rightSeat + 1, guest2.Name);
-            ctx.Insert(newSeating);
+        var newSeating = new Seating(cnt, seatId, false, rightSeat, seating.RightGuestName, rightSeat + 1, guest2.Name);
+        ctx.Insert(newSeating);
 
-            var path = new Path(cnt, rightSeat + 1, guest2.Name);
-            ctx.Insert(path);
+        var path = new Path(cnt, rightSeat + 1, guest2.Name);
+        ctx.Insert(path);
 
-            var chosen = new Chosen(seatId, guest2.Name, guest1.Hobby);
-            ctx.Insert(chosen);
+        var chosen = new Chosen(seatId, guest2.Name, guest1.Hobby);
+        ctx.Insert(chosen);
 
-            count.Increment();
-            ctx.Update(count);
+        count.Increment();
+        ctx.Update(count);
 
-            context.SetState(ContextState.MakePath);
-            ctx.Update(context);
-        }
+        context.SetState(ContextState.MakePath);
+        ctx.Update(context);
     }
 }

--- a/samples/MissManners/Rules/MakePath.cs
+++ b/samples/MissManners/Rules/MakePath.cs
@@ -2,32 +2,31 @@
 using NRules.RuleModel;
 using NRules.Samples.MissManners.Domain;
 
-namespace NRules.Samples.MissManners.Rules
+namespace NRules.Samples.MissManners.Rules;
+
+[Name("MakePath")]
+[Priority(1)]
+public class MakePath : Rule
 {
-    [Name("MakePath")]
-    [Priority(1)]
-    public class MakePath : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Context context = default;
-            Seating seating = default;
-            Path path = default;
+        Context context = default;
+        Seating seating = default;
+        Path path = default;
 
-            When()
-                .Match(() => context, c => c.State == ContextState.MakePath)
-                .Match(() => seating, s => !s.PathDone)
-                .Match(() => path, p => p.Id == seating.Pid)
-                .Not<Path>(p => p.Id == seating.Id, p => p.GuestName == path.GuestName);
+        When()
+            .Match(() => context, c => c.State == ContextState.MakePath)
+            .Match(() => seating, s => !s.PathDone)
+            .Match(() => path, p => p.Id == seating.Pid)
+            .Not<Path>(p => p.Id == seating.Id, p => p.GuestName == path.GuestName);
 
-            Then()
-                .Do(ctx => MakeNewPath(ctx, context, seating, path));
-        }
+        Then()
+            .Do(ctx => MakeNewPath(ctx, context, seating, path));
+    }
 
-        private void MakeNewPath(IContext ctx, Context context, Seating seating, Path path)
-        {
-            var newPath = new Path(seating.Id, path.SeatId, path.GuestName);
-            ctx.Insert(newPath);
-        }
+    private void MakeNewPath(IContext ctx, Context context, Seating seating, Path path)
+    {
+        var newPath = new Path(seating.Id, path.SeatId, path.GuestName);
+        ctx.Insert(newPath);
     }
 }

--- a/samples/MissManners/Rules/PathDone.cs
+++ b/samples/MissManners/Rules/PathDone.cs
@@ -2,31 +2,30 @@ using NRules.Fluent.Dsl;
 using NRules.RuleModel;
 using NRules.Samples.MissManners.Domain;
 
-namespace NRules.Samples.MissManners.Rules
+namespace NRules.Samples.MissManners.Rules;
+
+[Name("PathDone")]
+public class PathDone : Rule
 {
-    [Name("PathDone")]
-    public class PathDone : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Context context = default;
-            Seating seating = default;
+        Context context = default;
+        Seating seating = default;
 
-            When()
-                .Match(() => context, c => c.State == ContextState.MakePath)
-                .Match(() => seating, s => !s.PathDone);
+        When()
+            .Match(() => context, c => c.State == ContextState.MakePath)
+            .Match(() => seating, s => !s.PathDone);
 
-            Then()
-                .Do(ctx => CompletePath(ctx, context, seating));
-        }
+        Then()
+            .Do(ctx => CompletePath(ctx, context, seating));
+    }
 
-        private void CompletePath(IContext ctx, Context context, Seating seating)
-        {
-            seating.SetPathDone();
-            ctx.Update(seating);
+    private void CompletePath(IContext ctx, Context context, Seating seating)
+    {
+        seating.SetPathDone();
+        ctx.Update(seating);
 
-            context.SetState(ContextState.CheckDone);
-            ctx.Update(context);
-        }
+        context.SetState(ContextState.CheckDone);
+        ctx.Update(context);
     }
 }

--- a/samples/RuleBuilder/CustomRuleRepository.cs
+++ b/samples/RuleBuilder/CustomRuleRepository.cs
@@ -6,138 +6,137 @@ using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 using NRules.Samples.RuleBuilder.Domain;
 
-namespace NRules.Samples.RuleBuilder
+namespace NRules.Samples.RuleBuilder;
+
+public class CustomRuleRepository : IRuleRepository
 {
-    public class CustomRuleRepository : IRuleRepository
+    private readonly IRuleSet _ruleSet = new RuleSet("DefaultRuleSet");
+
+    public IEnumerable<IRuleSet> GetRuleSets()
     {
-        private readonly IRuleSet _ruleSet = new RuleSet("DefaultRuleSet");
+        return new[] {_ruleSet};
+    }
 
-        public IEnumerable<IRuleSet> GetRuleSets()
+    public void LoadRules()
+    {
+        _ruleSet.Add(new []
         {
-            return new[] {_ruleSet};
-        }
+            BuildJohnDoLargeOrderRule(),
+            BuildMultipleOrdersRule(),
+            BuildImportantCustomerRule(),
+        });
+    }
 
-        public void LoadRules()
-        {
-            _ruleSet.Add(new []
-            {
-                BuildJohnDoLargeOrderRule(),
-                BuildMultipleOrdersRule(),
-                BuildImportantCustomerRule(),
-            });
-        }
+    private IRuleDefinition BuildJohnDoLargeOrderRule()
+    {
+        //rule "John Do Large Order Rule"
+        //when
+        //    customer = Customer(x => x.Name == "John Do");
+        //    order = Order(x => x.Customer == customer, x => x.Amount > 100);
+        //then
+        //    Console.WriteLine("Customer {0} has an order in amount of ${1}", customer.Name, order.Amount);
 
-        private IRuleDefinition BuildJohnDoLargeOrderRule()
-        {
-            //rule "John Do Large Order Rule"
-            //when
-            //    customer = Customer(x => x.Name == "John Do");
-            //    order = Order(x => x.Customer == customer, x => x.Amount > 100);
-            //then
-            //    Console.WriteLine("Customer {0} has an order in amount of ${1}", customer.Name, order.Amount);
+        var builder = new RuleModel.Builders.RuleBuilder();
+        builder.Name("John Do Large Order Rule");
 
-            var builder = new RuleModel.Builders.RuleBuilder();
-            builder.Name("John Do Large Order Rule");
+        PatternBuilder customerPattern = builder.LeftHandSide().Pattern(typeof (Customer), "customer");
+        ParameterExpression customerParameter = customerPattern.Declaration.ToParameterExpression();
+        var customerCondition = Expression.Lambda(
+            Expression.Equal(
+                Expression.Property(customerParameter, "Name"),
+                Expression.Constant("John Do")),
+            customerParameter);
+        customerPattern.Condition(customerCondition);
 
-            PatternBuilder customerPattern = builder.LeftHandSide().Pattern(typeof (Customer), "customer");
-            ParameterExpression customerParameter = customerPattern.Declaration.ToParameterExpression();
-            var customerCondition = Expression.Lambda(
-                Expression.Equal(
-                    Expression.Property(customerParameter, "Name"),
-                    Expression.Constant("John Do")),
-                customerParameter);
-            customerPattern.Condition(customerCondition);
+        PatternBuilder orderPattern = builder.LeftHandSide().Pattern(typeof (Order), "order");
+        Expression<Func<Order, Customer, bool>> orderCondition1 = (order, customer) => order.Customer == customer;
+        orderPattern.Condition(orderCondition1);
+        Expression<Func<Order, bool>> orderCondition2 = order => order.Amount > 100.00;
+        orderPattern.Condition(orderCondition2);
 
-            PatternBuilder orderPattern = builder.LeftHandSide().Pattern(typeof (Order), "order");
-            Expression<Func<Order, Customer, bool>> orderCondition1 = (order, customer) => order.Customer == customer;
-            orderPattern.Condition(orderCondition1);
-            Expression<Func<Order, bool>> orderCondition2 = order => order.Amount > 100.00;
-            orderPattern.Condition(orderCondition2);
+        Expression<Action<IContext, Customer, Order>> action = 
+            (ctx, customer, order) => Console.WriteLine("Customer {0} has an order in amount of ${1}", customer.Name, order.Amount);
+        builder.RightHandSide().Action(action);
 
-            Expression<Action<IContext, Customer, Order>> action = 
-                (ctx, customer, order) => Console.WriteLine("Customer {0} has an order in amount of ${1}", customer.Name, order.Amount);
-            builder.RightHandSide().Action(action);
+        return builder.Build();
+    }
 
-            return builder.Build();
-        }
+    private IRuleDefinition BuildMultipleOrdersRule()
+    {
+        //rule "Multiple Orders Rule"
+        //when
+        //    customer = Customer(x => x.IsPreferred);
+        //    orders = Query(
+        //        Order(x => x.Customer == customer, x => x.IsOpen)
+        //        Collect()
+        //        Where(c => c.Count() >= 3)
+        //    );
+        //then
+        //    Console.WriteLine("Customer {0} has {1} open order(s)", customer.Name, orders.Count());
 
-        private IRuleDefinition BuildMultipleOrdersRule()
-        {
-            //rule "Multiple Orders Rule"
-            //when
-            //    customer = Customer(x => x.IsPreferred);
-            //    orders = Query(
-            //        Order(x => x.Customer == customer, x => x.IsOpen)
-            //        Collect()
-            //        Where(c => c.Count() >= 3)
-            //    );
-            //then
-            //    Console.WriteLine("Customer {0} has {1} open order(s)", customer.Name, orders.Count());
+        var builder = new RuleModel.Builders.RuleBuilder();
+        builder.Name("Multiple Orders Rule");
 
-            var builder = new RuleModel.Builders.RuleBuilder();
-            builder.Name("Multiple Orders Rule");
+        PatternBuilder customerPattern = builder.LeftHandSide().Pattern(typeof(Customer), "customer");
+        Expression<Func<Customer, bool>> customerCondition = customer => customer.IsPreferred;
+        customerPattern.Condition(customerCondition);
 
-            PatternBuilder customerPattern = builder.LeftHandSide().Pattern(typeof(Customer), "customer");
-            Expression<Func<Customer, bool>> customerCondition = customer => customer.IsPreferred;
-            customerPattern.Condition(customerCondition);
+        PatternBuilder ordersPattern = builder.LeftHandSide().Pattern(typeof(IEnumerable<Order>), "orders");
+        Expression<Func<IEnumerable<Order>, bool>> aggregateCondition = orders => orders.Count() >= 3;
+        ordersPattern.Condition(aggregateCondition);
 
-            PatternBuilder ordersPattern = builder.LeftHandSide().Pattern(typeof(IEnumerable<Order>), "orders");
-            Expression<Func<IEnumerable<Order>, bool>> aggregateCondition = orders => orders.Count() >= 3;
-            ordersPattern.Condition(aggregateCondition);
+        var aggregate = ordersPattern.Aggregate();
+        aggregate.Collect();
 
-            var aggregate = ordersPattern.Aggregate();
-            aggregate.Collect();
+        var orderPattern = aggregate.Pattern(typeof(Order), "order");
+        Expression<Func<Order, Customer, bool>> orderCondition1 = (order, customer) => order.Customer == customer;
+        orderPattern.Condition(orderCondition1);
+        Expression<Func<Order, bool>> orderCondition2 = order => order.IsOpen;
+        orderPattern.Condition(orderCondition2);
 
-            var orderPattern = aggregate.Pattern(typeof(Order), "order");
-            Expression<Func<Order, Customer, bool>> orderCondition1 = (order, customer) => order.Customer == customer;
-            orderPattern.Condition(orderCondition1);
-            Expression<Func<Order, bool>> orderCondition2 = order => order.IsOpen;
-            orderPattern.Condition(orderCondition2);
+        Expression<Action<IContext, Customer, IEnumerable<Order>>> action =
+            (ctx, customer, orders) => Console.WriteLine("Customer {0} has {1} open order(s)", customer.Name, orders.Count());
+        builder.RightHandSide().Action(action);
 
-            Expression<Action<IContext, Customer, IEnumerable<Order>>> action =
-                (ctx, customer, orders) => Console.WriteLine("Customer {0} has {1} open order(s)", customer.Name, orders.Count());
-            builder.RightHandSide().Action(action);
+        return builder.Build();
+    }
 
-            return builder.Build();
-        }
+    private IRuleDefinition BuildImportantCustomerRule()
+    {
+        //rule "Important Customer Rule"
+        //when
+        //    customer = Customer(x => x.IsPreferred);
+        //    or
+        //    (
+        //        customer = Customer(x => !x.IsPreferred)
+        //        exists Order(o => o.Customer == customer, o => o.Amount >= 1000.00)
+        //    )
+        //then
+        //    Console.WriteLine("Customer {0} is important", customer.Name);
 
-        private IRuleDefinition BuildImportantCustomerRule()
-        {
-            //rule "Important Customer Rule"
-            //when
-            //    customer = Customer(x => x.IsPreferred);
-            //    or
-            //    (
-            //        customer = Customer(x => !x.IsPreferred)
-            //        exists Order(o => o.Customer == customer, o => o.Amount >= 1000.00)
-            //    )
-            //then
-            //    Console.WriteLine("Customer {0} is important", customer.Name);
+        var builder = new RuleModel.Builders.RuleBuilder();
+        builder.Name("Important Customer Rule");
 
-            var builder = new RuleModel.Builders.RuleBuilder();
-            builder.Name("Important Customer Rule");
+        var orGroup = builder.LeftHandSide().Group(GroupType.Or);
 
-            var orGroup = builder.LeftHandSide().Group(GroupType.Or);
+        PatternBuilder customerPattern1 = orGroup.Pattern(typeof(Customer), "customer");
+        Expression<Func<Customer, bool>> customerCondition1 = customer => customer.IsPreferred;
+        customerPattern1.Condition(customerCondition1);
 
-            PatternBuilder customerPattern1 = orGroup.Pattern(typeof(Customer), "customer");
-            Expression<Func<Customer, bool>> customerCondition1 = customer => customer.IsPreferred;
-            customerPattern1.Condition(customerCondition1);
+        var andGroup = orGroup.Group(GroupType.And);
 
-            var andGroup = orGroup.Group(GroupType.And);
+        PatternBuilder customerPattern2 = andGroup.Pattern(typeof(Customer), "customer");
+        Expression<Func<Customer, bool>> customerCondition2 = customer => !customer.IsPreferred;
+        customerPattern2.Condition(customerCondition2);
 
-            PatternBuilder customerPattern2 = andGroup.Pattern(typeof(Customer), "customer");
-            Expression<Func<Customer, bool>> customerCondition2 = customer => !customer.IsPreferred;
-            customerPattern2.Condition(customerCondition2);
+        PatternBuilder orderExistsPattern = andGroup.Exists().Pattern(typeof(Order), "order");
+        Expression<Func<Order, bool>> orderCondition = order => order.Amount >= 1000;
+        orderExistsPattern.Condition(orderCondition);
 
-            PatternBuilder orderExistsPattern = andGroup.Exists().Pattern(typeof(Order), "order");
-            Expression<Func<Order, bool>> orderCondition = order => order.Amount >= 1000;
-            orderExistsPattern.Condition(orderCondition);
+        Expression<Action<IContext, Customer>> action =
+            (ctx, customer) => Console.WriteLine("Customer {0} is important", customer.Name);
+        builder.RightHandSide().Action(action);
 
-            Expression<Action<IContext, Customer>> action =
-                (ctx, customer) => Console.WriteLine("Customer {0} is important", customer.Name);
-            builder.RightHandSide().Action(action);
-
-            return builder.Build();
-        }
+        return builder.Build();
     }
 }

--- a/samples/RuleBuilder/Domain/Customer.cs
+++ b/samples/RuleBuilder/Domain/Customer.cs
@@ -1,13 +1,12 @@
-﻿namespace NRules.Samples.RuleBuilder.Domain
-{
-    public class Customer
-    {
-        public string Name { get; private set; }
-        public bool IsPreferred { get; set; }
+﻿namespace NRules.Samples.RuleBuilder.Domain;
 
-        public Customer(string name)
-        {
-            Name = name;
-        }
+public class Customer
+{
+    public string Name { get; private set; }
+    public bool IsPreferred { get; set; }
+
+    public Customer(string name)
+    {
+        Name = name;
     }
 }

--- a/samples/RuleBuilder/Domain/Order.cs
+++ b/samples/RuleBuilder/Domain/Order.cs
@@ -1,26 +1,25 @@
-﻿namespace NRules.Samples.RuleBuilder.Domain
+﻿namespace NRules.Samples.RuleBuilder.Domain;
+
+public class Order
 {
-    public class Order
+    public int Id { get; private set; }
+    public Customer Customer { get; private set; }
+    public int Quantity { get; private set; }
+    public double UnitPrice { get; private set; }
+    public double PercentDiscount { get; private set; }
+    public bool IsOpen { get; private set; }
+
+    public double Amount
     {
-        public int Id { get; private set; }
-        public Customer Customer { get; private set; }
-        public int Quantity { get; private set; }
-        public double UnitPrice { get; private set; }
-        public double PercentDiscount { get; private set; }
-        public bool IsOpen { get; private set; }
+        get { return UnitPrice * Quantity * (1.0 - PercentDiscount / 100.0); }
+    }
 
-        public double Amount
-        {
-            get { return UnitPrice * Quantity * (1.0 - PercentDiscount / 100.0); }
-        }
-
-        public Order(int id, Customer customer, int quantity, double unitPrice)
-        {
-            Id = id;
-            Customer = customer;
-            Quantity = quantity;
-            UnitPrice = unitPrice;
-            IsOpen = true;
-        }
+    public Order(int id, Customer customer, int quantity, double unitPrice)
+    {
+        Id = id;
+        Customer = customer;
+        Quantity = quantity;
+        UnitPrice = unitPrice;
+        IsOpen = true;
     }
 }

--- a/samples/RuleBuilder/Program.cs
+++ b/samples/RuleBuilder/Program.cs
@@ -1,39 +1,38 @@
 ﻿using System;
 using NRules.Samples.RuleBuilder.Domain;
 
-namespace NRules.Samples.RuleBuilder
+namespace NRules.Samples.RuleBuilder;
+
+internal class Program
 {
-    internal class Program
+    private static void Main()
     {
-        private static void Main(string[] args)
+        var repository = new CustomRuleRepository();
+        repository.LoadRules();
+
+        Console.WriteLine("Loaded rules:");
+        foreach (var rule in repository.GetRules())
         {
-            var repository = new CustomRuleRepository();
-            repository.LoadRules();
-
-            Console.WriteLine("Loaded rules:");
-            foreach (var rule in repository.GetRules())
-            {
-                Console.WriteLine(rule.Name);
-            }
-            Console.WriteLine();
-            
-            ISessionFactory factory = repository.Compile();
-            ISession session = factory.CreateSession();
-
-            var customer1 = new Customer("John Do");
-            var customer2 = new Customer("Jean Do") {IsPreferred = true};
-            session.Insert(customer1);
-            session.Insert(customer2);
-            session.Insert(new Order(1, customer1, 2, 90.00));
-            session.Insert(new Order(2, customer1, 1, 110.00));
-            session.Insert(new Order(3, customer1, 1, 1000.00));
-            session.Insert(new Order(4, customer2, 1, 120.00));
-            session.Insert(new Order(5, customer2, 1, 10.00));
-            session.Insert(new Order(6, customer2, 1, 12.50));
-            session.Insert(new Order(7, customer2, 1, 400.00));
-
-            Console.WriteLine("Running rules:");
-            session.Fire();
+            Console.WriteLine(rule.Name);
         }
+        Console.WriteLine();
+
+        ISessionFactory factory = repository.Compile();
+        ISession session = factory.CreateSession();
+
+        var customer1 = new Customer("John Do");
+        var customer2 = new Customer("Jean Do") { IsPreferred = true };
+        session.Insert(customer1);
+        session.Insert(customer2);
+        session.Insert(new Order(1, customer1, 2, 90.00));
+        session.Insert(new Order(2, customer1, 1, 110.00));
+        session.Insert(new Order(3, customer1, 1, 1000.00));
+        session.Insert(new Order(4, customer2, 1, 120.00));
+        session.Insert(new Order(5, customer2, 1, 10.00));
+        session.Insert(new Order(6, customer2, 1, 12.50));
+        session.Insert(new Order(7, customer2, 1, 400.00));
+
+        Console.WriteLine("Running rules:");
+        session.Fire();
     }
 }

--- a/samples/RuleBuilder/RuleBuilder.csproj
+++ b/samples/RuleBuilder/RuleBuilder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace>NRules.Samples.RuleBuilder</RootNamespace>
     <AssemblyName>NRules.Samples.RuleBuilder</AssemblyName>
   </PropertyGroup>

--- a/samples/SimpleRules/Domain/Account.cs
+++ b/samples/SimpleRules/Domain/Account.cs
@@ -1,18 +1,17 @@
-﻿namespace NRules.Samples.SimpleRules.Domain
-{
-    public class Account
-    {
-        public string AccountNumber { get; }
-        public Customer Owner { get; }
-        public bool IsActive { get; set; }
-        public bool IsDelinquent { get; set; }
+﻿namespace NRules.Samples.SimpleRules.Domain;
 
-        public Account(string accountNumber, Customer owner)
-        {
-            AccountNumber = accountNumber;
-            Owner = owner;
-            IsActive = true;
-            IsDelinquent = false;
-        }
+public class Account
+{
+    public string AccountNumber { get; }
+    public Customer Owner { get; }
+    public bool IsActive { get; set; }
+    public bool IsDelinquent { get; set; }
+
+    public Account(string accountNumber, Customer owner)
+    {
+        AccountNumber = accountNumber;
+        Owner = owner;
+        IsActive = true;
+        IsDelinquent = false;
     }
 }

--- a/samples/SimpleRules/Domain/Customer.cs
+++ b/samples/SimpleRules/Domain/Customer.cs
@@ -1,13 +1,12 @@
-﻿namespace NRules.Samples.SimpleRules.Domain
-{
-    public class Customer
-    {
-        public string Name { get; }
-        public bool IsPreferred { get; set; }
+﻿namespace NRules.Samples.SimpleRules.Domain;
 
-        public Customer(string name)
-        {
-            Name = name;
-        }
+public class Customer
+{
+    public string Name { get; }
+    public bool IsPreferred { get; set; }
+
+    public Customer(string name)
+    {
+        Name = name;
     }
 }

--- a/samples/SimpleRules/Domain/Order.cs
+++ b/samples/SimpleRules/Domain/Order.cs
@@ -1,23 +1,22 @@
-﻿namespace NRules.Samples.SimpleRules.Domain
+﻿namespace NRules.Samples.SimpleRules.Domain;
+
+public class Order
 {
-    public class Order
+    public int Id { get; }
+    public Customer Customer { get; }
+    public int Quantity { get; }
+    public double UnitPrice { get; }
+    public double PercentDiscount { get; set; }
+    public bool IsOpen { get; set; }
+
+    public double Amount { get; set; }
+
+    public Order(int id, Customer customer, int quantity, double unitPrice)
     {
-        public int Id { get; }
-        public Customer Customer { get; }
-        public int Quantity { get; }
-        public double UnitPrice { get; }
-        public double PercentDiscount { get; set; }
-        public bool IsOpen { get; set; }
-
-        public double Amount { get; set; }
-
-        public Order(int id, Customer customer, int quantity, double unitPrice)
-        {
-            Id = id;
-            Customer = customer;
-            Quantity = quantity;
-            UnitPrice = unitPrice;
-            IsOpen = true;
-        }
+        Id = id;
+        Customer = customer;
+        Quantity = quantity;
+        UnitPrice = unitPrice;
+        IsOpen = true;
     }
 }

--- a/samples/SimpleRules/Program.cs
+++ b/samples/SimpleRules/Program.cs
@@ -2,51 +2,50 @@
 using NRules.Fluent;
 using NRules.Samples.SimpleRules.Domain;
 
-namespace NRules.Samples.SimpleRules
+namespace NRules.Samples.SimpleRules;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-            //Load rules
-            var repository = new RuleRepository();
-            repository.Load(x => x.From(Assembly.GetExecutingAssembly()));
+        //Load rules
+        var repository = new RuleRepository();
+        repository.Load(x => x.From(Assembly.GetExecutingAssembly()));
 
-            //Compile rules
-            var factory = repository.Compile();
+        //Compile rules
+        var factory = repository.Compile();
 
-            //Create a working session
-            var session = factory.CreateSession();
+        //Create a working session
+        var session = factory.CreateSession();
 
-            //Load domain model
-            var customer1 = new Customer("John Doe") { IsPreferred = true };
-            var account11 = new Account("12456789", customer1);
-            var account12 = new Account("12456790", customer1);
-            var account13 = new Account("12456791", customer1) {IsActive = false, IsDelinquent = true};
-            var order11 = new Order(123456, customer1, 2, 25.0);
-            var order12 = new Order(123457, customer1, 1, 100.0);
-            var order13 = new Order(123458, customer1, 1, 5.0);
+        //Load domain model
+        var customer1 = new Customer("John Doe") { IsPreferred = true };
+        var account11 = new Account("12456789", customer1);
+        var account12 = new Account("12456790", customer1);
+        var account13 = new Account("12456791", customer1) { IsActive = false, IsDelinquent = true };
+        var order11 = new Order(123456, customer1, 2, 25.0);
+        var order12 = new Order(123457, customer1, 1, 100.0);
+        var order13 = new Order(123458, customer1, 1, 5.0);
 
-            var customer2 = new Customer("Sarah Jones");
-            var account21 = new Account("22456789", customer2);
-            var order21 = new Order(223456, customer2, 2, 2225.0);
+        var customer2 = new Customer("Sarah Jones");
+        var account21 = new Account("22456789", customer2);
+        var order21 = new Order(223456, customer2, 2, 2225.0);
 
-            //Insert facts into rules engine's memory
-            session.Insert(customer1);
-            session.Insert(account11);
-            session.Insert(account12);
-            session.Insert(account13);
-            session.Insert(order11);
-            session.Insert(order12);
-            session.Insert(order13);
+        //Insert facts into rules engine's memory
+        session.Insert(customer1);
+        session.Insert(account11);
+        session.Insert(account12);
+        session.Insert(account13);
+        session.Insert(order11);
+        session.Insert(order12);
+        session.Insert(order13);
 
-            session.Insert(customer2);
-            session.Insert(account21);
-            session.Insert(order21);
+        session.Insert(customer2);
+        session.Insert(account21);
+        session.Insert(order21);
 
-            //Start match/resolve/act cycle
-            session.Update(customer1);
-            session.Fire();
-        }
+        //Start match/resolve/act cycle
+        session.Update(customer1);
+        session.Fire();
     }
 }

--- a/samples/SimpleRules/Rules/ActiveCustomerAccountRule.cs
+++ b/samples/SimpleRules/Rules/ActiveCustomerAccountRule.cs
@@ -2,23 +2,22 @@ using System;
 using NRules.Fluent.Dsl;
 using NRules.Samples.SimpleRules.Domain;
 
-namespace NRules.Samples.SimpleRules.Rules
+namespace NRules.Samples.SimpleRules.Rules;
+
+public class ActiveCustomerAccountRule : Rule
 {
-    public class ActiveCustomerAccountRule : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Customer customer = default;
-            Account account = default;
+        Customer customer = default;
+        Account account = default;
 
-            When()
-                .Match(() => customer, c => c.IsPreferred)
-                .Match(() => account, a => a.Owner == customer, a => a.IsActive);
+        When()
+            .Match(() => customer, c => c.IsPreferred)
+            .Match(() => account, a => a.Owner == customer, a => a.IsActive);
 
-            Then()
-                .Do(ctx =>
-                    Console.WriteLine("Customer {0} has active account #{1}",
-                        customer.Name, account.AccountNumber));
-        }
+        Then()
+            .Do(ctx =>
+                Console.WriteLine("Customer {0} has active account #{1}",
+                    customer.Name, account.AccountNumber));
     }
 }

--- a/samples/SimpleRules/Rules/ActiveDelinquentAccountRule.cs
+++ b/samples/SimpleRules/Rules/ActiveDelinquentAccountRule.cs
@@ -2,20 +2,19 @@ using System;
 using NRules.Fluent.Dsl;
 using NRules.Samples.SimpleRules.Domain;
 
-namespace NRules.Samples.SimpleRules.Rules
+namespace NRules.Samples.SimpleRules.Rules;
+
+public class ActiveDelinquentAccountRule : Rule
 {
-    public class ActiveDelinquentAccountRule : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Customer customer = default;
+        Customer customer = default;
 
-            When()
-                .Match(() => customer, c => c.IsPreferred)
-                .Exists<Account>(a => a.Owner == customer, a => a.IsActive, a => a.IsDelinquent);
+        When()
+            .Match(() => customer, c => c.IsPreferred)
+            .Exists<Account>(a => a.Owner == customer, a => a.IsActive, a => a.IsDelinquent);
 
-            Then()
-                .Do(ctx => Console.WriteLine("Customer {0} has active delinquent accounts", customer.Name));
-        }
+        Then()
+            .Do(ctx => Console.WriteLine("Customer {0} has active delinquent accounts", customer.Name));
     }
 }

--- a/samples/SimpleRules/Rules/AllActiveAccountsRule.cs
+++ b/samples/SimpleRules/Rules/AllActiveAccountsRule.cs
@@ -2,20 +2,19 @@ using System;
 using NRules.Fluent.Dsl;
 using NRules.Samples.SimpleRules.Domain;
 
-namespace NRules.Samples.SimpleRules.Rules
+namespace NRules.Samples.SimpleRules.Rules;
+
+public class AllActiveAccountsRule : Rule
 {
-    public class AllActiveAccountsRule : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Customer customer = default;
+        Customer customer = default;
 
-            When()
-                .Match(() => customer, c => c.IsPreferred)
-                .All<Account>(a => a.Owner == customer && a.IsActive, a => !a.IsDelinquent);
+        When()
+            .Match(() => customer, c => c.IsPreferred)
+            .All<Account>(a => a.Owner == customer && a.IsActive, a => !a.IsDelinquent);
 
-            Then()
-                .Do(ctx => Console.WriteLine("All active accounts of customer {0} are not delinquent", customer.Name));
-        }
+        Then()
+            .Do(ctx => Console.WriteLine("All active accounts of customer {0} are not delinquent", customer.Name));
     }
 }

--- a/samples/SimpleRules/Rules/DiscountNotificationRule.cs
+++ b/samples/SimpleRules/Rules/DiscountNotificationRule.cs
@@ -2,20 +2,19 @@
 using NRules.Fluent.Dsl;
 using NRules.Samples.SimpleRules.Domain;
 
-namespace NRules.Samples.SimpleRules.Rules
+namespace NRules.Samples.SimpleRules.Rules;
+
+public class DiscountNotificationRule : Rule
 {
-    public class DiscountNotificationRule : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Customer customer = default;
+        Customer customer = default;
 
-            When()
-                .Match(() => customer)
-                .Exists<Order>(o => o.Customer == customer, o => o.PercentDiscount > 0.0);
+        When()
+            .Match(() => customer)
+            .Exists<Order>(o => o.Customer == customer, o => o.PercentDiscount > 0.0);
 
-            Then()
-                .Do(_ => Console.WriteLine("Customer {0} was notified about a discount", customer.Name));
-        }
+        Then()
+            .Do(_ => Console.WriteLine("Customer {0} was notified about a discount", customer.Name));
     }
 }

--- a/samples/SimpleRules/Rules/ImportantCustomerRule.cs
+++ b/samples/SimpleRules/Rules/ImportantCustomerRule.cs
@@ -2,23 +2,22 @@ using System;
 using NRules.Fluent.Dsl;
 using NRules.Samples.SimpleRules.Domain;
 
-namespace NRules.Samples.SimpleRules.Rules
+namespace NRules.Samples.SimpleRules.Rules;
+
+public class ImportantCustomerRule : Rule
 {
-    public class ImportantCustomerRule : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Customer customer = default;
+        Customer customer = default;
 
-            When()
-            .Or(x => x
-                .Match(() => customer, c => c.IsPreferred)
-                .And(xx => xx
-                    .Match(() => customer, c => !c.IsPreferred)
-                    .Exists<Order>(o => o.Customer == customer, o => o.Amount >= 1000.00)));
+        When()
+        .Or(x => x
+            .Match(() => customer, c => c.IsPreferred)
+            .And(xx => xx
+                .Match(() => customer, c => !c.IsPreferred)
+                .Exists<Order>(o => o.Customer == customer, o => o.Amount >= 1000.00)));
 
-            Then()
-                .Do(ctx => Console.WriteLine("Customer {0} is important", customer.Name));
-        }
+        Then()
+            .Do(ctx => Console.WriteLine("Customer {0} is important", customer.Name));
     }
 }

--- a/samples/SimpleRules/Rules/LargeTotalRule.cs
+++ b/samples/SimpleRules/Rules/LargeTotalRule.cs
@@ -4,28 +4,27 @@ using System.Linq;
 using NRules.Fluent.Dsl;
 using NRules.Samples.SimpleRules.Domain;
 
-namespace NRules.Samples.SimpleRules.Rules
+namespace NRules.Samples.SimpleRules.Rules;
+
+public class LargeTotalRule : Rule
 {
-    public class LargeTotalRule : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Customer customer = default;
-            IEnumerable<Order> orders = default;
-            double total = default;
+        Customer customer = default;
+        IEnumerable<Order> orders = default;
+        double total = default;
 
-            When()
-                .Match(() => customer, c => c.IsPreferred)
-                .Query(() => orders, x => x
-                    .Match<Order>(
-                        o => o.Customer == customer,
-                        o => o.IsOpen)
-                    .Collect())
-                .Let(() => total, () => orders.Sum(x => x.Amount))
-                .Having(() => total > 100);
+        When()
+            .Match(() => customer, c => c.IsPreferred)
+            .Query(() => orders, x => x
+                .Match<Order>(
+                    o => o.Customer == customer,
+                    o => o.IsOpen)
+                .Collect())
+            .Let(() => total, () => orders.Sum(x => x.Amount))
+            .Having(() => total > 100);
 
-            Then()
-                .Do(ctx => Console.WriteLine("Customer {0} has orders over $100 total", customer.Name));
-        }
+        Then()
+            .Do(ctx => Console.WriteLine("Customer {0} has orders over $100 total", customer.Name));
     }
 }

--- a/samples/SimpleRules/Rules/MultipleOrdersRule.cs
+++ b/samples/SimpleRules/Rules/MultipleOrdersRule.cs
@@ -4,26 +4,25 @@ using System.Linq;
 using NRules.Fluent.Dsl;
 using NRules.Samples.SimpleRules.Domain;
 
-namespace NRules.Samples.SimpleRules.Rules
+namespace NRules.Samples.SimpleRules.Rules;
+
+public class MultipleOrdersRule : Rule
 {
-    public class MultipleOrdersRule : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Customer customer = default;
-            IEnumerable<Order> orders = default;
+        Customer customer = default;
+        IEnumerable<Order> orders = default;
 
-            When()
-                .Match(() => customer, c => c.IsPreferred)
-                .Query(() => orders, x => x
-                    .Match<Order>(
-                        o => o.Customer == customer,
-                        o => o.IsOpen)
-                    .Collect()
-                    .Where(c => c.Count() >= 3));
+        When()
+            .Match(() => customer, c => c.IsPreferred)
+            .Query(() => orders, x => x
+                .Match<Order>(
+                    o => o.Customer == customer,
+                    o => o.IsOpen)
+                .Collect()
+                .Where(c => c.Count() >= 3));
 
-            Then()
-                .Do(ctx => Console.WriteLine("Customer {0} has over 3 open orders", customer.Name));
-        }
+        Then()
+            .Do(ctx => Console.WriteLine("Customer {0} has over 3 open orders", customer.Name));
     }
 }

--- a/samples/SimpleRules/Rules/NoActiveDelinquentAccountsRule.cs
+++ b/samples/SimpleRules/Rules/NoActiveDelinquentAccountsRule.cs
@@ -2,20 +2,19 @@ using System;
 using NRules.Fluent.Dsl;
 using NRules.Samples.SimpleRules.Domain;
 
-namespace NRules.Samples.SimpleRules.Rules
+namespace NRules.Samples.SimpleRules.Rules;
+
+public class NoActiveDelinquentAccountsRule : Rule
 {
-    public class NoActiveDelinquentAccountsRule : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Customer customer = default;
+        Customer customer = default;
 
-            When()
-                .Match(() => customer, c => c.IsPreferred)
-                .Not<Account>(a => a.Owner == customer, a => a.IsActive, a => a.IsDelinquent);
+        When()
+            .Match(() => customer, c => c.IsPreferred)
+            .Not<Account>(a => a.Owner == customer, a => a.IsActive, a => a.IsDelinquent);
 
-            Then()
-                .Do(ctx => Console.WriteLine("Customer {0} does not have active delinquent accounts", customer.Name));
-        }
+        Then()
+            .Do(ctx => Console.WriteLine("Customer {0} does not have active delinquent accounts", customer.Name));
     }
 }

--- a/samples/SimpleRules/Rules/OrderAmountCalculationRule.cs
+++ b/samples/SimpleRules/Rules/OrderAmountCalculationRule.cs
@@ -2,28 +2,27 @@
 using NRules.Fluent.Dsl;
 using NRules.Samples.SimpleRules.Domain;
 
-namespace NRules.Samples.SimpleRules.Rules
+namespace NRules.Samples.SimpleRules.Rules;
+
+public class OrderAmountCalculationRule : Rule
 {
-    public class OrderAmountCalculationRule : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            Order order = null;
+        Order order = null;
 
-            When()
-                .Match(() => order);
+        When()
+            .Match(() => order);
 
-            Filter()
-                .OnChange(() => order.Quantity, () => order.UnitPrice, () => order.PercentDiscount);
+        Filter()
+            .OnChange(() => order.Quantity, () => order.UnitPrice, () => order.PercentDiscount);
 
-            Then()
-                .Do(ctx => ctx.Update(order, CalculateAmount));
-        }
+        Then()
+            .Do(ctx => ctx.Update(order, CalculateAmount));
+    }
 
-        private static void CalculateAmount(Order order)
-        {
-            order.Amount = order.UnitPrice * order.Quantity * (1.0 - order.PercentDiscount / 100.0);
-            Console.WriteLine("Order amount calculated. Id={0}, Amount={1}", order.Id, order.Amount);
-        }
+    private static void CalculateAmount(Order order)
+    {
+        order.Amount = order.UnitPrice * order.Quantity * (1.0 - order.PercentDiscount / 100.0);
+        Console.WriteLine("Order amount calculated. Id={0}, Amount={1}", order.Id, order.Amount);
     }
 }

--- a/samples/SimpleRules/Rules/OrdersByCustomerRule.cs
+++ b/samples/SimpleRules/Rules/OrdersByCustomerRule.cs
@@ -3,24 +3,23 @@ using System.Linq;
 using NRules.Fluent.Dsl;
 using NRules.Samples.SimpleRules.Domain;
 
-namespace NRules.Samples.SimpleRules.Rules
+namespace NRules.Samples.SimpleRules.Rules;
+
+public class OrdersByCustomerRule : Rule
 {
-    public class OrdersByCustomerRule : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            IGrouping<Customer, Order> group = null;
+        IGrouping<Customer, Order> group = null;
 
-            When()
-                .Query(() => group, q => 
-                    from o in q.Match<Order>()
-                    where o.IsOpen
-                    group o by o.Customer into g 
-                    select g);
+        When()
+            .Query(() => group, q => 
+                from o in q.Match<Order>()
+                where o.IsOpen
+                group o by o.Customer into g 
+                select g);
 
-            Then()
-                .Do(ctx => Console.WriteLine("Customer {0} has {1} open order(s)", 
-                    group.Key.Name, group.Count()));
-        }
+        Then()
+            .Do(ctx => Console.WriteLine("Customer {0} has {1} open order(s)", 
+                group.Key.Name, group.Count()));
     }
 }

--- a/samples/SimpleRules/Rules/PreferredCustomerDiscountRule.cs
+++ b/samples/SimpleRules/Rules/PreferredCustomerDiscountRule.cs
@@ -3,37 +3,36 @@ using System.Linq;
 using NRules.Fluent.Dsl;
 using NRules.Samples.SimpleRules.Domain;
 
-namespace NRules.Samples.SimpleRules.Rules
+namespace NRules.Samples.SimpleRules.Rules;
+
+[Name("Preferred customer discount")]
+public class PreferredCustomerDiscountRule : Rule
 {
-    [Name("Preferred customer discount")]
-    public class PreferredCustomerDiscountRule : Rule
+    public override void Define()
     {
-        public override void Define()
+        Customer customer = default;
+        IEnumerable<Order> orders = default;
+
+        When()
+            .Match(() => customer, c => c.IsPreferred)
+            .Query(() => orders, x => x
+                .Match<Order>(
+                    o => o.Customer == customer,
+                    o => o.IsOpen,
+                    o => o.PercentDiscount == 0.0)
+                .Collect()
+                .Where(c => c.Any()));
+
+        Then()
+            .Do(ctx => ApplyDiscount(orders, 10.0))
+            .Do(ctx => orders.ToList().ForEach(ctx.Update));
+    }
+
+    private static void ApplyDiscount(IEnumerable<Order> orders, double discount)
+    {
+        foreach (var order in orders)
         {
-            Customer customer = default;
-            IEnumerable<Order> orders = default;
-
-            When()
-                .Match(() => customer, c => c.IsPreferred)
-                .Query(() => orders, x => x
-                    .Match<Order>(
-                        o => o.Customer == customer,
-                        o => o.IsOpen,
-                        o => o.PercentDiscount == 0.0)
-                    .Collect()
-                    .Where(c => c.Any()));
-
-            Then()
-                .Do(ctx => ApplyDiscount(orders, 10.0))
-                .Do(ctx => orders.ToList().ForEach(ctx.Update));
-        }
-
-        private static void ApplyDiscount(IEnumerable<Order> orders, double discount)
-        {
-            foreach (var order in orders)
-            {
-                order.PercentDiscount = discount;
-            }
+            order.PercentDiscount = discount;
         }
     }
 }

--- a/samples/SimpleRules/SimpleRules.csproj
+++ b/samples/SimpleRules/SimpleRules.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace>NRules.Samples.SimpleRules</RootNamespace>
     <AssemblyName>NRules.Samples.SimpleRules</AssemblyName>
   </PropertyGroup>

--- a/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.DebuggeeSide/NRules.Debugger.Visualizer.DebuggeeSide.csproj
+++ b/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.DebuggeeSide/NRules.Debugger.Visualizer.DebuggeeSide.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>NRules.Debugger.Visualizer</RootNamespace>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.DebuggeeSide/SessionObjectSource.cs
+++ b/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.DebuggeeSide/SessionObjectSource.cs
@@ -3,18 +3,17 @@ using Microsoft.VisualStudio.DebuggerVisualizers;
 using NRules.Diagnostics;
 using NRules.Diagnostics.Dgml;
 
-namespace NRules.Debugger.Visualizer
+namespace NRules.Debugger.Visualizer;
+
+public class SessionObjectSource : VisualizerObjectSource
 {
-    public class SessionObjectSource : VisualizerObjectSource
+    public override void GetData(object target, Stream outgoingData)
     {
-        public override void GetData(object target, Stream outgoingData)
-        {
-            var session = (ISessionSchemaProvider) target;
-            var schema = session.GetSchema();
-            var dgmlWriter = new DgmlWriter(schema);
-            var contents = dgmlWriter.GetContents();
-            using var writer = new StreamWriter(outgoingData);
-            writer.Write(contents);
-        }
+        var session = (ISessionSchemaProvider)target;
+        var schema = session.GetSchema();
+        var dgmlWriter = new DgmlWriter(schema);
+        var contents = dgmlWriter.GetContents();
+        using var writer = new StreamWriter(outgoingData);
+        writer.Write(contents);
     }
 }

--- a/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.DebuggeeSide/SessionPerformanceObjectSource.cs
+++ b/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.DebuggeeSide/SessionPerformanceObjectSource.cs
@@ -2,19 +2,18 @@
 using Microsoft.VisualStudio.DebuggerVisualizers;
 using NRules.Diagnostics.Dgml;
 
-namespace NRules.Debugger.Visualizer
+namespace NRules.Debugger.Visualizer;
+
+public class SessionPerformanceObjectSource : VisualizerObjectSource
 {
-    public class SessionPerformanceObjectSource : VisualizerObjectSource
+    public override void GetData(object target, Stream outgoingData)
     {
-        public override void GetData(object target, Stream outgoingData)
-        {
-            var session = (ISession) target;
-            var schema = session.GetSchema();
-            var dgmlWriter = new DgmlWriter(schema);
-            dgmlWriter.SetMetricsProvider(session.Metrics);
-            var contents = dgmlWriter.GetContents();
-            using var writer = new StreamWriter(outgoingData);
-            writer.Write(contents);
-        }
+        var session = (ISession) target;
+        var schema = session.GetSchema();
+        var dgmlWriter = new DgmlWriter(schema);
+        dgmlWriter.SetMetricsProvider(session.Metrics);
+        var contents = dgmlWriter.GetContents();
+        using var writer = new StreamWriter(outgoingData);
+        writer.Write(contents);
     }
 }

--- a/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.Tests/NRules.Debugger.Visualizer.Tests.csproj
+++ b/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.Tests/NRules.Debugger.Visualizer.Tests.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>net48</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <OutputType>Exe</OutputType>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.Tests/Program.cs
+++ b/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.Tests/Program.cs
@@ -3,22 +3,21 @@ using System.Reflection;
 using NRules.Debugger.Visualizer.Tests.TestAssets;
 using NRules.Fluent;
 
-namespace NRules.Debugger.Visualizer.Tests
+namespace NRules.Debugger.Visualizer.Tests;
+
+public class Program
 {
-    public class Program
+    [STAThread]
+    private static void Main(string[] args)
     {
-        [STAThread]
-        private static void Main(string[] args)
-        {
-            var repository = new RuleRepository();
-            repository.Load(x => x.From(Assembly.GetExecutingAssembly()));
+        var repository = new RuleRepository();
+        repository.Load(x => x.From(Assembly.GetExecutingAssembly()));
 
-            ISessionFactory factory = repository.Compile();
-            ISession session = factory.CreateSession();
+        ISessionFactory factory = repository.Compile();
+        ISession session = factory.CreateSession();
 
-            session.Insert(new Fact1 { TestProperty = "Valid Value" });
+        session.Insert(new Fact1 { TestProperty = "Valid Value" });
 
-            VisualizerHost.Visualize(session);
-        }
+        VisualizerHost.Visualize(session);
     }
 }

--- a/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.Tests/TestAssets/TestRule.cs
+++ b/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.Tests/TestAssets/TestRule.cs
@@ -2,58 +2,57 @@
 using System.Linq;
 using NRules.Fluent.Dsl;
 
-namespace NRules.Debugger.Visualizer.Tests.TestAssets
+namespace NRules.Debugger.Visualizer.Tests.TestAssets;
+
+public class Fact1
 {
-    public class Fact1
+    public string TestProperty { get; set; }
+}
+
+public class Fact2
+{
+    public string TestProperty { get; set; }
+    public string JoinProperty { get; set; }
+}
+
+public class Fact3
+{
+    public string TestProperty { get; set; }
+}
+
+public class Fact4
+{
+    public string TestProperty { get; set; }
+}
+
+public class TestRule : Rule
+{
+    public override void Define()
     {
-        public string TestProperty { get; set; }
+        Fact1 fact1 = null;
+        string joinValue = null;
+        Fact2 fact2 = null;
+        IEnumerable<Fact4> group = null;
+
+        When()
+            .Match<Fact1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+            .Let(() => joinValue, () => fact1.TestProperty)
+            .Match<Fact2>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == joinValue)
+            .Not<Fact3>(f => f.TestProperty.StartsWith("Invalid"))
+            .Exists<Fact3>(f => f.TestProperty.StartsWith("Valid"))
+            .Query(() => group, q => q
+                .Match<Fact4>()
+                .Where(f => f.TestProperty.StartsWith("Valid"))
+                .GroupBy(f => f.TestProperty)
+                .SelectMany(x => x)
+                .Collect()
+                .Where(c => c.Any()));
+
+        Then()
+            .Do(ctx => NoOp());
     }
 
-    public class Fact2
+    private void NoOp()
     {
-        public string TestProperty { get; set; }
-        public string JoinProperty { get; set; }
-    }
-
-    public class Fact3
-    {
-        public string TestProperty { get; set; }
-    }
-
-    public class Fact4
-    {
-        public string TestProperty { get; set; }
-    }
-
-    public class TestRule : Rule
-    {
-        public override void Define()
-        {
-            Fact1 fact1 = null;
-            string joinValue = null;
-            Fact2 fact2 = null;
-            IEnumerable<Fact4> group = null;
-
-            When()
-                .Match<Fact1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                .Let(() => joinValue, () => fact1.TestProperty)
-                .Match<Fact2>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == joinValue)
-                .Not<Fact3>(f => f.TestProperty.StartsWith("Invalid"))
-                .Exists<Fact3>(f => f.TestProperty.StartsWith("Valid"))
-                .Query(() => group, q => q
-                    .Match<Fact4>()
-                    .Where(f => f.TestProperty.StartsWith("Valid"))
-                    .GroupBy(f => f.TestProperty)
-                    .SelectMany(x => x)
-                    .Collect()
-                    .Where(c => c.Any()));
-
-            Then()
-                .Do(ctx => NoOp());
-        }
-
-        private void NoOp()
-        {
-        }
     }
 }

--- a/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.Tests/VisualizerHost.cs
+++ b/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.Tests/VisualizerHost.cs
@@ -1,18 +1,17 @@
 ﻿using Microsoft.VisualStudio.DebuggerVisualizers;
 
-namespace NRules.Debugger.Visualizer.Tests
-{
-    public class VisualizerHost : VisualizerDevelopmentHost
-    {
-        internal VisualizerHost(ISession objectToVisualize)
-            : base(objectToVisualize, typeof (SessionVisualizer), typeof (SessionObjectSource))
-        {
-        }
+namespace NRules.Debugger.Visualizer.Tests;
 
-        public static void Visualize(ISession session)
-        {
-            var host = new VisualizerHost(session);
-            host.ShowVisualizer();
-        }
+public class VisualizerHost : VisualizerDevelopmentHost
+{
+    internal VisualizerHost(ISession objectToVisualize)
+        : base(objectToVisualize, typeof (SessionVisualizer), typeof (SessionObjectSource))
+    {
+    }
+
+    public static void Visualize(ISession session)
+    {
+        var host = new VisualizerHost(session);
+        host.ShowVisualizer();
     }
 }

--- a/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.csproj
+++ b/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer.csproj
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer/SessionVisualizer.cs
+++ b/src/NRules.Debugger.Visualizer/NRules.Debugger.Visualizer/SessionVisualizer.cs
@@ -19,18 +19,17 @@ using NRules.Debugger.Visualizer;
     TargetTypeName = "NRules.Session, NRules",
     Description = "NRules Session Performance Visualizer")]
 
-namespace NRules.Debugger.Visualizer
+namespace NRules.Debugger.Visualizer;
+
+public class SessionVisualizer : DialogDebuggerVisualizer
 {
-    public class SessionVisualizer : DialogDebuggerVisualizer
+    protected override void Show(IDialogVisualizerService windowService, IVisualizerObjectProvider objectProvider)
     {
-        protected override void Show(IDialogVisualizerService windowService, IVisualizerObjectProvider objectProvider)
-        {
-            var stream = objectProvider.GetData();
-            using var streamReader = new StreamReader(stream);
-            var snapshot = streamReader.ReadToEnd();
-            string fileName = Path.Combine(Path.GetTempPath(), "session.dgml");
-            File.WriteAllText(fileName, snapshot);
-            Process.Start(fileName);
-        }
+        var stream = objectProvider.GetData();
+        using var streamReader = new StreamReader(stream);
+        var snapshot = streamReader.ReadToEnd();
+        string fileName = Path.Combine(Path.GetTempPath(), "session.dgml");
+        File.WriteAllText(fileName, snapshot);
+        Process.Start(fileName);
     }
 }

--- a/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/NRules.Integration.Autofac.Tests.csproj
+++ b/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/NRules.Integration.Autofac.Tests.csproj
@@ -6,7 +6,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/RuleDependencyInjectionTests.cs
+++ b/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/RuleDependencyInjectionTests.cs
@@ -3,137 +3,136 @@ using NRules.Integration.Autofac.Tests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.Integration.Autofac.Tests
+namespace NRules.Integration.Autofac.Tests;
+
+public class RuleDependencyInjectionTests
 {
-    public class RuleDependencyInjectionTests
+    [Fact]
+    public void RuleRepository_Resolved_Returns()
     {
-        [Fact]
-        public void RuleRepository_Resolved_Returns()
+        //Arrange
+        var builder = new ContainerBuilder();
+        builder.RegisterType<TestService>().AsImplementedInterfaces().SingleInstance();
+        builder.RegisterRuleRepository(x => x.Type(typeof(RuleWithConstructorDependency)));
+
+        var container = builder.Build();
+
+        //Act
+        var repository = container.Resolve<IRuleRepository>();
+        var rules = repository.GetRules();
+
+        //Assert
+        Assert.Single(rules);
+    }
+
+    [Fact]
+    public void SessionFactory_Resolved_Returns()
+    {
+        //Arrange
+        var builder = new ContainerBuilder();
+        builder.RegisterType<TestService>().AsImplementedInterfaces().SingleInstance();
+        builder.RegisterRuleRepository(x => x.Type(typeof(RuleWithConstructorDependency)));
+        builder.RegisterSessionFactory();
+
+        var container = builder.Build();
+
+        //Act
+        var factory = container.Resolve<ISessionFactory>();
+
+        //Assert
+        Assert.NotNull(factory);
+    }
+
+    [Fact]
+    public void Session_Resolved_Returns()
+    {
+        //Arrange
+        var builder = new ContainerBuilder();
+        builder.RegisterType<TestService>().AsImplementedInterfaces().SingleInstance();
+        builder.RegisterRuleRepository(x => x.Type(typeof(RuleWithConstructorDependency)));
+        builder.RegisterSessionFactory();
+        builder.RegisterSession();
+
+        var container = builder.Build();
+
+        //Act
+        var session = container.Resolve<ISession>();
+
+        //Assert
+        Assert.NotNull(session);
+    }
+
+    [Fact]
+    public void Session_ConstructorInjectedServiceCalled_Works()
+    {
+        //Arrange
+        var builder = new ContainerBuilder();
+        builder.RegisterType<TestService>().AsImplementedInterfaces().SingleInstance();
+        builder.RegisterRuleRepository(x => x.Type(typeof(RuleWithConstructorDependency)));
+        builder.RegisterSessionFactory();
+        builder.RegisterSession();
+
+        var container = builder.Build();
+        var service = container.Resolve<ITestService>();
+        var session = container.Resolve<ISession>();
+
+        //Act
+        session.Insert(new TestFact1());
+        session.Fire();
+
+        //Assert
+        Assert.Equal("It's done", service.Status);
+    }
+
+    [Fact]
+    public void Session_ActionInjectedServiceCalled_Works()
+    {
+        //Arrange
+        var builder = new ContainerBuilder();
+        builder.RegisterType<TestService>().AsImplementedInterfaces().SingleInstance();
+        builder.RegisterRuleRepository(x => x.Type(typeof(RuleWithActionDependency)));
+        builder.RegisterSessionFactory();
+        builder.RegisterSession();
+
+        var container = builder.Build();
+        var service = container.Resolve<ITestService>();
+        var session = container.Resolve<ISession>();
+
+        //Act
+        session.Insert(new TestFact1());
+        session.Fire();
+
+        //Assert
+        Assert.Equal("It's done", service.Status);
+    }
+
+    [Fact]
+    public void Session_ActionInjectedScopedServiceCalled_Works()
+    {
+        //Arrange
+        var builder = new ContainerBuilder();
+        builder.RegisterType<TestService>().AsImplementedInterfaces().SingleInstance();
+        builder.RegisterRuleRepository(x => x.Type(typeof(RuleWithActionDependency)));
+        builder.RegisterSessionFactory();
+
+        var container = builder.Build();
+
+        using var scope = container.BeginLifetimeScope(sb =>
         {
-            //Arrange
-            var builder = new ContainerBuilder();
-            builder.RegisterType<TestService>().AsImplementedInterfaces().SingleInstance();
-            builder.RegisterRuleRepository(x => x.Type(typeof(RuleWithConstructorDependency)));
+            sb.RegisterType<TestService>().AsImplementedInterfaces().InstancePerLifetimeScope();
+            sb.RegisterSession();
+        });
 
-            var container = builder.Build();
+        var rootService = container.Resolve<ITestService>();
+        var scopedService = scope.Resolve<ITestService>();
+        var session = scope.Resolve<ISession>();
 
-            //Act
-            var repository = container.Resolve<IRuleRepository>();
-            var rules = repository.GetRules();
-         
-            //Assert
-            Assert.Single(rules);
-        }
-        
-        [Fact]
-        public void SessionFactory_Resolved_Returns()
-        {
-            //Arrange
-            var builder = new ContainerBuilder();
-            builder.RegisterType<TestService>().AsImplementedInterfaces().SingleInstance();
-            builder.RegisterRuleRepository(x => x.Type(typeof(RuleWithConstructorDependency)));
-            builder.RegisterSessionFactory();
+        //Act
+        session.Insert(new TestFact1());
+        session.Fire();
 
-            var container = builder.Build();
-
-            //Act
-            var factory = container.Resolve<ISessionFactory>();
-         
-            //Assert
-            Assert.NotNull(factory);
-        }
-        
-        [Fact]
-        public void Session_Resolved_Returns()
-        {
-            //Arrange
-            var builder = new ContainerBuilder();
-            builder.RegisterType<TestService>().AsImplementedInterfaces().SingleInstance();
-            builder.RegisterRuleRepository(x => x.Type(typeof(RuleWithConstructorDependency)));
-            builder.RegisterSessionFactory();
-            builder.RegisterSession();
-
-            var container = builder.Build();
-
-            //Act
-            var session = container.Resolve<ISession>();
-         
-            //Assert
-            Assert.NotNull(session);
-        }
-
-        [Fact]
-        public void Session_ConstructorInjectedServiceCalled_Works()
-        {
-            //Arrange
-            var builder = new ContainerBuilder();
-            builder.RegisterType<TestService>().AsImplementedInterfaces().SingleInstance();
-            builder.RegisterRuleRepository(x => x.Type(typeof(RuleWithConstructorDependency)));
-            builder.RegisterSessionFactory();
-            builder.RegisterSession();
-
-            var container = builder.Build();
-            var service = container.Resolve<ITestService>();
-            var session = container.Resolve<ISession>();
-
-            //Act
-            session.Insert(new TestFact1());
-            session.Fire();
-         
-            //Assert
-            Assert.Equal("It's done", service.Status);
-        }
-
-        [Fact]
-        public void Session_ActionInjectedServiceCalled_Works()
-        {
-            //Arrange
-            var builder = new ContainerBuilder();
-            builder.RegisterType<TestService>().AsImplementedInterfaces().SingleInstance();
-            builder.RegisterRuleRepository(x => x.Type(typeof(RuleWithActionDependency)));
-            builder.RegisterSessionFactory();
-            builder.RegisterSession();
-
-            var container = builder.Build();
-            var service = container.Resolve<ITestService>();
-            var session = container.Resolve<ISession>();
-
-            //Act
-            session.Insert(new TestFact1());
-            session.Fire();
-         
-            //Assert
-            Assert.Equal("It's done", service.Status);
-        }
-
-        [Fact]
-        public void Session_ActionInjectedScopedServiceCalled_Works()
-        {
-            //Arrange
-            var builder = new ContainerBuilder();
-            builder.RegisterType<TestService>().AsImplementedInterfaces().SingleInstance();
-            builder.RegisterRuleRepository(x => x.Type(typeof(RuleWithActionDependency)));
-            builder.RegisterSessionFactory();
-
-            var container = builder.Build();
-
-            using var scope = container.BeginLifetimeScope(sb =>
-            {
-                sb.RegisterType<TestService>().AsImplementedInterfaces().InstancePerLifetimeScope();
-                sb.RegisterSession();
-            });
-
-            var rootService = container.Resolve<ITestService>();
-            var scopedService = scope.Resolve<ITestService>();
-            var session = scope.Resolve<ISession>();
-
-            //Act
-            session.Insert(new TestFact1());
-            session.Fire();
-
-            //Assert
-            Assert.Null(rootService.Status);
-            Assert.Equal("It's done", scopedService.Status);
-        }
+        //Assert
+        Assert.Null(rootService.Status);
+        Assert.Equal("It's done", scopedService.Status);
     }
 }

--- a/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/TestAssets/RuleWithActionDependency.cs
+++ b/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/TestAssets/RuleWithActionDependency.cs
@@ -1,18 +1,17 @@
 ﻿using NRules.Fluent.Dsl;
 
-namespace NRules.Integration.Autofac.Tests.TestAssets
+namespace NRules.Integration.Autofac.Tests.TestAssets;
+
+public class RuleWithActionDependency : Rule
 {
-    public class RuleWithActionDependency : Rule
+    public override void Define()
     {
-        public override void Define()
-        {
-            TestFact1 fact1 = default;
+        TestFact1 fact1 = default;
 
-            When()
-                .Match(() => fact1);
+        When()
+            .Match(() => fact1);
 
-            Then()
-                .Do(ctx => ctx.Resolve<ITestService>().DoIt());
-        }
+        Then()
+            .Do(ctx => ctx.Resolve<ITestService>().DoIt());
     }
 }

--- a/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/TestAssets/RuleWithConstructorDependency.cs
+++ b/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/TestAssets/RuleWithConstructorDependency.cs
@@ -1,25 +1,24 @@
 ﻿using NRules.Fluent.Dsl;
 
-namespace NRules.Integration.Autofac.Tests.TestAssets
+namespace NRules.Integration.Autofac.Tests.TestAssets;
+
+public class RuleWithConstructorDependency : Rule
 {
-    public class RuleWithConstructorDependency : Rule
+    public ITestService Service { get; }
+
+    public RuleWithConstructorDependency(ITestService service)
     {
-        public ITestService Service { get; }
+        Service = service;
+    }
 
-        public RuleWithConstructorDependency(ITestService service)
-        {
-            Service = service;
-        }
+    public override void Define()
+    {
+        TestFact1 fact1 = default;
 
-        public override void Define()
-        {
-            TestFact1 fact1 = default;
+        When()
+            .Match(() => fact1);
 
-            When()
-                .Match(() => fact1);
-
-            Then()
-                .Do(_ => Service.DoIt());
-        }
+        Then()
+            .Do(_ => Service.DoIt());
     }
 }

--- a/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/TestAssets/TestFact1.cs
+++ b/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/TestAssets/TestFact1.cs
@@ -1,6 +1,5 @@
-﻿namespace NRules.Integration.Autofac.Tests.TestAssets
+﻿namespace NRules.Integration.Autofac.Tests.TestAssets;
+
+public class TestFact1
 {
-    public class TestFact1
-    {
-    }
 }

--- a/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/TestAssets/TestService.cs
+++ b/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/TestAssets/TestService.cs
@@ -1,18 +1,17 @@
-﻿namespace NRules.Integration.Autofac.Tests.TestAssets
+﻿namespace NRules.Integration.Autofac.Tests.TestAssets;
+
+public interface ITestService
 {
-    public interface ITestService
-    {
-        public string Status { get; }
-        void DoIt();
-    }
+    public string Status { get; }
+    void DoIt();
+}
 
-    public class TestService : ITestService
-    {
-        public string Status { get; set; }
+public class TestService : ITestService
+{
+    public string Status { get; set; }
 
-        public void DoIt()
-        {
-            Status = "It's done";
-        }
+    public void DoIt()
+    {
+        Status = "It's done";
     }
 }

--- a/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac/AutofacDependencyResolver.cs
+++ b/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac/AutofacDependencyResolver.cs
@@ -2,23 +2,22 @@
 using Autofac;
 using NRules.Extensibility;
 
-namespace NRules.Integration.Autofac
+namespace NRules.Integration.Autofac;
+
+/// <summary>
+/// Dependency resolver that uses Autofac DI container.
+/// </summary>
+public class AutofacDependencyResolver : IDependencyResolver
 {
-    /// <summary>
-    /// Dependency resolver that uses Autofac DI container.
-    /// </summary>
-    public class AutofacDependencyResolver : IDependencyResolver
+    private readonly ILifetimeScope _container;
+
+    public AutofacDependencyResolver(ILifetimeScope container)
     {
-        private readonly ILifetimeScope _container;
+        _container = container;
+    }
 
-        public AutofacDependencyResolver(ILifetimeScope container)
-        {
-            _container = container;
-        }
-
-        public object Resolve(IResolutionContext context, Type serviceType)
-        {
-            return _container.Resolve(serviceType);
-        }
+    public object Resolve(IResolutionContext context, Type serviceType)
+    {
+        return _container.Resolve(serviceType);
     }
 }

--- a/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac/AutofacRuleActivator.cs
+++ b/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac/AutofacRuleActivator.cs
@@ -4,34 +4,33 @@ using Autofac;
 using NRules.Fluent;
 using NRules.Fluent.Dsl;
 
-namespace NRules.Integration.Autofac
+namespace NRules.Integration.Autofac;
+
+/// <summary>
+/// Rule activator that uses Autofac DI container.
+/// </summary>
+public class AutofacRuleActivator : IRuleActivator
 {
-    /// <summary>
-    /// Rule activator that uses Autofac DI container.
-    /// </summary>
-    public class AutofacRuleActivator : IRuleActivator
+    private readonly ILifetimeScope _container;
+
+    public AutofacRuleActivator(ILifetimeScope container)
     {
-        private readonly ILifetimeScope _container;
+        _container = container;
+    }
 
-        public AutofacRuleActivator(ILifetimeScope container)
+    public IEnumerable<Rule> Activate(Type type)
+    {
+        if (_container.IsRegistered(type))
         {
-            _container = container;
+            var collectionType = typeof (IEnumerable<>).MakeGenericType(type);
+            return (IEnumerable<Rule>)_container.Resolve(collectionType);
         }
 
-        public IEnumerable<Rule> Activate(Type type)
-        {
-            if (_container.IsRegistered(type))
-            {
-                var collectionType = typeof (IEnumerable<>).MakeGenericType(type);
-                return (IEnumerable<Rule>)_container.Resolve(collectionType);
-            }
+        return ActivateDefault(type);
+    }
 
-            return ActivateDefault(type);
-        }
-
-        private static IEnumerable<Rule> ActivateDefault(Type type)
-        {
-            yield return (Rule) Activator.CreateInstance(type);
-        }
+    private static IEnumerable<Rule> ActivateDefault(Type type)
+    {
+        yield return (Rule) Activator.CreateInstance(type);
     }
 }

--- a/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac/NRules.Integration.Autofac.csproj
+++ b/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac/NRules.Integration.Autofac.csproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac/RegistrationExtensions.cs
+++ b/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac/RegistrationExtensions.cs
@@ -5,109 +5,108 @@ using NRules.Extensibility;
 using NRules.Fluent;
 using NRules.RuleModel;
 
-namespace NRules.Integration.Autofac
+namespace NRules.Integration.Autofac;
+
+public static class RegistrationExtensions
 {
-    public static class RegistrationExtensions
+    /// <summary>
+    /// Registers fluent rule types with the container, registers <see cref="RuleRepository"/> with the container
+    /// and loads registered rules into the repository.
+    /// By default repository is registered as a single instance and is wired with a <see cref="IRuleActivator"/>.
+    /// </summary>
+    /// <param name="builder">Container builder.</param>
+    /// <param name="scanAction">Configuration action on the rule type scanner.</param>
+    /// <returns>Registration builder for <see cref="RuleRepository"/> to specify additional registration configuration.</returns>
+    public static IRegistrationBuilder<RuleRepository, ConcreteReflectionActivatorData, SingleRegistrationStyle> 
+        RegisterRuleRepository(this ContainerBuilder builder, Action<IRuleTypeScanner> scanAction)
     {
-        /// <summary>
-        /// Registers fluent rule types with the container, registers <see cref="RuleRepository"/> with the container
-        /// and loads registered rules into the repository.
-        /// By default repository is registered as a single instance and is wired with a <see cref="IRuleActivator"/>.
-        /// </summary>
-        /// <param name="builder">Container builder.</param>
-        /// <param name="scanAction">Configuration action on the rule type scanner.</param>
-        /// <returns>Registration builder for <see cref="RuleRepository"/> to specify additional registration configuration.</returns>
-        public static IRegistrationBuilder<RuleRepository, ConcreteReflectionActivatorData, SingleRegistrationStyle> 
-            RegisterRuleRepository(this ContainerBuilder builder, Action<IRuleTypeScanner> scanAction)
-        {
-            var scanner = new RuleTypeScanner();
-            scanAction(scanner);
-            var ruleTypes = scanner.GetRuleTypes();
-            builder.RegisterTypes(ruleTypes)
-                .AsSelf()
-                .InstancePerDependency();
+        var scanner = new RuleTypeScanner();
+        scanAction(scanner);
+        var ruleTypes = scanner.GetRuleTypes();
+        builder.RegisterTypes(ruleTypes)
+            .AsSelf()
+            .InstancePerDependency();
 
-            builder.RegisterType<AutofacRuleActivator>()
-                .As<IRuleActivator>();
+        builder.RegisterType<AutofacRuleActivator>()
+            .As<IRuleActivator>();
 
-           return builder.RegisterType<RuleRepository>()
-                .As<IRuleRepository>()
-                .SingleInstance()
-                .OnActivating(e =>
-                {
-                    e.Instance.Activator = e.Context.Resolve<IRuleActivator>();
-                    e.Instance.Load(s => s.From(scanAction));
-                });
-        }
+       return builder.RegisterType<RuleRepository>()
+            .As<IRuleRepository>()
+            .SingleInstance()
+            .OnActivating(e =>
+            {
+                e.Instance.Activator = e.Context.Resolve<IRuleActivator>();
+                e.Instance.Load(s => s.From(scanAction));
+            });
+    }
 
-        /// <summary>
-        /// Registers <see cref="ISessionFactory"/> with the container.
-        /// Requires that <see cref="IRuleRepository"/> is registered with the container.
-        /// By default session factory is registered as a single instance and is wired with a <see cref="IDependencyResolver"/>.
-        /// </summary>
-        /// <param name="builder">Container builder.</param>
-        /// <returns>Registration builder for <see cref="ISessionFactory"/> to specify additional registration configuration.</returns>
-        public static IRegistrationBuilder<ISessionFactory, SimpleActivatorData, SingleRegistrationStyle> 
-            RegisterSessionFactory(this ContainerBuilder builder)
-        {
-            return builder.RegisterSessionFactory(c => c.Resolve<IRuleRepository>().Compile());
-        }
+    /// <summary>
+    /// Registers <see cref="ISessionFactory"/> with the container.
+    /// Requires that <see cref="IRuleRepository"/> is registered with the container.
+    /// By default session factory is registered as a single instance and is wired with a <see cref="IDependencyResolver"/>.
+    /// </summary>
+    /// <param name="builder">Container builder.</param>
+    /// <returns>Registration builder for <see cref="ISessionFactory"/> to specify additional registration configuration.</returns>
+    public static IRegistrationBuilder<ISessionFactory, SimpleActivatorData, SingleRegistrationStyle> 
+        RegisterSessionFactory(this ContainerBuilder builder)
+    {
+        return builder.RegisterSessionFactory(c => c.Resolve<IRuleRepository>().Compile());
+    }
 
-        /// <summary>
-        /// Registers <see cref="ISessionFactory"/> with the container.
-        /// By default session factory is registered as a single instance and is wired with a <see cref="IDependencyResolver"/>.
-        /// </summary>
-        /// <param name="builder">Container builder.</param>
-        /// <param name="compileFunc">Compile function that creates an instance of <see cref="ISessionFactory"/>.</param>
-        /// <returns>Registration builder for <see cref="ISessionFactory"/> to specify additional registration configuration.</returns>
-        public static IRegistrationBuilder<ISessionFactory, SimpleActivatorData, SingleRegistrationStyle> 
-            RegisterSessionFactory(this ContainerBuilder builder, Func<IComponentContext, ISessionFactory> compileFunc)
-        {
-            builder.RegisterDependencyResolver()
-                .SingleInstance();
+    /// <summary>
+    /// Registers <see cref="ISessionFactory"/> with the container.
+    /// By default session factory is registered as a single instance and is wired with a <see cref="IDependencyResolver"/>.
+    /// </summary>
+    /// <param name="builder">Container builder.</param>
+    /// <param name="compileFunc">Compile function that creates an instance of <see cref="ISessionFactory"/>.</param>
+    /// <returns>Registration builder for <see cref="ISessionFactory"/> to specify additional registration configuration.</returns>
+    public static IRegistrationBuilder<ISessionFactory, SimpleActivatorData, SingleRegistrationStyle> 
+        RegisterSessionFactory(this ContainerBuilder builder, Func<IComponentContext, ISessionFactory> compileFunc)
+    {
+        builder.RegisterDependencyResolver()
+            .SingleInstance();
 
-            return builder.Register(compileFunc)
-                .As<ISessionFactory>()
-                .SingleInstance()
-                .OnActivating(e => e.Instance.DependencyResolver = e.Context.Resolve<IDependencyResolver>());
-        }
+        return builder.Register(compileFunc)
+            .As<ISessionFactory>()
+            .SingleInstance()
+            .OnActivating(e => e.Instance.DependencyResolver = e.Context.Resolve<IDependencyResolver>());
+    }
 
-        /// <summary>
-        /// Registers <see cref="ISession"/> with the container.
-        /// By default session is registered as an instance per lifetime scope.
-        /// </summary>
-        /// <param name="builder">Container builder.</param>
-        /// <returns>Registration builder for <see cref="ISession"/> to specify additional registration configuration.</returns>
-        public static IRegistrationBuilder<ISession, SimpleActivatorData, SingleRegistrationStyle> 
-            RegisterSession(this ContainerBuilder builder)
-        {
-            return builder.RegisterSession(c => c.Resolve<ISessionFactory>().CreateSession());
-        }
+    /// <summary>
+    /// Registers <see cref="ISession"/> with the container.
+    /// By default session is registered as an instance per lifetime scope.
+    /// </summary>
+    /// <param name="builder">Container builder.</param>
+    /// <returns>Registration builder for <see cref="ISession"/> to specify additional registration configuration.</returns>
+    public static IRegistrationBuilder<ISession, SimpleActivatorData, SingleRegistrationStyle> 
+        RegisterSession(this ContainerBuilder builder)
+    {
+        return builder.RegisterSession(c => c.Resolve<ISessionFactory>().CreateSession());
+    }
 
-        /// <summary>
-        /// Registers <see cref="ISession"/> with the container.
-        /// By default session is registered as an instance per lifetime scope.
-        /// </summary>
-        /// <param name="builder">Container builder.</param>
-        /// <param name="factoryFunc">Factory function that creates an instance of <see cref="ISession"/>.</param>
-        /// <returns>Registration builder for <see cref="ISession"/> to specify additional registration configuration.</returns>
-        public static IRegistrationBuilder<ISession, SimpleActivatorData, SingleRegistrationStyle> 
-            RegisterSession(this ContainerBuilder builder, Func<IComponentContext, ISession> factoryFunc)
-        {
-            builder.RegisterDependencyResolver()
-                .InstancePerDependency();
+    /// <summary>
+    /// Registers <see cref="ISession"/> with the container.
+    /// By default session is registered as an instance per lifetime scope.
+    /// </summary>
+    /// <param name="builder">Container builder.</param>
+    /// <param name="factoryFunc">Factory function that creates an instance of <see cref="ISession"/>.</param>
+    /// <returns>Registration builder for <see cref="ISession"/> to specify additional registration configuration.</returns>
+    public static IRegistrationBuilder<ISession, SimpleActivatorData, SingleRegistrationStyle> 
+        RegisterSession(this ContainerBuilder builder, Func<IComponentContext, ISession> factoryFunc)
+    {
+        builder.RegisterDependencyResolver()
+            .InstancePerDependency();
 
-            return builder.Register(factoryFunc)
-                .As<ISession>()
-                .InstancePerLifetimeScope()
-                .OnActivating(e => e.Instance.DependencyResolver = e.Context.Resolve<IDependencyResolver>());
-        }
+        return builder.Register(factoryFunc)
+            .As<ISession>()
+            .InstancePerLifetimeScope()
+            .OnActivating(e => e.Instance.DependencyResolver = e.Context.Resolve<IDependencyResolver>());
+    }
 
-        private static IRegistrationBuilder<AutofacDependencyResolver, ConcreteReflectionActivatorData, SingleRegistrationStyle>
-            RegisterDependencyResolver(this ContainerBuilder builder)
-        {
-            return builder.RegisterType<AutofacDependencyResolver>()
-                .As<IDependencyResolver>();
-        }
+    private static IRegistrationBuilder<AutofacDependencyResolver, ConcreteReflectionActivatorData, SingleRegistrationStyle>
+        RegisterDependencyResolver(this ContainerBuilder builder)
+    {
+        return builder.RegisterType<AutofacDependencyResolver>()
+            .As<IDependencyResolver>();
     }
 }

--- a/src/NRules/NRules.Fluent/Dsl/ContextExtensions.cs
+++ b/src/NRules/NRules.Fluent/Dsl/ContextExtensions.cs
@@ -1,33 +1,32 @@
 using System;
 using NRules.RuleModel;
 
-namespace NRules.Fluent.Dsl
-{
-    public static class ContextExtensions
-    {
-        /// <summary>
-        /// Updates existing fact in the rules engine's memory.
-        /// First the update action is applied to the fact, then the fact is updated in the engine's memory.
-        /// </summary>
-        /// <param name="context">Context instance.</param>
-        /// <param name="fact">Existing fact to update.</param>
-        /// <param name="updateAction">Action to apply to the fact.</param>
-        public static void Update<T>(this IContext context, T fact, Action<T> updateAction)
-        {
-            updateAction(fact);
-            context.Update(fact);
-        }
+namespace NRules.Fluent.Dsl;
 
-        /// <summary>
-        /// Resolves a registered service (normally via an IoC container).
-        /// </summary>
-        /// <typeparam name="TService">Type of service to resolve.</typeparam>
-        /// <param name="context">Context instance.</param>
-        /// <returns>Service instance.</returns>
-        public static TService Resolve<TService>(this IContext context)
-        {
-            var service = context.Resolve(typeof(TService));
-            return (TService)service;
-        }
+public static class ContextExtensions
+{
+    /// <summary>
+    /// Updates existing fact in the rules engine's memory.
+    /// First the update action is applied to the fact, then the fact is updated in the engine's memory.
+    /// </summary>
+    /// <param name="context">Context instance.</param>
+    /// <param name="fact">Existing fact to update.</param>
+    /// <param name="updateAction">Action to apply to the fact.</param>
+    public static void Update<T>(this IContext context, T fact, Action<T> updateAction)
+    {
+        updateAction(fact);
+        context.Update(fact);
+    }
+
+    /// <summary>
+    /// Resolves a registered service (normally via an IoC container).
+    /// </summary>
+    /// <typeparam name="TService">Type of service to resolve.</typeparam>
+    /// <param name="context">Context instance.</param>
+    /// <returns>Service instance.</returns>
+    public static TService Resolve<TService>(this IContext context)
+    {
+        var service = context.Resolve(typeof(TService));
+        return (TService)service;
     }
 }

--- a/src/NRules/NRules.Fluent/Dsl/DescriptionAttribute.cs
+++ b/src/NRules/NRules.Fluent/Dsl/DescriptionAttribute.cs
@@ -1,18 +1,17 @@
 using System;
 
-namespace NRules.Fluent.Dsl
-{
-    /// <summary>
-    /// Sets rule's description.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    public sealed class DescriptionAttribute : Attribute
-    {
-        public DescriptionAttribute(string value)
-        {
-            Value = value;
-        }
+namespace NRules.Fluent.Dsl;
 
-        internal string Value { get; }
+/// <summary>
+/// Sets rule's description.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class DescriptionAttribute : Attribute
+{
+    public DescriptionAttribute(string value)
+    {
+        Value = value;
     }
+
+    internal string Value { get; }
 }

--- a/src/NRules/NRules.Fluent/Dsl/IDependencyExpression.cs
+++ b/src/NRules/NRules.Fluent/Dsl/IDependencyExpression.cs
@@ -1,19 +1,18 @@
 using System;
 using System.Linq.Expressions;
 
-namespace NRules.Fluent.Dsl
+namespace NRules.Fluent.Dsl;
+
+/// <summary>
+/// Rule's dependencies expression builder.
+/// </summary>
+public interface IDependencyExpression
 {
     /// <summary>
-    /// Rule's dependencies expression builder.
+    /// Configures the engine to inject the rules with a required dependency. 
     /// </summary>
-    public interface IDependencyExpression
-    {
-        /// <summary>
-        /// Configures the engine to inject the rules with a required dependency. 
-        /// </summary>
-        /// <typeparam name="TDependency">Type of the service to inject.</typeparam>
-        /// <param name="alias">Alias for the injected service.</param>
-        /// <returns>Dependencies expression builder.</returns>
-        IDependencyExpression Resolve<TDependency>(Expression<Func<TDependency>> alias);
-    }
+    /// <typeparam name="TDependency">Type of the service to inject.</typeparam>
+    /// <param name="alias">Alias for the injected service.</param>
+    /// <returns>Dependencies expression builder.</returns>
+    IDependencyExpression Resolve<TDependency>(Expression<Func<TDependency>> alias);
 }

--- a/src/NRules/NRules.Fluent/Dsl/IFilterExpression.cs
+++ b/src/NRules/NRules.Fluent/Dsl/IFilterExpression.cs
@@ -1,27 +1,26 @@
 using System;
 using System.Linq.Expressions;
 
-namespace NRules.Fluent.Dsl
+namespace NRules.Fluent.Dsl;
+
+/// <summary>
+/// Rule's filters expression builder.
+/// </summary>
+public interface IFilterExpression
 {
     /// <summary>
-    /// Rule's filters expression builder.
+    /// Configures the engine to filter rule's matches, so that updates are only triggered if given keys changed.
+    /// If multiple keys are configured, the match is accepted if any of the keys changed.
     /// </summary>
-    public interface IFilterExpression
-    {
-        /// <summary>
-        /// Configures the engine to filter rule's matches, so that updates are only triggered if given keys changed.
-        /// If multiple keys are configured, the match is accepted if any of the keys changed.
-        /// </summary>
-        /// <param name="keySelectors">Key selector expressions.</param>
-        /// <returns>Filters expression builder.</returns>
-        IFilterExpression OnChange(params Expression<Func<object>>[] keySelectors);
+    /// <param name="keySelectors">Key selector expressions.</param>
+    /// <returns>Filters expression builder.</returns>
+    IFilterExpression OnChange(params Expression<Func<object>>[] keySelectors);
 
-        /// <summary>
-        /// Configures the engine to filter rule's matches given a set of predicates.
-        /// If multiple predicates are configured, the match is accepted if all predicates are true.
-        /// </summary>
-        /// <param name="predicates">Predicate expressions.</param>
-        /// <returns>Filters expression builder.</returns>
-        IFilterExpression Where(params Expression<Func<bool>>[] predicates);
-    }
+    /// <summary>
+    /// Configures the engine to filter rule's matches given a set of predicates.
+    /// If multiple predicates are configured, the match is accepted if all predicates are true.
+    /// </summary>
+    /// <param name="predicates">Predicate expressions.</param>
+    /// <returns>Filters expression builder.</returns>
+    IFilterExpression Where(params Expression<Func<bool>>[] predicates);
 }

--- a/src/NRules/NRules.Fluent/Dsl/ILeftHandSideExpression.cs
+++ b/src/NRules/NRules.Fluent/Dsl/ILeftHandSideExpression.cs
@@ -1,104 +1,103 @@
 using System;
 using System.Linq.Expressions;
 
-namespace NRules.Fluent.Dsl
+namespace NRules.Fluent.Dsl;
+
+/// <summary>
+/// Rule's left-hand side (conditions) expression builder.
+/// </summary>
+public interface ILeftHandSideExpression
 {
     /// <summary>
-    /// Rule's left-hand side (conditions) expression builder.
+    /// Defines a pattern for facts matching a set of conditions.
+    /// Binds matching fact to a variable.
     /// </summary>
-    public interface ILeftHandSideExpression
-    {
-        /// <summary>
-        /// Defines a pattern for facts matching a set of conditions.
-        /// Binds matching fact to a variable.
-        /// </summary>
-        /// <typeparam name="TFact">Type of fact to match.</typeparam>
-        /// <param name="alias">Alias for the matching fact.</param>
-        /// <param name="conditions">Set of conditions the fact must satisfy to trigger the rule.</param>
-        /// <returns>Left hand side expression builder.</returns>
-        ILeftHandSideExpression Match<TFact>(Expression<Func<TFact>> alias, params Expression<Func<TFact, bool>>[] conditions);
+    /// <typeparam name="TFact">Type of fact to match.</typeparam>
+    /// <param name="alias">Alias for the matching fact.</param>
+    /// <param name="conditions">Set of conditions the fact must satisfy to trigger the rule.</param>
+    /// <returns>Left hand side expression builder.</returns>
+    ILeftHandSideExpression Match<TFact>(Expression<Func<TFact>> alias, params Expression<Func<TFact, bool>>[] conditions);
 
-        /// <summary>
-        /// Defines a pattern for facts matching a set of conditions.
-        /// Does not bind matching fact to a variable. Optionally, enables aggregation of matching facts.
-        /// </summary>
-        /// <param name="conditions">Set of additional conditions the fact must satisfy to trigger the rule.</param>
-        /// <returns>Left hand side expression builder.</returns>
-        ILeftHandSideExpression Match<TFact>(params Expression<Func<TFact, bool>>[] conditions);
+    /// <summary>
+    /// Defines a pattern for facts matching a set of conditions.
+    /// Does not bind matching fact to a variable. Optionally, enables aggregation of matching facts.
+    /// </summary>
+    /// <param name="conditions">Set of additional conditions the fact must satisfy to trigger the rule.</param>
+    /// <returns>Left hand side expression builder.</returns>
+    ILeftHandSideExpression Match<TFact>(params Expression<Func<TFact, bool>>[] conditions);
 
-        /// <summary>
-        /// Defines a pattern that triggers the rule only if there is at least one matching fact (existential quantifier).
-        /// </summary>
-        /// <typeparam name="TFact">Type of fact to match.</typeparam>
-        /// <param name="conditions">Set of conditions the facts must satisfy to trigger the rule.</param>
-        /// <returns>Left hand side expression builder.</returns>
-        ILeftHandSideExpression Exists<TFact>(params Expression<Func<TFact, bool>>[] conditions);
+    /// <summary>
+    /// Defines a pattern that triggers the rule only if there is at least one matching fact (existential quantifier).
+    /// </summary>
+    /// <typeparam name="TFact">Type of fact to match.</typeparam>
+    /// <param name="conditions">Set of conditions the facts must satisfy to trigger the rule.</param>
+    /// <returns>Left hand side expression builder.</returns>
+    ILeftHandSideExpression Exists<TFact>(params Expression<Func<TFact, bool>>[] conditions);
 
-        /// <summary>
-        /// Defines a pattern that triggers the rule only if there are no matching facts (negation quantifier).
-        /// </summary>
-        /// <typeparam name="TFact">Type of fact to match.</typeparam>
-        /// <param name="conditions">Set of conditions the facts must not satisfy to trigger the rule.</param>
-        /// <returns>Left hand side expression builder.</returns>
-        ILeftHandSideExpression Not<TFact>(params Expression<Func<TFact, bool>>[] conditions);
+    /// <summary>
+    /// Defines a pattern that triggers the rule only if there are no matching facts (negation quantifier).
+    /// </summary>
+    /// <typeparam name="TFact">Type of fact to match.</typeparam>
+    /// <param name="conditions">Set of conditions the facts must not satisfy to trigger the rule.</param>
+    /// <returns>Left hand side expression builder.</returns>
+    ILeftHandSideExpression Not<TFact>(params Expression<Func<TFact, bool>>[] conditions);
 
-        /// <summary>
-        /// Defines a pattern that triggers the rule only if all facts that match the base condition
-        /// also match all the remaining conditions (universal quantifier).
-        /// </summary>
-        /// <typeparam name="TFact">Type of fact to match.</typeparam>
-        /// <param name="baseCondition">Base condition that filters the facts to match the remaining conditions.</param>
-        /// <param name="conditions">Set of additional conditions that all matching facts must satisfy to trigger the rule.</param>
-        /// <returns>Left hand side expression builder.</returns>
-        ILeftHandSideExpression All<TFact>(Expression<Func<TFact, bool>> baseCondition, params Expression<Func<TFact, bool>>[] conditions);
+    /// <summary>
+    /// Defines a pattern that triggers the rule only if all facts that match the base condition
+    /// also match all the remaining conditions (universal quantifier).
+    /// </summary>
+    /// <typeparam name="TFact">Type of fact to match.</typeparam>
+    /// <param name="baseCondition">Base condition that filters the facts to match the remaining conditions.</param>
+    /// <param name="conditions">Set of additional conditions that all matching facts must satisfy to trigger the rule.</param>
+    /// <returns>Left hand side expression builder.</returns>
+    ILeftHandSideExpression All<TFact>(Expression<Func<TFact, bool>> baseCondition, params Expression<Func<TFact, bool>>[] conditions);
 
-        /// <summary>
-        /// Defines a pattern that triggers the rule only if all facts of a given type match the condition.
-        /// </summary>
-        /// <typeparam name="TFact">Type of fact to match.</typeparam>
-        /// <param name="condition">Condition that all facts of a given type must satisfy to trigger the rule.</param>
-        /// <returns>Left hand side expression builder.</returns>
-        ILeftHandSideExpression All<TFact>(Expression<Func<TFact, bool>> condition);
+    /// <summary>
+    /// Defines a pattern that triggers the rule only if all facts of a given type match the condition.
+    /// </summary>
+    /// <typeparam name="TFact">Type of fact to match.</typeparam>
+    /// <param name="condition">Condition that all facts of a given type must satisfy to trigger the rule.</param>
+    /// <returns>Left hand side expression builder.</returns>
+    ILeftHandSideExpression All<TFact>(Expression<Func<TFact, bool>> condition);
 
-        /// <summary>
-        /// Queries rules engine for matching facts.
-        /// </summary>
-        /// <typeparam name="TResult">Query result type.</typeparam>
-        /// <param name="alias">Alias for the query results.</param>
-        /// <param name="queryExpression">Query expression.</param>
-        /// <returns>Left hand side expression builder.</returns>
-        ILeftHandSideExpression Query<TResult>(Expression<Func<TResult>> alias, Func<IQuery, IQuery<TResult>> queryExpression);
+    /// <summary>
+    /// Queries rules engine for matching facts.
+    /// </summary>
+    /// <typeparam name="TResult">Query result type.</typeparam>
+    /// <param name="alias">Alias for the query results.</param>
+    /// <param name="queryExpression">Query expression.</param>
+    /// <returns>Left hand side expression builder.</returns>
+    ILeftHandSideExpression Query<TResult>(Expression<Func<TResult>> alias, Func<IQuery, IQuery<TResult>> queryExpression);
 
-        /// <summary>
-        /// Defines a group of patterns joined by an AND operator.
-        /// If all of the patterns in the group match then the whole group matches.
-        /// </summary>
-        /// <param name="builder">Group expression builder.</param>
-        /// <returns>Left hand side expression builder.</returns>
-        ILeftHandSideExpression And(Action<ILeftHandSideExpression> builder);
+    /// <summary>
+    /// Defines a group of patterns joined by an AND operator.
+    /// If all of the patterns in the group match then the whole group matches.
+    /// </summary>
+    /// <param name="builder">Group expression builder.</param>
+    /// <returns>Left hand side expression builder.</returns>
+    ILeftHandSideExpression And(Action<ILeftHandSideExpression> builder);
 
-        /// <summary>
-        /// Defines a group of patterns joined by an OR operator.
-        /// If either of the patterns in the group matches then the whole group matches.
-        /// </summary>
-        /// <param name="builder">Group expression builder.</param>
-        /// <returns>Left hand side expression builder.</returns>
-        ILeftHandSideExpression Or(Action<ILeftHandSideExpression> builder);
+    /// <summary>
+    /// Defines a group of patterns joined by an OR operator.
+    /// If either of the patterns in the group matches then the whole group matches.
+    /// </summary>
+    /// <param name="builder">Group expression builder.</param>
+    /// <returns>Left hand side expression builder.</returns>
+    ILeftHandSideExpression Or(Action<ILeftHandSideExpression> builder);
 
-        /// <summary>
-        /// Binds expression to a variable. Expression can use previously defined rule patterns.
-        /// </summary>
-        /// <typeparam name="TResult">Type of the expression result.</typeparam>
-        /// <param name="alias">Alias for the expression.</param>
-        /// <param name="expression">Expression to bind.</param>
-        /// <returns>Left hand side expression builder.</returns>
-        ILeftHandSideExpression Let<TResult>(Expression<Func<TResult>> alias, Expression<Func<TResult>> expression);
+    /// <summary>
+    /// Binds expression to a variable. Expression can use previously defined rule patterns.
+    /// </summary>
+    /// <typeparam name="TResult">Type of the expression result.</typeparam>
+    /// <param name="alias">Alias for the expression.</param>
+    /// <param name="expression">Expression to bind.</param>
+    /// <returns>Left hand side expression builder.</returns>
+    ILeftHandSideExpression Let<TResult>(Expression<Func<TResult>> alias, Expression<Func<TResult>> expression);
 
-        /// <summary>
-        /// Adds match conditions to existing rule patterns.
-        /// </summary>
-        /// <param name="conditions">Additional match conditions.</param>
-        /// <returns>Left hand side expression builder.</returns>
-        ILeftHandSideExpression Having(params Expression<Func<bool>>[] conditions);
-    }
+    /// <summary>
+    /// Adds match conditions to existing rule patterns.
+    /// </summary>
+    /// <param name="conditions">Additional match conditions.</param>
+    /// <returns>Left hand side expression builder.</returns>
+    ILeftHandSideExpression Having(params Expression<Func<bool>>[] conditions);
 }

--- a/src/NRules/NRules.Fluent/Dsl/IQuery.cs
+++ b/src/NRules/NRules.Fluent/Dsl/IQuery.cs
@@ -1,47 +1,46 @@
 ﻿using System.ComponentModel;
 
-namespace NRules.Fluent.Dsl
+namespace NRules.Fluent.Dsl;
+
+/// <summary>
+/// Root of the query method chain.
+/// </summary>
+public interface IQuery
 {
     /// <summary>
-    /// Root of the query method chain.
+    /// Internal query builder.
+    /// This method is intended for framework use only.
     /// </summary>
-    public interface IQuery
-    {
-        /// <summary>
-        /// Internal query builder.
-        /// This method is intended for framework use only.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        IQueryBuilder Builder { get; }
-    }
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    IQueryBuilder Builder { get; }
+}
 
+/// <summary>
+/// Intermediate query chain element.
+/// </summary>
+/// <typeparam name="TSource">Type of the element the query operates on.</typeparam>
+public interface IQuery<out TSource>
+{
     /// <summary>
-    /// Intermediate query chain element.
+    /// Internal query builder.
+    /// This method is intended for framework use only.
     /// </summary>
-    /// <typeparam name="TSource">Type of the element the query operates on.</typeparam>
-    public interface IQuery<out TSource>
-    {
-        /// <summary>
-        /// Internal query builder.
-        /// This method is intended for framework use only.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        IQueryBuilder Builder { get; }
-    }
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    IQueryBuilder Builder { get; }
+}
 
-    /// <summary>
-    /// Intermediate query chain element used for Collect modifiers.
-    /// </summary>
-    /// <typeparam name="TSource">Type of the element the query operates on.</typeparam>
-    public interface ICollectQuery<out TSource> : IQuery<TSource>
-    {
-    }
+/// <summary>
+/// Intermediate query chain element used for Collect modifiers.
+/// </summary>
+/// <typeparam name="TSource">Type of the element the query operates on.</typeparam>
+public interface ICollectQuery<out TSource> : IQuery<TSource>
+{
+}
 
-    /// <summary>
-    /// Intermediate query chain element used for OrderBy modifiers.
-    /// </summary>
-    /// <typeparam name="TSource">Type of the element the query operates on.</typeparam>
-    public interface IOrderedQuery<out TSource> : IQuery<TSource>
-    {
-    }
+/// <summary>
+/// Intermediate query chain element used for OrderBy modifiers.
+/// </summary>
+/// <typeparam name="TSource">Type of the element the query operates on.</typeparam>
+public interface IOrderedQuery<out TSource> : IQuery<TSource>
+{
 }

--- a/src/NRules/NRules.Fluent/Dsl/IQueryBuilder.cs
+++ b/src/NRules/NRules.Fluent/Dsl/IQueryBuilder.cs
@@ -3,23 +3,22 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using NRules.RuleModel;
 
-namespace NRules.Fluent.Dsl
+namespace NRules.Fluent.Dsl;
+
+/// <summary>
+/// Internal builder for queries.
+/// </summary>
+public interface IQueryBuilder
 {
-    /// <summary>
-    /// Internal builder for queries.
-    /// </summary>
-    public interface IQueryBuilder
-    {
-        void FactQuery<TSource>(Expression<Func<TSource, bool>>[] conditions);
-        void From<TSource>(Expression<Func<TSource>> source);
-        void Where<TSource>(Expression<Func<TSource, bool>>[] predicates);
-        void Select<TSource, TResult>(Expression<Func<TSource, TResult>> selector);
-        void SelectMany<TSource, TResult>(Expression<Func<TSource, IEnumerable<TResult>>> selector);
-        void GroupBy<TSource, TKey, TElement>(Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector);
-        void Collect<TSource>();
-        void ToLookup<TSource, TKey, TElement>(Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector);
-        void OrderBy<TSource, TKey>(Expression<Func<TSource, TKey>> keySelector, SortDirection sortDirection);
-        void Aggregate<TSource, TResult>(string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions);
-        void Aggregate<TSource, TResult>(string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, Type customFactoryType);
-    }
+    void FactQuery<TSource>(Expression<Func<TSource, bool>>[] conditions);
+    void From<TSource>(Expression<Func<TSource>> source);
+    void Where<TSource>(Expression<Func<TSource, bool>>[] predicates);
+    void Select<TSource, TResult>(Expression<Func<TSource, TResult>> selector);
+    void SelectMany<TSource, TResult>(Expression<Func<TSource, IEnumerable<TResult>>> selector);
+    void GroupBy<TSource, TKey, TElement>(Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector);
+    void Collect<TSource>();
+    void ToLookup<TSource, TKey, TElement>(Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector);
+    void OrderBy<TSource, TKey>(Expression<Func<TSource, TKey>> keySelector, SortDirection sortDirection);
+    void Aggregate<TSource, TResult>(string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions);
+    void Aggregate<TSource, TResult>(string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, Type customFactoryType);
 }

--- a/src/NRules/NRules.Fluent/Dsl/IRightHandSideExpression.cs
+++ b/src/NRules/NRules.Fluent/Dsl/IRightHandSideExpression.cs
@@ -2,54 +2,53 @@ using System;
 using System.Linq.Expressions;
 using NRules.RuleModel;
 
-namespace NRules.Fluent.Dsl
+namespace NRules.Fluent.Dsl;
+
+/// <summary>
+/// Rule's right-hand side (actions) expression builder.
+/// </summary>
+public interface IRightHandSideExpression
 {
     /// <summary>
-    /// Rule's right-hand side (actions) expression builder.
+    /// Defines rule's action that engine executes for a given trigger.
     /// </summary>
-    public interface IRightHandSideExpression
-    {
-        /// <summary>
-        /// Defines rule's action that engine executes for a given trigger.
-        /// </summary>
-        /// <param name="action">Action expression.</param>
-        /// <param name="actionTrigger">Events that should trigger this action.</param>
-        /// <returns>Right hand side expression builder.</returns>
-        IRightHandSideExpression Action(Expression<Action<IContext>> action, ActionTrigger actionTrigger);
+    /// <param name="action">Action expression.</param>
+    /// <param name="actionTrigger">Events that should trigger this action.</param>
+    /// <returns>Right hand side expression builder.</returns>
+    IRightHandSideExpression Action(Expression<Action<IContext>> action, ActionTrigger actionTrigger);
 
-        /// <summary>
-        /// Defines rule's action that engine executes when the rule fires
-        /// due to the initial rule match or due to an update.
-        /// </summary>
-        /// <param name="action">Action expression.</param>
-        /// <returns>Right hand side expression builder.</returns>
-        IRightHandSideExpression Do(Expression<Action<IContext>> action);
+    /// <summary>
+    /// Defines rule's action that engine executes when the rule fires
+    /// due to the initial rule match or due to an update.
+    /// </summary>
+    /// <param name="action">Action expression.</param>
+    /// <returns>Right hand side expression builder.</returns>
+    IRightHandSideExpression Do(Expression<Action<IContext>> action);
 
-        /// <summary>
-        /// Defines rule's action that engine executes when the rule fires
-        /// due to the match removal (provided the rule previously fired on the match).
-        /// </summary>
-        /// <param name="action">Action expression.</param>
-        /// <returns>Right hand side expression builder.</returns>
-        IRightHandSideExpression Undo(Expression<Action<IContext>> action);
+    /// <summary>
+    /// Defines rule's action that engine executes when the rule fires
+    /// due to the match removal (provided the rule previously fired on the match).
+    /// </summary>
+    /// <param name="action">Action expression.</param>
+    /// <returns>Right hand side expression builder.</returns>
+    IRightHandSideExpression Undo(Expression<Action<IContext>> action);
 
-        /// <summary>
-        /// Defines rule's action that yields a linked fact when the rule fires.
-        /// If the rule fires due to an update, the linked fact is also updated with the new yielded value.
-        /// </summary>
-        /// <typeparam name="TFact">Type of fact to yield.</typeparam>
-        /// <param name="yield">Action expression that yields the linked fact.</param>
-        /// <returns>Right hand side expression builder.</returns>
-        IRightHandSideExpression Yield<TFact>(Expression<Func<IContext, TFact>> yield);
+    /// <summary>
+    /// Defines rule's action that yields a linked fact when the rule fires.
+    /// If the rule fires due to an update, the linked fact is also updated with the new yielded value.
+    /// </summary>
+    /// <typeparam name="TFact">Type of fact to yield.</typeparam>
+    /// <param name="yield">Action expression that yields the linked fact.</param>
+    /// <returns>Right hand side expression builder.</returns>
+    IRightHandSideExpression Yield<TFact>(Expression<Func<IContext, TFact>> yield);
 
-        /// <summary>
-        /// Defines rule's action that yields a linked fact when the rule fires.
-        /// If the rule fires due to an update, the update expression is evaluated to produce an updated linked fact.
-        /// </summary>
-        /// <typeparam name="TFact">Type of fact to yield.</typeparam>
-        /// <param name="yieldInsert">Action expression that yields a new linked fact.</param>
-        /// <param name="yieldUpdate">Action expression that yields an updated linked fact.</param>
-        /// <returns>Right hand side expression builder.</returns>
-        IRightHandSideExpression Yield<TFact>(Expression<Func<IContext, TFact>> yieldInsert, Expression<Func<IContext, TFact, TFact>> yieldUpdate);
-    }
+    /// <summary>
+    /// Defines rule's action that yields a linked fact when the rule fires.
+    /// If the rule fires due to an update, the update expression is evaluated to produce an updated linked fact.
+    /// </summary>
+    /// <typeparam name="TFact">Type of fact to yield.</typeparam>
+    /// <param name="yieldInsert">Action expression that yields a new linked fact.</param>
+    /// <param name="yieldUpdate">Action expression that yields an updated linked fact.</param>
+    /// <returns>Right hand side expression builder.</returns>
+    IRightHandSideExpression Yield<TFact>(Expression<Func<IContext, TFact>> yieldInsert, Expression<Func<IContext, TFact, TFact>> yieldUpdate);
 }

--- a/src/NRules/NRules.Fluent/Dsl/NameAttribute.cs
+++ b/src/NRules/NRules.Fluent/Dsl/NameAttribute.cs
@@ -1,19 +1,18 @@
 ﻿using System;
 
-namespace NRules.Fluent.Dsl
-{
-    /// <summary>
-    /// Sets rule's name.
-    /// Name set via the attribute overrides the default name, which is the fully qualified class name.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    public sealed class NameAttribute : Attribute
-    {
-        public NameAttribute(string value)
-        {
-            Value = value;
-        }
+namespace NRules.Fluent.Dsl;
 
-        internal string Value { get; }
+/// <summary>
+/// Sets rule's name.
+/// Name set via the attribute overrides the default name, which is the fully qualified class name.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class NameAttribute : Attribute
+{
+    public NameAttribute(string value)
+    {
+        Value = value;
     }
+
+    internal string Value { get; }
 }

--- a/src/NRules/NRules.Fluent/Dsl/PriorityAttribute.cs
+++ b/src/NRules/NRules.Fluent/Dsl/PriorityAttribute.cs
@@ -1,21 +1,20 @@
 ﻿using System;
 
-namespace NRules.Fluent.Dsl
-{
-    /// <summary>
-    /// Sets rule's priority.
-    /// If multiple rules get activated at the same time, rules with higher priority get executed first.
-    /// Priority value can be positive, negative or zero.
-    /// Default priority is zero.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-    public sealed class PriorityAttribute : Attribute
-    {
-        public PriorityAttribute(int value)
-        {
-            Value = value;
-        }
+namespace NRules.Fluent.Dsl;
 
-        internal int Value { get; }
+/// <summary>
+/// Sets rule's priority.
+/// If multiple rules get activated at the same time, rules with higher priority get executed first.
+/// Priority value can be positive, negative or zero.
+/// Default priority is zero.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class PriorityAttribute : Attribute
+{
+    public PriorityAttribute(int value)
+    {
+        Value = value;
     }
+
+    internal int Value { get; }
 }

--- a/src/NRules/NRules.Fluent/Dsl/QueryExpression.cs
+++ b/src/NRules/NRules.Fluent/Dsl/QueryExpression.cs
@@ -1,23 +1,22 @@
-﻿namespace NRules.Fluent.Dsl
+﻿namespace NRules.Fluent.Dsl;
+
+/// <summary>
+/// Expression builder for queries.
+/// </summary>
+/// <typeparam name="TSource">Type of query source.</typeparam>
+public class QueryExpression<TSource> : IQuery<TSource>, ICollectQuery<TSource>, IOrderedQuery<TSource>
 {
     /// <summary>
-    /// Expression builder for queries.
+    /// Constructs a query expression builder that wraps a <see cref="IQueryBuilder"/>.
     /// </summary>
-    /// <typeparam name="TSource">Type of query source.</typeparam>
-    public class QueryExpression<TSource> : IQuery<TSource>, ICollectQuery<TSource>, IOrderedQuery<TSource>
+    /// <param name="builder">Query builder to wrap.</param>
+    public QueryExpression(IQueryBuilder builder)
     {
-        /// <summary>
-        /// Constructs a query expression builder that wraps a <see cref="IQueryBuilder"/>.
-        /// </summary>
-        /// <param name="builder">Query builder to wrap.</param>
-        public QueryExpression(IQueryBuilder builder)
-        {
-            Builder = builder;
-        }
-
-        /// <summary>
-        /// Wrapped <see cref="IQueryBuilder"/>.
-        /// </summary>
-        public IQueryBuilder Builder { get; }
+        Builder = builder;
     }
+
+    /// <summary>
+    /// Wrapped <see cref="IQueryBuilder"/>.
+    /// </summary>
+    public IQueryBuilder Builder { get; }
 }

--- a/src/NRules/NRules.Fluent/Dsl/QueryExtensions.cs
+++ b/src/NRules/NRules.Fluent/Dsl/QueryExtensions.cs
@@ -4,220 +4,219 @@ using System.Linq;
 using System.Linq.Expressions;
 using NRules.RuleModel;
 
-namespace NRules.Fluent.Dsl
+namespace NRules.Fluent.Dsl;
+
+public static class QueryExtensions
 {
-    public static class QueryExtensions
+    /// <summary>
+    /// Creates a query from matching facts in the engine's working memory.
+    /// </summary>
+    /// <typeparam name="TFact">Type of facts to query.</typeparam>
+    /// <param name="query">Query expression builder.</param>
+    /// <param name="conditions">Set of conditions the fact must satisfy.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IQuery<TFact> Match<TFact>(this IQuery query, params Expression<Func<TFact, bool>>[] conditions)
     {
-        /// <summary>
-        /// Creates a query from matching facts in the engine's working memory.
-        /// </summary>
-        /// <typeparam name="TFact">Type of facts to query.</typeparam>
-        /// <param name="query">Query expression builder.</param>
-        /// <param name="conditions">Set of conditions the fact must satisfy.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IQuery<TFact> Match<TFact>(this IQuery query, params Expression<Func<TFact, bool>>[] conditions)
-        {
-            query.Builder.FactQuery(conditions);
-            return new QueryExpression<TFact>(query.Builder);
-        }
+        query.Builder.FactQuery(conditions);
+        return new QueryExpression<TFact>(query.Builder);
+    }
 
-        /// <summary>
-        /// Creates a query from a given expression.
-        /// </summary>
-        /// <typeparam name="TFact">Type of facts to query.</typeparam>
-        /// <param name="query">Query expression builder.</param>
-        /// <param name="source">Expression that generates source facts.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IQuery<TFact> From<TFact>(this IQuery query, Expression<Func<TFact>> source)
-        {
-            query.Builder.From(source);
-            return new QueryExpression<TFact>(query.Builder);
-        }
+    /// <summary>
+    /// Creates a query from a given expression.
+    /// </summary>
+    /// <typeparam name="TFact">Type of facts to query.</typeparam>
+    /// <param name="query">Query expression builder.</param>
+    /// <param name="source">Expression that generates source facts.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IQuery<TFact> From<TFact>(this IQuery query, Expression<Func<TFact>> source)
+    {
+        query.Builder.From(source);
+        return new QueryExpression<TFact>(query.Builder);
+    }
 
-        /// <summary>
-        /// Filters source facts using a set of predicate expressions.
-        /// The facts must match all predicate expressions in order to pass the filter.
-        /// </summary>
-        /// <typeparam name="TSource">Type of facts to filter.</typeparam>
-        /// <param name="source">Query expression builder.</param>
-        /// <param name="predicates">Filter expressions.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IQuery<TSource> Where<TSource>(this IQuery<TSource> source, params Expression<Func<TSource, bool>>[] predicates)
-        {
-            source.Builder.Where(predicates);
-            return new QueryExpression<TSource>(source.Builder);
-        }
+    /// <summary>
+    /// Filters source facts using a set of predicate expressions.
+    /// The facts must match all predicate expressions in order to pass the filter.
+    /// </summary>
+    /// <typeparam name="TSource">Type of facts to filter.</typeparam>
+    /// <param name="source">Query expression builder.</param>
+    /// <param name="predicates">Filter expressions.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IQuery<TSource> Where<TSource>(this IQuery<TSource> source, params Expression<Func<TSource, bool>>[] predicates)
+    {
+        source.Builder.Where(predicates);
+        return new QueryExpression<TSource>(source.Builder);
+    }
 
-        /// <summary>
-        /// Projects source facts using selector expression.
-        /// </summary>
-        /// <typeparam name="TSource">Type of source facts.</typeparam>
-        /// <typeparam name="TResult">Type of projected facts.</typeparam>
-        /// <param name="source">Query expression builder.</param>
-        /// <param name="selector">Projection expression.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IQuery<TResult> Select<TSource, TResult>(this IQuery<TSource> source, Expression<Func<TSource, TResult>> selector)
-        {
-            source.Builder.Select(selector);
-            return new QueryExpression<TResult>(source.Builder);
-        }
+    /// <summary>
+    /// Projects source facts using selector expression.
+    /// </summary>
+    /// <typeparam name="TSource">Type of source facts.</typeparam>
+    /// <typeparam name="TResult">Type of projected facts.</typeparam>
+    /// <param name="source">Query expression builder.</param>
+    /// <param name="selector">Projection expression.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IQuery<TResult> Select<TSource, TResult>(this IQuery<TSource> source, Expression<Func<TSource, TResult>> selector)
+    {
+        source.Builder.Select(selector);
+        return new QueryExpression<TResult>(source.Builder);
+    }
 
-        /// <summary>
-        /// Flattens source facts using collection selector expression.
-        /// </summary>
-        /// <typeparam name="TSource">Type of source facts.</typeparam>
-        /// <typeparam name="TResult">Type of flattened facts.</typeparam>
-        /// <param name="source">Query expression builder.</param>
-        /// <param name="selector">Collection flattening expression.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IQuery<TResult> SelectMany<TSource, TResult>(this IQuery<TSource> source, Expression<Func<TSource, IEnumerable<TResult>>> selector)
-        {
-            source.Builder.SelectMany(selector);
-            return new QueryExpression<TResult>(source.Builder);
-        }
+    /// <summary>
+    /// Flattens source facts using collection selector expression.
+    /// </summary>
+    /// <typeparam name="TSource">Type of source facts.</typeparam>
+    /// <typeparam name="TResult">Type of flattened facts.</typeparam>
+    /// <param name="source">Query expression builder.</param>
+    /// <param name="selector">Collection flattening expression.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IQuery<TResult> SelectMany<TSource, TResult>(this IQuery<TSource> source, Expression<Func<TSource, IEnumerable<TResult>>> selector)
+    {
+        source.Builder.SelectMany(selector);
+        return new QueryExpression<TResult>(source.Builder);
+    }
 
-        /// <summary>
-        /// Aggregates source facts into groups based on a grouping key.
-        /// </summary>
-        /// <typeparam name="TSource">Type of source facts.</typeparam>
-        /// <typeparam name="TKey">Type of grouping key.</typeparam>
-        /// <param name="source">Query expression builder.</param>
-        /// <param name="keySelector">Grouping key selection expression.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IQuery<IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IQuery<TSource> source, Expression<Func<TSource, TKey>> keySelector)
-        {
-            source.Builder.GroupBy(keySelector, x => x);
-            return new QueryExpression<IGrouping<TKey, TSource>>(source.Builder);
-        }
+    /// <summary>
+    /// Aggregates source facts into groups based on a grouping key.
+    /// </summary>
+    /// <typeparam name="TSource">Type of source facts.</typeparam>
+    /// <typeparam name="TKey">Type of grouping key.</typeparam>
+    /// <param name="source">Query expression builder.</param>
+    /// <param name="keySelector">Grouping key selection expression.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IQuery<IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IQuery<TSource> source, Expression<Func<TSource, TKey>> keySelector)
+    {
+        source.Builder.GroupBy(keySelector, x => x);
+        return new QueryExpression<IGrouping<TKey, TSource>>(source.Builder);
+    }
 
-        /// <summary>
-        /// Aggregates source facts into groups based on a grouping key.
-        /// Projects facts as part of grouping based on a value selection expression.
-        /// </summary>
-        /// <typeparam name="TSource">Type of source facts.</typeparam>
-        /// <typeparam name="TKey">Type of grouping key.</typeparam>
-        /// <typeparam name="TElement">Type of projected facts.</typeparam>
-        /// <param name="source">Query expression builder.</param>
-        /// <param name="keySelector">Grouping key selection expression.</param>
-        /// <param name="elementSelector">Projected fact selection expression.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IQuery<IGrouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IQuery<TSource> source,
-            Expression<Func<TSource, TKey>> keySelector,
-            Expression<Func<TSource, TElement>> elementSelector)
-        {
-            source.Builder.GroupBy(keySelector, elementSelector);
-            return new QueryExpression<IGrouping<TKey, TElement>>(source.Builder);
-        }
+    /// <summary>
+    /// Aggregates source facts into groups based on a grouping key.
+    /// Projects facts as part of grouping based on a value selection expression.
+    /// </summary>
+    /// <typeparam name="TSource">Type of source facts.</typeparam>
+    /// <typeparam name="TKey">Type of grouping key.</typeparam>
+    /// <typeparam name="TElement">Type of projected facts.</typeparam>
+    /// <param name="source">Query expression builder.</param>
+    /// <param name="keySelector">Grouping key selection expression.</param>
+    /// <param name="elementSelector">Projected fact selection expression.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IQuery<IGrouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IQuery<TSource> source,
+        Expression<Func<TSource, TKey>> keySelector,
+        Expression<Func<TSource, TElement>> elementSelector)
+    {
+        source.Builder.GroupBy(keySelector, elementSelector);
+        return new QueryExpression<IGrouping<TKey, TElement>>(source.Builder);
+    }
 
-        /// <summary>
-        /// Aggregates matching facts into a collection.
-        /// </summary>
-        /// <typeparam name="TSource">Type of source facts.</typeparam>
-        /// <param name="source">Query expression builder.</param>
-        /// <returns>Query expression builder.</returns>
-        public static ICollectQuery<IEnumerable<TSource>> Collect<TSource>(this IQuery<TSource> source)
-        {
-            source.Builder.Collect<TSource>();
-            return new QueryExpression<IEnumerable<TSource>>(source.Builder);
-        }
+    /// <summary>
+    /// Aggregates matching facts into a collection.
+    /// </summary>
+    /// <typeparam name="TSource">Type of source facts.</typeparam>
+    /// <param name="source">Query expression builder.</param>
+    /// <returns>Query expression builder.</returns>
+    public static ICollectQuery<IEnumerable<TSource>> Collect<TSource>(this IQuery<TSource> source)
+    {
+        source.Builder.Collect<TSource>();
+        return new QueryExpression<IEnumerable<TSource>>(source.Builder);
+    }
 
-        /// <summary>
-        /// Configures collected matching facts to be arranged into a lookup keyed on the fact itself.
-        /// </summary>
-        /// <typeparam name="TSource">Type of source facts.</typeparam>
-        /// <param name="source">Query expression builder.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IQuery<IKeyedLookup<TSource, TSource>> ToLookup<TSource>(this ICollectQuery<IEnumerable<TSource>> source)
-        {
-            source.Builder.ToLookup<TSource, TSource, TSource>(x => x, x => x);
-            return new QueryExpression<IKeyedLookup<TSource, TSource>>(source.Builder);
-        }
+    /// <summary>
+    /// Configures collected matching facts to be arranged into a lookup keyed on the fact itself.
+    /// </summary>
+    /// <typeparam name="TSource">Type of source facts.</typeparam>
+    /// <param name="source">Query expression builder.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IQuery<IKeyedLookup<TSource, TSource>> ToLookup<TSource>(this ICollectQuery<IEnumerable<TSource>> source)
+    {
+        source.Builder.ToLookup<TSource, TSource, TSource>(x => x, x => x);
+        return new QueryExpression<IKeyedLookup<TSource, TSource>>(source.Builder);
+    }
 
-        /// <summary>
-        /// Configures collected matching facts to be arranged into a lookup based on a grouping key.
-        /// </summary>
-        /// <typeparam name="TSource">Type of source facts.</typeparam>
-        /// <typeparam name="TKey">Type of grouping key.</typeparam>
-        /// <param name="source">Query expression builder.</param>
-        /// <param name="keySelector">Grouping key selection expression.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IQuery<IKeyedLookup<TKey, TSource>> ToLookup<TSource, TKey>(this ICollectQuery<IEnumerable<TSource>> source, Expression<Func<TSource, TKey>> keySelector)
-        {
-            source.Builder.ToLookup(keySelector, x => x);
-            return new QueryExpression<IKeyedLookup<TKey, TSource>>(source.Builder);
-        }
+    /// <summary>
+    /// Configures collected matching facts to be arranged into a lookup based on a grouping key.
+    /// </summary>
+    /// <typeparam name="TSource">Type of source facts.</typeparam>
+    /// <typeparam name="TKey">Type of grouping key.</typeparam>
+    /// <param name="source">Query expression builder.</param>
+    /// <param name="keySelector">Grouping key selection expression.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IQuery<IKeyedLookup<TKey, TSource>> ToLookup<TSource, TKey>(this ICollectQuery<IEnumerable<TSource>> source, Expression<Func<TSource, TKey>> keySelector)
+    {
+        source.Builder.ToLookup(keySelector, x => x);
+        return new QueryExpression<IKeyedLookup<TKey, TSource>>(source.Builder);
+    }
 
-        /// <summary>
-        /// Configures collected matching facts to be arranged into a lookup based on a grouping key.
-        /// Projects facts collected into a lookup based on a value selection expression.
-        /// </summary>
-        /// <typeparam name="TSource">Type of source facts.</typeparam>
-        /// <typeparam name="TKey">Type of grouping key.</typeparam>
-        /// <typeparam name="TElement">Type of projected facts.</typeparam>
-        /// <param name="source">Query expression builder.</param>
-        /// <param name="keySelector">Grouping key selection expression.</param>
-        /// <param name="elementSelector">Projected fact selection expression.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IQuery<IKeyedLookup<TKey, TElement>> ToLookup<TSource, TKey, TElement>(this ICollectQuery<IEnumerable<TSource>> source, Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector)
-        {
-            source.Builder.ToLookup(keySelector, elementSelector);
-            return new QueryExpression<IKeyedLookup<TKey, TElement>>(source.Builder);
-        }
+    /// <summary>
+    /// Configures collected matching facts to be arranged into a lookup based on a grouping key.
+    /// Projects facts collected into a lookup based on a value selection expression.
+    /// </summary>
+    /// <typeparam name="TSource">Type of source facts.</typeparam>
+    /// <typeparam name="TKey">Type of grouping key.</typeparam>
+    /// <typeparam name="TElement">Type of projected facts.</typeparam>
+    /// <param name="source">Query expression builder.</param>
+    /// <param name="keySelector">Grouping key selection expression.</param>
+    /// <param name="elementSelector">Projected fact selection expression.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IQuery<IKeyedLookup<TKey, TElement>> ToLookup<TSource, TKey, TElement>(this ICollectQuery<IEnumerable<TSource>> source, Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector)
+    {
+        source.Builder.ToLookup(keySelector, elementSelector);
+        return new QueryExpression<IKeyedLookup<TKey, TElement>>(source.Builder);
+    }
 
-        /// <summary>
-        /// Configures collected matching facts to be sorted ascending by key.
-        /// </summary>
-        /// <typeparam name="TSource">Type of source facts.</typeparam>
-        /// <typeparam name="TKey">Type of sorting key.</typeparam>
-        /// <param name="source">Query expression builder.</param>
-        /// <param name="keySelector">Key selection expression used for sorting.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IOrderedQuery<IEnumerable<TSource>> OrderBy<TSource, TKey>(this ICollectQuery<IEnumerable<TSource>> source, Expression<Func<TSource, TKey>> keySelector)
-        {
-            source.Builder.OrderBy(keySelector, SortDirection.Ascending);
-            return new QueryExpression<IEnumerable<TSource>>(source.Builder);
-        }
+    /// <summary>
+    /// Configures collected matching facts to be sorted ascending by key.
+    /// </summary>
+    /// <typeparam name="TSource">Type of source facts.</typeparam>
+    /// <typeparam name="TKey">Type of sorting key.</typeparam>
+    /// <param name="source">Query expression builder.</param>
+    /// <param name="keySelector">Key selection expression used for sorting.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IOrderedQuery<IEnumerable<TSource>> OrderBy<TSource, TKey>(this ICollectQuery<IEnumerable<TSource>> source, Expression<Func<TSource, TKey>> keySelector)
+    {
+        source.Builder.OrderBy(keySelector, SortDirection.Ascending);
+        return new QueryExpression<IEnumerable<TSource>>(source.Builder);
+    }
 
-        /// <summary>
-        /// Configures collected matching facts to be sorted descending by key.
-        /// </summary>
-        /// <typeparam name="TSource">Type of source facts.</typeparam>
-        /// <typeparam name="TKey">Type of sorting key.</typeparam>
-        /// <param name="source">Query expression builder.</param>
-        /// <param name="keySelector">Key selection expression used for sorting.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IOrderedQuery<IEnumerable<TSource>> OrderByDescending<TSource, TKey>(this ICollectQuery<IEnumerable<TSource>> source, Expression<Func<TSource, TKey>> keySelector)
-        {
-            source.Builder.OrderBy(keySelector, SortDirection.Descending);
-            return new QueryExpression<IEnumerable<TSource>>(source.Builder);
-        }
+    /// <summary>
+    /// Configures collected matching facts to be sorted descending by key.
+    /// </summary>
+    /// <typeparam name="TSource">Type of source facts.</typeparam>
+    /// <typeparam name="TKey">Type of sorting key.</typeparam>
+    /// <param name="source">Query expression builder.</param>
+    /// <param name="keySelector">Key selection expression used for sorting.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IOrderedQuery<IEnumerable<TSource>> OrderByDescending<TSource, TKey>(this ICollectQuery<IEnumerable<TSource>> source, Expression<Func<TSource, TKey>> keySelector)
+    {
+        source.Builder.OrderBy(keySelector, SortDirection.Descending);
+        return new QueryExpression<IEnumerable<TSource>>(source.Builder);
+    }
 
-        /// <summary>
-        /// Configures sorted matching facts to subsequently be sorted ascending by key.
-        /// </summary>
-        /// <typeparam name="TSource">Type of source facts.</typeparam>
-        /// <typeparam name="TKey">Type of sorting key.</typeparam>
-        /// <param name="source">Query expression builder.</param>
-        /// <param name="keySelector">Key selection expression used for sorting.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IOrderedQuery<IEnumerable<TSource>> ThenBy<TSource, TKey>(this IOrderedQuery<IEnumerable<TSource>> source, Expression<Func<TSource, TKey>> keySelector)
-        {
-            source.Builder.OrderBy(keySelector, SortDirection.Ascending);
-            return new QueryExpression<IEnumerable<TSource>>(source.Builder);
-        }
+    /// <summary>
+    /// Configures sorted matching facts to subsequently be sorted ascending by key.
+    /// </summary>
+    /// <typeparam name="TSource">Type of source facts.</typeparam>
+    /// <typeparam name="TKey">Type of sorting key.</typeparam>
+    /// <param name="source">Query expression builder.</param>
+    /// <param name="keySelector">Key selection expression used for sorting.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IOrderedQuery<IEnumerable<TSource>> ThenBy<TSource, TKey>(this IOrderedQuery<IEnumerable<TSource>> source, Expression<Func<TSource, TKey>> keySelector)
+    {
+        source.Builder.OrderBy(keySelector, SortDirection.Ascending);
+        return new QueryExpression<IEnumerable<TSource>>(source.Builder);
+    }
 
-        /// <summary>
-        /// Configures sorted matching facts to subsequently be sorted descending by key.
-        /// </summary>
-        /// <typeparam name="TSource">Type of source facts.</typeparam>
-        /// <typeparam name="TKey">Type of sorting key.</typeparam>
-        /// <param name="source">Query expression builder.</param>
-        /// <param name="keySelector">Key selection expression used for sorting.</param>
-        /// <returns>Query expression builder.</returns>
-        public static IOrderedQuery<IEnumerable<TSource>> ThenByDescending<TSource, TKey>(this IOrderedQuery<IEnumerable<TSource>> source, Expression<Func<TSource, TKey>> keySelector)
-        {
-            source.Builder.OrderBy(keySelector, SortDirection.Descending);
-            return new QueryExpression<IEnumerable<TSource>>(source.Builder);
-        }
+    /// <summary>
+    /// Configures sorted matching facts to subsequently be sorted descending by key.
+    /// </summary>
+    /// <typeparam name="TSource">Type of source facts.</typeparam>
+    /// <typeparam name="TKey">Type of sorting key.</typeparam>
+    /// <param name="source">Query expression builder.</param>
+    /// <param name="keySelector">Key selection expression used for sorting.</param>
+    /// <returns>Query expression builder.</returns>
+    public static IOrderedQuery<IEnumerable<TSource>> ThenByDescending<TSource, TKey>(this IOrderedQuery<IEnumerable<TSource>> source, Expression<Func<TSource, TKey>> keySelector)
+    {
+        source.Builder.OrderBy(keySelector, SortDirection.Descending);
+        return new QueryExpression<IEnumerable<TSource>>(source.Builder);
     }
 }

--- a/src/NRules/NRules.Fluent/Dsl/RepeatabilityAttribute.cs
+++ b/src/NRules/NRules.Fluent/Dsl/RepeatabilityAttribute.cs
@@ -1,23 +1,22 @@
 ﻿using System;
 using NRules.RuleModel;
 
-namespace NRules.Fluent.Dsl
-{
-    /// <summary>
-    /// Sets rule's repeatability, that is, how it behaves when it is activated with the same set of facts multiple times, 
-    /// which is important for recursion control. By default rules are <see cref="RuleRepeatability.Repeatable"/>, 
-    /// which means a rule will fire every time it is activated with the same set of facts.
-    /// If repeatability is set to <see cref="RuleRepeatability.NonRepeatable"/> then the rule will not fire with the same combination of facts, 
-    /// unless that combination was previously deactivated (i.e. through retraction).
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    public sealed class RepeatabilityAttribute : Attribute
-    {
-        public RepeatabilityAttribute(RuleRepeatability value)
-        {
-            Value = value;
-        }
+namespace NRules.Fluent.Dsl;
 
-        internal RuleRepeatability Value { get; }
+/// <summary>
+/// Sets rule's repeatability, that is, how it behaves when it is activated with the same set of facts multiple times, 
+/// which is important for recursion control. By default rules are <see cref="RuleRepeatability.Repeatable"/>, 
+/// which means a rule will fire every time it is activated with the same set of facts.
+/// If repeatability is set to <see cref="RuleRepeatability.NonRepeatable"/> then the rule will not fire with the same combination of facts, 
+/// unless that combination was previously deactivated (i.e. through retraction).
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class RepeatabilityAttribute : Attribute
+{
+    public RepeatabilityAttribute(RuleRepeatability value)
+    {
+        Value = value;
     }
+
+    internal RuleRepeatability Value { get; }
 }

--- a/src/NRules/NRules.Fluent/Dsl/Rule.cs
+++ b/src/NRules/NRules.Fluent/Dsl/Rule.cs
@@ -3,125 +3,124 @@ using NRules.Fluent.Expressions;
 using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 
-namespace NRules.Fluent.Dsl
+namespace NRules.Fluent.Dsl;
+
+/// <summary>
+/// Base class for inline rule definitions.
+/// To create a rule using internal DSL, create a class that inherits from <c>NRules.Fluent.Dsl.Rule</c>
+/// and override <see cref="Define"/> method.
+/// Use <see cref="When"/> and <see cref="Then"/> methods to define rule's conditions and actions correspondingly.
+/// A rule can also be decorated with attributes to add relevant metadata:
+/// <see cref="NameAttribute"/>, <see cref="DescriptionAttribute"/>, <see cref="TagAttribute"/>, 
+/// <see cref="PriorityAttribute"/>, <see cref="RepeatabilityAttribute"/>.
+/// </summary>
+public abstract class Rule
 {
-    /// <summary>
-    /// Base class for inline rule definitions.
-    /// To create a rule using internal DSL, create a class that inherits from <c>NRules.Fluent.Dsl.Rule</c>
-    /// and override <see cref="Define"/> method.
-    /// Use <see cref="When"/> and <see cref="Then"/> methods to define rule's conditions and actions correspondingly.
-    /// A rule can also be decorated with attributes to add relevant metadata:
-    /// <see cref="NameAttribute"/>, <see cref="DescriptionAttribute"/>, <see cref="TagAttribute"/>, 
-    /// <see cref="PriorityAttribute"/>, <see cref="RepeatabilityAttribute"/>.
-    /// </summary>
-    public abstract class Rule
+    private readonly Lazy<IRuleDefinition> _definition;
+    private readonly RuleBuilder _builder;
+    private readonly SymbolStack _symbolStack;
+
+    protected Rule()
     {
-        private readonly Lazy<IRuleDefinition> _definition;
-        private readonly RuleBuilder _builder;
-        private readonly SymbolStack _symbolStack;
+        _builder = new RuleBuilder();
+        _symbolStack = new SymbolStack();
+        _definition = new Lazy<IRuleDefinition>(BuildDefinition);
+    }
 
-        protected Rule()
+    /// <summary>
+    /// Sets rule's name.
+    /// Name value set at this level overrides the values specified via <see cref="NameAttribute"/> attribute.
+    /// </summary>
+    /// <param name="value">Rule name value.</param>
+    protected void Name(string value)
+    {
+        _builder.Name(value);
+    }
+
+    /// <summary>
+    /// Sets rule's priority.
+    /// Priority value set at this level overrides the value specified via <see cref="PriorityAttribute"/> attribute.
+    /// </summary>
+    /// <param name="value">Priority value.</param>
+    protected void Priority(int value)
+    {
+        _builder.Priority(value);
+    }
+
+    /// <summary>
+    /// Returns expression builder for rule's dependencies.
+    /// </summary>
+    /// <returns>Dependencies expression builder.</returns>
+    protected IDependencyExpression Dependency()
+    {
+        var builder = _builder.Dependencies();
+        var expression = new DependencyExpression(builder, _symbolStack);
+        return expression;
+    }
+
+    /// <summary>
+    /// Returns expression builder for rule's filters.
+    /// </summary>
+    /// <returns>Filters expression builder.</returns>
+    protected IFilterExpression Filter()
+    {
+        var builder = _builder.Filters();
+        var expression = new FilterExpression(builder, _symbolStack);
+        return expression;
+    }
+
+    /// <summary>
+    /// Returns expression builder for rule's left-hand side (conditions).
+    /// </summary>
+    /// <returns>Left hand side expression builder.</returns>
+    protected ILeftHandSideExpression When()
+    {
+        var builder = _builder.LeftHandSide();
+        var expression = new LeftHandSideExpression(builder, _symbolStack);
+        return expression;
+    }
+
+    /// <summary>
+    /// Returns expression builder for rule's right-hand side (actions).
+    /// </summary>
+    /// <returns>Right hand side expression builder.</returns>
+    protected IRightHandSideExpression Then()
+    {
+        var builder = _builder.RightHandSide();
+        var expression = new RightHandSideExpression(builder, _symbolStack);
+        return expression;
+    }
+
+    /// <summary>
+    /// Method called by the rules engine to define the rule.
+    /// </summary>
+    public abstract void Define();
+
+    internal IRuleDefinition GetDefinition()
+    {
+        return _definition.Value;
+    }
+
+    private IRuleDefinition BuildDefinition()
+    {
+        var ruleType = GetType();
+        var metadata = new RuleMetadata(ruleType);
+        _builder.Name(metadata.Name);
+        _builder.Description(metadata.Description);
+        _builder.Tags(metadata.Tags);
+        _builder.Property(RuleProperties.ClrType, ruleType);
+
+        if (metadata.Priority.HasValue)
         {
-            _builder = new RuleBuilder();
-            _symbolStack = new SymbolStack();
-            _definition = new Lazy<IRuleDefinition>(BuildDefinition);
+            _builder.Priority(metadata.Priority.Value);
+        }
+        if (metadata.Repeatability.HasValue)
+        {
+            _builder.Repeatability(metadata.Repeatability.Value);
         }
 
-        /// <summary>
-        /// Sets rule's name.
-        /// Name value set at this level overrides the values specified via <see cref="NameAttribute"/> attribute.
-        /// </summary>
-        /// <param name="value">Rule name value.</param>
-        protected void Name(string value)
-        {
-            _builder.Name(value);
-        }
+        Define();
 
-        /// <summary>
-        /// Sets rule's priority.
-        /// Priority value set at this level overrides the value specified via <see cref="PriorityAttribute"/> attribute.
-        /// </summary>
-        /// <param name="value">Priority value.</param>
-        protected void Priority(int value)
-        {
-            _builder.Priority(value);
-        }
-
-        /// <summary>
-        /// Returns expression builder for rule's dependencies.
-        /// </summary>
-        /// <returns>Dependencies expression builder.</returns>
-        protected IDependencyExpression Dependency()
-        {
-            var builder = _builder.Dependencies();
-            var expression = new DependencyExpression(builder, _symbolStack);
-            return expression;
-        }
-
-        /// <summary>
-        /// Returns expression builder for rule's filters.
-        /// </summary>
-        /// <returns>Filters expression builder.</returns>
-        protected IFilterExpression Filter()
-        {
-            var builder = _builder.Filters();
-            var expression = new FilterExpression(builder, _symbolStack);
-            return expression;
-        }
-
-        /// <summary>
-        /// Returns expression builder for rule's left-hand side (conditions).
-        /// </summary>
-        /// <returns>Left hand side expression builder.</returns>
-        protected ILeftHandSideExpression When()
-        {
-            var builder = _builder.LeftHandSide();
-            var expression = new LeftHandSideExpression(builder, _symbolStack);
-            return expression;
-        }
-
-        /// <summary>
-        /// Returns expression builder for rule's right-hand side (actions).
-        /// </summary>
-        /// <returns>Right hand side expression builder.</returns>
-        protected IRightHandSideExpression Then()
-        {
-            var builder = _builder.RightHandSide();
-            var expression = new RightHandSideExpression(builder, _symbolStack);
-            return expression;
-        }
-
-        /// <summary>
-        /// Method called by the rules engine to define the rule.
-        /// </summary>
-        public abstract void Define();
-
-        internal IRuleDefinition GetDefinition()
-        {
-            return _definition.Value;
-        }
-
-        private IRuleDefinition BuildDefinition()
-        {
-            var ruleType = GetType();
-            var metadata = new RuleMetadata(ruleType);
-            _builder.Name(metadata.Name);
-            _builder.Description(metadata.Description);
-            _builder.Tags(metadata.Tags);
-            _builder.Property(RuleProperties.ClrType, ruleType);
-
-            if (metadata.Priority.HasValue)
-            {
-                _builder.Priority(metadata.Priority.Value);
-            }
-            if (metadata.Repeatability.HasValue)
-            {
-                _builder.Repeatability(metadata.Repeatability.Value);
-            }
-
-            Define();
-
-            return _builder.Build();
-        }
+        return _builder.Build();
     }
 }

--- a/src/NRules/NRules.Fluent/Dsl/TagAttribute.cs
+++ b/src/NRules/NRules.Fluent/Dsl/TagAttribute.cs
@@ -1,23 +1,22 @@
 using System;
 
-namespace NRules.Fluent.Dsl
-{
-    /// <summary>
-    /// Adds a tag to rule's metadata.
-    /// A rule class can have multiple tag attributes, and also inherits tag attributes from its parent classes.
-    /// Tags can be used to filter rules when loading them through fluent load specification.
-    /// </summary>
-    /// <remarks>
-    /// A custom tag attribute class could be inherited from the <see cref="TagAttribute"/> to provide strongly-typed version of a tag.
-    /// </remarks>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-    public class TagAttribute : Attribute
-    {
-        public TagAttribute(string value)
-        {
-            Value = value;
-        }
+namespace NRules.Fluent.Dsl;
 
-        internal string Value { get; }
+/// <summary>
+/// Adds a tag to rule's metadata.
+/// A rule class can have multiple tag attributes, and also inherits tag attributes from its parent classes.
+/// Tags can be used to filter rules when loading them through fluent load specification.
+/// </summary>
+/// <remarks>
+/// A custom tag attribute class could be inherited from the <see cref="TagAttribute"/> to provide strongly-typed version of a tag.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public class TagAttribute : Attribute
+{
+    public TagAttribute(string value)
+    {
+        Value = value;
     }
+
+    internal string Value { get; }
 }

--- a/src/NRules/NRules.Fluent/EnumerableExtensions.cs
+++ b/src/NRules/NRules.Fluent/EnumerableExtensions.cs
@@ -2,19 +2,18 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace NRules.Fluent
+namespace NRules.Fluent;
+
+internal static class EnumerableExtensions
 {
-    internal static class EnumerableExtensions
+    public static TValue? SingleNullable<T, TValue>(this IEnumerable<T> sequence, Func<T, TValue> projection)
+        where T : Attribute where TValue : struct
     {
-        public static TValue? SingleNullable<T, TValue>(this IEnumerable<T> sequence, Func<T, TValue> projection)
-            where T : Attribute where TValue : struct
+        T element = sequence.SingleOrDefault();
+        if (element == null)
         {
-            T element = sequence.SingleOrDefault();
-            if (element == null)
-            {
-                return null;
-            }
-            return projection(element);
+            return null;
         }
+        return projection(element);
     }
 }

--- a/src/NRules/NRules.Fluent/Expressions/BuilderExtensions.cs
+++ b/src/NRules/NRules.Fluent/Expressions/BuilderExtensions.cs
@@ -4,56 +4,55 @@ using System.Linq.Expressions;
 using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 
-namespace NRules.Fluent.Expressions
+namespace NRules.Fluent.Expressions;
+
+internal static class BuilderExtensions
 {
-    internal static class BuilderExtensions
+    public static void DslConditions<TFact>(this PatternBuilder builder, IEnumerable<Declaration> declarations, params Expression<Func<TFact, bool>>[] conditions)
     {
-        public static void DslConditions<TFact>(this PatternBuilder builder, IEnumerable<Declaration> declarations, params Expression<Func<TFact, bool>>[] conditions)
+        var rewriter = new PatternExpressionRewriter(builder.Declaration, declarations);
+        foreach (var condition in conditions)
         {
-            var rewriter = new PatternExpressionRewriter(builder.Declaration, declarations);
-            foreach (var condition in conditions)
-            {
-                var rewrittenCondition = rewriter.Rewrite(condition);
-                builder.Condition(rewrittenCondition);
-            }
+            var rewrittenCondition = rewriter.Rewrite(condition);
+            builder.Condition(rewrittenCondition);
         }
+    }
 
-        public static void DslConditions(this PatternBuilder builder, IEnumerable<Declaration> declarations, params Expression<Func<bool>>[] conditions)
+    public static void DslConditions(this PatternBuilder builder, IEnumerable<Declaration> declarations, params Expression<Func<bool>>[] conditions)
+    {
+        var rewriter = new ExpressionRewriter(declarations);
+        foreach (var condition in conditions)
         {
-            var rewriter = new ExpressionRewriter(declarations);
-            foreach (var condition in conditions)
-            {
-                var rewrittenCondition = rewriter.Rewrite(condition);
-                builder.Condition(rewrittenCondition);
-            }
+            var rewrittenCondition = rewriter.Rewrite(condition);
+            builder.Condition(rewrittenCondition);
         }
+    }
 
-        public static void DslBindingExpression(this BindingBuilder builder, IEnumerable<Declaration> declarations, LambdaExpression expression)
-        {
-            var rewriter = new ExpressionRewriter(declarations);
-            var rewrittenExpression = rewriter.Rewrite(expression);
-            builder.BindingExpression(rewrittenExpression);
-        }
+    public static void DslBindingExpression(this BindingBuilder builder, IEnumerable<Declaration> declarations, LambdaExpression expression)
+    {
+        var rewriter = new ExpressionRewriter(declarations);
+        var rewrittenExpression = rewriter.Rewrite(expression);
+        builder.BindingExpression(rewrittenExpression);
+    }
 
-        public static void DslAction(this ActionGroupBuilder builder, IEnumerable<Declaration> declarations, Expression<Action<IContext>> action, ActionTrigger actionTrigger)
-        {
-            var rewriter = new ExpressionRewriter(declarations);
-            var rewrittenAction = rewriter.Rewrite(action);
-            builder.Action(rewrittenAction, actionTrigger);
-        }
+    public static void DslAction(this ActionGroupBuilder builder, IEnumerable<Declaration> declarations, Expression<Action<IContext>> action, ActionTrigger actionTrigger)
+    {
+        var rewriter = new ExpressionRewriter(declarations);
+        var rewrittenAction = rewriter.Rewrite(action);
+        builder.Action(rewrittenAction, actionTrigger);
+    }
 
-        public static LambdaExpression DslPatternExpression(this PatternBuilder builder, IEnumerable<Declaration> declarations, LambdaExpression expression)
-        {
-            var rewriter = new PatternExpressionRewriter(builder.Declaration, declarations);
-            var rewrittenExpression = rewriter.Rewrite(expression);
-            return rewrittenExpression;
-        }
+    public static LambdaExpression DslPatternExpression(this PatternBuilder builder, IEnumerable<Declaration> declarations, LambdaExpression expression)
+    {
+        var rewriter = new PatternExpressionRewriter(builder.Declaration, declarations);
+        var rewrittenExpression = rewriter.Rewrite(expression);
+        return rewrittenExpression;
+    }
 
-        public static LambdaExpression DslExpression(this LambdaExpression expression, IEnumerable<Declaration> declarations)
-        {
-            var rewriter = new ExpressionRewriter(declarations);
-            var rewrittenExpression = rewriter.Rewrite(expression);
-            return rewrittenExpression;
-        }
+    public static LambdaExpression DslExpression(this LambdaExpression expression, IEnumerable<Declaration> declarations)
+    {
+        var rewriter = new ExpressionRewriter(declarations);
+        var rewrittenExpression = rewriter.Rewrite(expression);
+        return rewrittenExpression;
     }
 }

--- a/src/NRules/NRules.Fluent/Expressions/DependencyExpression.cs
+++ b/src/NRules/NRules.Fluent/Expressions/DependencyExpression.cs
@@ -3,25 +3,24 @@ using System.Linq.Expressions;
 using NRules.Fluent.Dsl;
 using NRules.RuleModel.Builders;
 
-namespace NRules.Fluent.Expressions
+namespace NRules.Fluent.Expressions;
+
+internal class DependencyExpression : IDependencyExpression
 {
-    internal class DependencyExpression : IDependencyExpression
+    private readonly DependencyGroupBuilder _builder;
+    private readonly SymbolStack _symbolStack;
+
+    public DependencyExpression(DependencyGroupBuilder builder, SymbolStack symbolStack)
     {
-        private readonly DependencyGroupBuilder _builder;
-        private readonly SymbolStack _symbolStack;
+        _builder = builder;
+        _symbolStack = symbolStack;
+    }
 
-        public DependencyExpression(DependencyGroupBuilder builder, SymbolStack symbolStack)
-        {
-            _builder = builder;
-            _symbolStack = symbolStack;
-        }
-
-        public IDependencyExpression Resolve<TDependency>(Expression<Func<TDependency>> alias)
-        {
-            var symbol = alias.ToParameterExpression();
-            var declaration = _builder.Dependency(symbol.Type, symbol.Name);
-            _symbolStack.Scope.Add(declaration);
-            return this;
-        }
+    public IDependencyExpression Resolve<TDependency>(Expression<Func<TDependency>> alias)
+    {
+        var symbol = alias.ToParameterExpression();
+        var declaration = _builder.Dependency(symbol.Type, symbol.Name);
+        _symbolStack.Scope.Add(declaration);
+        return this;
     }
 }

--- a/src/NRules/NRules.Fluent/Expressions/ExpressionExtensions.cs
+++ b/src/NRules/NRules.Fluent/Expressions/ExpressionExtensions.cs
@@ -1,21 +1,20 @@
 ﻿using System;
 using System.Linq.Expressions;
 
-namespace NRules.Fluent.Expressions
-{
-    internal static class ExpressionExtensions
-    {
-        public static ParameterExpression ToParameterExpression<T>(this Expression<Func<T>> alias)
-        {
-            if (alias == null)
-                throw new ArgumentNullException(nameof(alias), "Pattern alias is null");
+namespace NRules.Fluent.Expressions;
 
-            if (!(alias.Body is MemberExpression fieldMember))
-            {
-                throw new ArgumentException(
-                    $"Invalid pattern alias expression. Expected={typeof(MemberExpression)}, Actual={alias.Body.GetType()}");
-            }
-            return Expression.Parameter(fieldMember.Type, fieldMember.Member.Name);
+internal static class ExpressionExtensions
+{
+    public static ParameterExpression ToParameterExpression<T>(this Expression<Func<T>> alias)
+    {
+        if (alias == null)
+            throw new ArgumentNullException(nameof(alias), "Pattern alias is null");
+
+        if (!(alias.Body is MemberExpression fieldMember))
+        {
+            throw new ArgumentException(
+                $"Invalid pattern alias expression. Expected={typeof(MemberExpression)}, Actual={alias.Body.GetType()}");
         }
+        return Expression.Parameter(fieldMember.Type, fieldMember.Member.Name);
     }
 }

--- a/src/NRules/NRules.Fluent/Expressions/ExpressionRewriter.cs
+++ b/src/NRules/NRules.Fluent/Expressions/ExpressionRewriter.cs
@@ -4,52 +4,51 @@ using System.Linq;
 using System.Linq.Expressions;
 using NRules.RuleModel;
 
-namespace NRules.Fluent.Expressions
+namespace NRules.Fluent.Expressions;
+
+internal class ExpressionRewriter : ExpressionVisitor
 {
-    internal class ExpressionRewriter : ExpressionVisitor
+    private IDictionary<string, Declaration> Declarations { get; }
+    protected List<ParameterExpression> Parameters { get; }
+
+    public ExpressionRewriter(IEnumerable<Declaration> declarations)
     {
-        private IDictionary<string, Declaration> Declarations { get; }
-        protected List<ParameterExpression> Parameters { get; }
+        Declarations = declarations.ToDictionary(d => d.Name);
+        Parameters = new List<ParameterExpression>();
+    }
 
-        public ExpressionRewriter(IEnumerable<Declaration> declarations)
-        {
-            Declarations = declarations.ToDictionary(d => d.Name);
-            Parameters = new List<ParameterExpression>();
-        }
+    public LambdaExpression Rewrite(LambdaExpression expression)
+    {
+        Parameters.Clear();
+        InitParameters(expression);
+        Expression body = Visit(expression.Body);
+        return Expression.Lambda(body, expression.TailCall, Parameters);
+    }
 
-        public LambdaExpression Rewrite(LambdaExpression expression)
-        {
-            Parameters.Clear();
-            InitParameters(expression);
-            Expression body = Visit(expression.Body);
-            return Expression.Lambda(body, expression.TailCall, Parameters);
-        }
+    protected virtual void InitParameters(LambdaExpression expression)
+    {
+        Parameters.Clear();
+        Parameters.AddRange(expression.Parameters);
+    }
 
-        protected virtual void InitParameters(LambdaExpression expression)
+    protected override Expression VisitMember(MemberExpression member)
+    {
+        if (Declarations.TryGetValue(member.Member.Name, out var declaration))
         {
-            Parameters.Clear();
-            Parameters.AddRange(expression.Parameters);
-        }
-
-        protected override Expression VisitMember(MemberExpression member)
-        {
-            if (Declarations.TryGetValue(member.Member.Name, out var declaration))
+            ParameterExpression parameter = Parameters.FirstOrDefault(p => p.Name == declaration.Name);
+            if (parameter == null)
             {
-                ParameterExpression parameter = Parameters.FirstOrDefault(p => p.Name == declaration.Name);
-                if (parameter == null)
-                {
-                    parameter = declaration.ToParameterExpression();
-                    Parameters.Add(parameter);
-                }
-                else if (parameter.Type != declaration.Type)
-                {
-                    throw new ArgumentException(
-                        $"Expression parameter type mismatch. Name={declaration.Name}, ExpectedType={declaration.Type}, FoundType={parameter.Type}");
-                }
-                return parameter;
+                parameter = declaration.ToParameterExpression();
+                Parameters.Add(parameter);
             }
-
-            return base.VisitMember(member);
+            else if (parameter.Type != declaration.Type)
+            {
+                throw new ArgumentException(
+                    $"Expression parameter type mismatch. Name={declaration.Name}, ExpectedType={declaration.Type}, FoundType={parameter.Type}");
+            }
+            return parameter;
         }
+
+        return base.VisitMember(member);
     }
 }

--- a/src/NRules/NRules.Fluent/Expressions/FilterExpression.cs
+++ b/src/NRules/NRules.Fluent/Expressions/FilterExpression.cs
@@ -4,37 +4,36 @@ using NRules.Fluent.Dsl;
 using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 
-namespace NRules.Fluent.Expressions
+namespace NRules.Fluent.Expressions;
+
+internal class FilterExpression : IFilterExpression
 {
-    internal class FilterExpression : IFilterExpression
+    private readonly FilterGroupBuilder _builder;
+    private readonly SymbolStack _symbolStack;
+
+    public FilterExpression(FilterGroupBuilder builder, SymbolStack symbolStack)
     {
-        private readonly FilterGroupBuilder _builder;
-        private readonly SymbolStack _symbolStack;
+        _builder = builder;
+        _symbolStack = symbolStack;
+    }
 
-        public FilterExpression(FilterGroupBuilder builder, SymbolStack symbolStack)
+    public IFilterExpression OnChange(params Expression<Func<object>>[] keySelectors)
+    {
+        foreach (var keySelector in keySelectors)
         {
-            _builder = builder;
-            _symbolStack = symbolStack;
+            var expression = keySelector.DslExpression(_symbolStack.Scope.Declarations);
+            _builder.Filter(FilterType.KeyChange, expression);
         }
+        return this;
+    }
 
-        public IFilterExpression OnChange(params Expression<Func<object>>[] keySelectors)
+    public IFilterExpression Where(params Expression<Func<bool>>[] predicates)
+    {
+        foreach (var predicate in predicates)
         {
-            foreach (var keySelector in keySelectors)
-            {
-                var expression = keySelector.DslExpression(_symbolStack.Scope.Declarations);
-                _builder.Filter(FilterType.KeyChange, expression);
-            }
-            return this;
+            var expression = predicate.DslExpression(_symbolStack.Scope.Declarations);
+            _builder.Filter(FilterType.Predicate, expression);
         }
-
-        public IFilterExpression Where(params Expression<Func<bool>>[] predicates)
-        {
-            foreach (var predicate in predicates)
-            {
-                var expression = predicate.DslExpression(_symbolStack.Scope.Declarations);
-                _builder.Filter(FilterType.Predicate, expression);
-            }
-            return this;
-        }
+        return this;
     }
 }

--- a/src/NRules/NRules.Fluent/Expressions/LeftHandSideExpression.cs
+++ b/src/NRules/NRules.Fluent/Expressions/LeftHandSideExpression.cs
@@ -3,120 +3,119 @@ using System.Linq.Expressions;
 using NRules.Fluent.Dsl;
 using NRules.RuleModel.Builders;
 
-namespace NRules.Fluent.Expressions
+namespace NRules.Fluent.Expressions;
+
+internal class LeftHandSideExpression : ILeftHandSideExpression
 {
-    internal class LeftHandSideExpression : ILeftHandSideExpression
+    private readonly GroupBuilder _builder;
+    private readonly SymbolStack _symbolStack;
+    private PatternBuilder _currentPatternBuilder;
+
+    public LeftHandSideExpression(GroupBuilder builder, SymbolStack symbolStack)
     {
-        private readonly GroupBuilder _builder;
-        private readonly SymbolStack _symbolStack;
-        private PatternBuilder _currentPatternBuilder;
+        _builder = builder;
+        _symbolStack = symbolStack;
+    }
 
-        public LeftHandSideExpression(GroupBuilder builder, SymbolStack symbolStack)
+    public ILeftHandSideExpression Match<TFact>(Expression<Func<TFact>> alias, params Expression<Func<TFact, bool>>[] conditions)
+    {
+        var symbol = alias.ToParameterExpression();
+        var patternBuilder = _builder.Pattern(symbol.Type, symbol.Name);
+        patternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
+        _symbolStack.Scope.Add(patternBuilder.Declaration);
+        _currentPatternBuilder = patternBuilder;
+        return this;
+    }
+
+    public ILeftHandSideExpression Match<TFact>(params Expression<Func<TFact, bool>>[] conditions)
+    {
+        var symbol = Expression.Parameter(typeof (TFact));
+        var patternBuilder = _builder.Pattern(symbol.Type, symbol.Name);
+        patternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
+        _symbolStack.Scope.Add(patternBuilder.Declaration);
+        _currentPatternBuilder = patternBuilder;
+        return this;
+    }
+
+    public ILeftHandSideExpression Exists<TFact>(params Expression<Func<TFact, bool>>[] conditions)
+    {
+        var existsBuilder = _builder.Exists();
+        var patternBuilder = existsBuilder.Pattern(typeof(TFact));
+        patternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
+        return this;
+    }
+
+    public ILeftHandSideExpression Not<TFact>(params Expression<Func<TFact, bool>>[] conditions)
+    {
+        var notBuilder = _builder.Not();
+        var patternBuilder = notBuilder.Pattern(typeof(TFact));
+        patternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
+        return this;
+    }
+
+    public ILeftHandSideExpression All<TFact>(Expression<Func<TFact, bool>> condition)
+    {
+        return ForAll(x => true, condition);
+    }
+
+    public ILeftHandSideExpression All<TFact>(Expression<Func<TFact, bool>> baseCondition, params Expression<Func<TFact, bool>>[] conditions)
+    {
+        return ForAll(baseCondition, conditions);
+    }
+
+    private ILeftHandSideExpression ForAll<TFact>(Expression<Func<TFact, bool>> baseCondition, params Expression<Func<TFact, bool>>[] conditions)
+    {
+        var forallBuilder = _builder.ForAll();
+
+        var basePatternBuilder = forallBuilder.BasePattern(typeof(TFact));
+        basePatternBuilder.DslConditions(_symbolStack.Scope.Declarations, baseCondition);
+
+        var patternBuilder = forallBuilder.Pattern(typeof(TFact));
+        patternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
+        return this;
+    }
+
+    public ILeftHandSideExpression Query<TResult>(Expression<Func<TResult>> alias, Func<IQuery, IQuery<TResult>> queryAction)
+    {
+        var symbol = alias.ToParameterExpression();
+        var queryBuilder = new QueryExpression(symbol, _symbolStack, _builder);
+        queryAction(queryBuilder);
+        _currentPatternBuilder = queryBuilder.Build();
+        return this;
+    }
+
+    public ILeftHandSideExpression And(Action<ILeftHandSideExpression> builderAction)
+    {
+        var expressionBuilder = new LeftHandSideExpression(_builder.Group(GroupType.And), _symbolStack);
+        builderAction(expressionBuilder);
+        return this;
+    }
+
+    public ILeftHandSideExpression Or(Action<ILeftHandSideExpression> builderAction)
+    {
+        var expressionBuilder = new LeftHandSideExpression(_builder.Group(GroupType.Or), _symbolStack);
+        builderAction(expressionBuilder);
+        return this;
+    }
+
+    public ILeftHandSideExpression Let<TResult>(Expression<Func<TResult>> alias, Expression<Func<TResult>> expression)
+    {
+        var symbol = alias.ToParameterExpression();
+        var patternBuilder = _builder.Pattern(symbol.Type, symbol.Name);
+        var bindingBuilder = patternBuilder.Binding();
+        bindingBuilder.DslBindingExpression(_symbolStack.Scope.Declarations, expression);
+        _symbolStack.Scope.Add(patternBuilder.Declaration);
+        _currentPatternBuilder = patternBuilder;
+        return this;
+    }
+
+    public ILeftHandSideExpression Having(params Expression<Func<bool>>[] conditions)
+    {
+        if (_currentPatternBuilder == null)
         {
-            _builder = builder;
-            _symbolStack = symbolStack;
+            throw new ArgumentException("HAVING clause can only be used on existing rule patterns");
         }
-
-        public ILeftHandSideExpression Match<TFact>(Expression<Func<TFact>> alias, params Expression<Func<TFact, bool>>[] conditions)
-        {
-            var symbol = alias.ToParameterExpression();
-            var patternBuilder = _builder.Pattern(symbol.Type, symbol.Name);
-            patternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
-            _symbolStack.Scope.Add(patternBuilder.Declaration);
-            _currentPatternBuilder = patternBuilder;
-            return this;
-        }
-
-        public ILeftHandSideExpression Match<TFact>(params Expression<Func<TFact, bool>>[] conditions)
-        {
-            var symbol = Expression.Parameter(typeof (TFact));
-            var patternBuilder = _builder.Pattern(symbol.Type, symbol.Name);
-            patternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
-            _symbolStack.Scope.Add(patternBuilder.Declaration);
-            _currentPatternBuilder = patternBuilder;
-            return this;
-        }
-
-        public ILeftHandSideExpression Exists<TFact>(params Expression<Func<TFact, bool>>[] conditions)
-        {
-            var existsBuilder = _builder.Exists();
-            var patternBuilder = existsBuilder.Pattern(typeof(TFact));
-            patternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
-            return this;
-        }
-
-        public ILeftHandSideExpression Not<TFact>(params Expression<Func<TFact, bool>>[] conditions)
-        {
-            var notBuilder = _builder.Not();
-            var patternBuilder = notBuilder.Pattern(typeof(TFact));
-            patternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
-            return this;
-        }
-
-        public ILeftHandSideExpression All<TFact>(Expression<Func<TFact, bool>> condition)
-        {
-            return ForAll(x => true, condition);
-        }
-
-        public ILeftHandSideExpression All<TFact>(Expression<Func<TFact, bool>> baseCondition, params Expression<Func<TFact, bool>>[] conditions)
-        {
-            return ForAll(baseCondition, conditions);
-        }
-
-        private ILeftHandSideExpression ForAll<TFact>(Expression<Func<TFact, bool>> baseCondition, params Expression<Func<TFact, bool>>[] conditions)
-        {
-            var forallBuilder = _builder.ForAll();
-
-            var basePatternBuilder = forallBuilder.BasePattern(typeof(TFact));
-            basePatternBuilder.DslConditions(_symbolStack.Scope.Declarations, baseCondition);
-
-            var patternBuilder = forallBuilder.Pattern(typeof(TFact));
-            patternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
-            return this;
-        }
-
-        public ILeftHandSideExpression Query<TResult>(Expression<Func<TResult>> alias, Func<IQuery, IQuery<TResult>> queryAction)
-        {
-            var symbol = alias.ToParameterExpression();
-            var queryBuilder = new QueryExpression(symbol, _symbolStack, _builder);
-            queryAction(queryBuilder);
-            _currentPatternBuilder = queryBuilder.Build();
-            return this;
-        }
-
-        public ILeftHandSideExpression And(Action<ILeftHandSideExpression> builderAction)
-        {
-            var expressionBuilder = new LeftHandSideExpression(_builder.Group(GroupType.And), _symbolStack);
-            builderAction(expressionBuilder);
-            return this;
-        }
-
-        public ILeftHandSideExpression Or(Action<ILeftHandSideExpression> builderAction)
-        {
-            var expressionBuilder = new LeftHandSideExpression(_builder.Group(GroupType.Or), _symbolStack);
-            builderAction(expressionBuilder);
-            return this;
-        }
-
-        public ILeftHandSideExpression Let<TResult>(Expression<Func<TResult>> alias, Expression<Func<TResult>> expression)
-        {
-            var symbol = alias.ToParameterExpression();
-            var patternBuilder = _builder.Pattern(symbol.Type, symbol.Name);
-            var bindingBuilder = patternBuilder.Binding();
-            bindingBuilder.DslBindingExpression(_symbolStack.Scope.Declarations, expression);
-            _symbolStack.Scope.Add(patternBuilder.Declaration);
-            _currentPatternBuilder = patternBuilder;
-            return this;
-        }
-
-        public ILeftHandSideExpression Having(params Expression<Func<bool>>[] conditions)
-        {
-            if (_currentPatternBuilder == null)
-            {
-                throw new ArgumentException("HAVING clause can only be used on existing rule patterns");
-            }
-            _currentPatternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
-            return this;
-        }
+        _currentPatternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
+        return this;
     }
 }

--- a/src/NRules/NRules.Fluent/Expressions/PatternExpressionRewriter.cs
+++ b/src/NRules/NRules.Fluent/Expressions/PatternExpressionRewriter.cs
@@ -3,34 +3,33 @@ using System.Linq;
 using System.Linq.Expressions;
 using NRules.RuleModel;
 
-namespace NRules.Fluent.Expressions
+namespace NRules.Fluent.Expressions;
+
+internal class PatternExpressionRewriter : ExpressionRewriter
 {
-    internal class PatternExpressionRewriter : ExpressionRewriter
+    private readonly Declaration _patternDeclaration;
+    private ParameterExpression _originalParameter;
+    private ParameterExpression _normalizedParameter;
+
+    public PatternExpressionRewriter(Declaration patternDeclaration, IEnumerable<Declaration> declarations)
+        : base(declarations)
     {
-        private readonly Declaration _patternDeclaration;
-        private ParameterExpression _originalParameter;
-        private ParameterExpression _normalizedParameter;
+        _patternDeclaration = patternDeclaration;
+    }
 
-        public PatternExpressionRewriter(Declaration patternDeclaration, IEnumerable<Declaration> declarations)
-            : base(declarations)
-        {
-            _patternDeclaration = patternDeclaration;
-        }
+    protected override void InitParameters(LambdaExpression expression)
+    {
+        _originalParameter = expression.Parameters.Single();
+        _normalizedParameter = _patternDeclaration.ToParameterExpression();
+        Parameters.Add(_normalizedParameter);
+    }
 
-        protected override void InitParameters(LambdaExpression expression)
+    protected override Expression VisitParameter(ParameterExpression parameter)
+    {
+        if (parameter == _originalParameter)
         {
-            _originalParameter = expression.Parameters.Single();
-            _normalizedParameter = _patternDeclaration.ToParameterExpression();
-            Parameters.Add(_normalizedParameter);
+            return Parameters.First();
         }
-
-        protected override Expression VisitParameter(ParameterExpression parameter)
-        {
-            if (parameter == _originalParameter)
-            {
-                return Parameters.First();
-            }
-            return base.VisitParameter(parameter);
-        }
+        return base.VisitParameter(parameter);
     }
 }

--- a/src/NRules/NRules.Fluent/Expressions/QueryExpression.cs
+++ b/src/NRules/NRules.Fluent/Expressions/QueryExpression.cs
@@ -6,244 +6,243 @@ using NRules.Fluent.Dsl;
 using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 
-namespace NRules.Fluent.Expressions
+namespace NRules.Fluent.Expressions;
+
+internal class QueryExpression : IQuery, IQueryBuilder
 {
-    internal class QueryExpression : IQuery, IQueryBuilder
+    private readonly ParameterExpression _symbol;
+    private readonly SymbolStack _symbolStack;
+    private readonly GroupBuilder _groupBuilder;
+    private Func<string, Type, BuildResult> _buildAction;
+
+    public QueryExpression(ParameterExpression symbol, SymbolStack symbolStack, GroupBuilder groupBuilder)
     {
-        private readonly ParameterExpression _symbol;
-        private readonly SymbolStack _symbolStack;
-        private readonly GroupBuilder _groupBuilder;
-        private Func<string, Type, BuildResult> _buildAction;
+        _symbol = symbol;
+        _symbolStack = symbolStack;
+        _groupBuilder = groupBuilder;
+        Builder = this;
+    }
 
-        public QueryExpression(ParameterExpression symbol, SymbolStack symbolStack, GroupBuilder groupBuilder)
+    public IQueryBuilder Builder { get; }
+
+    public void FactQuery<TSource>(Expression<Func<TSource, bool>>[] conditions)
+    {
+        _buildAction = (name, _) =>
         {
-            _symbol = symbol;
-            _symbolStack = symbolStack;
-            _groupBuilder = groupBuilder;
-            Builder = this;
-        }
+            var patternBuilder = new PatternBuilder(typeof(TSource), name);
+            patternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
+            _symbolStack.Scope.Add(patternBuilder.Declaration);
+            return new BuildResult(patternBuilder);
+        };
+    }
 
-        public IQueryBuilder Builder { get; }
-
-        public void FactQuery<TSource>(Expression<Func<TSource, bool>>[] conditions)
+    public void From<TSource>(Expression<Func<TSource>> source)
+    {
+        _buildAction = (name, _) =>
         {
-            _buildAction = (name, _) =>
+            var patternBuilder = new PatternBuilder(typeof(TSource), name);
+
+            var bindingBuilder = patternBuilder.Binding();
+            bindingBuilder.DslBindingExpression(_symbolStack.Scope.Declarations, source);
+
+            _symbolStack.Scope.Add(patternBuilder.Declaration);
+            return new BuildResult(patternBuilder);
+        };
+    }
+
+    public void Where<TSource>(Expression<Func<TSource, bool>>[] predicates)
+    {
+        var previousBuildAction = _buildAction;
+        _buildAction = (name, type) =>
+        {
+            var result = previousBuildAction(name, type);
+            result.Pattern.DslConditions(_symbolStack.Scope.Declarations, predicates);
+            return result;
+        };
+    }
+
+    public void Select<TSource, TResult>(Expression<Func<TSource, TResult>> selector)
+    {
+        var previousBuildAction = _buildAction;
+        _buildAction = (name, _) =>
+        {
+            var patternBuilder = new PatternBuilder(typeof(TResult), name);
+
+            BuildResult result;
+            using (_symbolStack.Frame())
             {
-                var patternBuilder = new PatternBuilder(typeof(TSource), name);
-                patternBuilder.DslConditions(_symbolStack.Scope.Declarations, conditions);
-                _symbolStack.Scope.Add(patternBuilder.Declaration);
-                return new BuildResult(patternBuilder);
-            };
-        }
-
-        public void From<TSource>(Expression<Func<TSource>> source)
-        {
-            _buildAction = (name, _) =>
-            {
-                var patternBuilder = new PatternBuilder(typeof(TSource), name);
-
-                var bindingBuilder = patternBuilder.Binding();
-                bindingBuilder.DslBindingExpression(_symbolStack.Scope.Declarations, source);
-
-                _symbolStack.Scope.Add(patternBuilder.Declaration);
-                return new BuildResult(patternBuilder);
-            };
-        }
-
-        public void Where<TSource>(Expression<Func<TSource, bool>>[] predicates)
-        {
-            var previousBuildAction = _buildAction;
-            _buildAction = (name, type) =>
-            {
-                var result = previousBuildAction(name, type);
-                result.Pattern.DslConditions(_symbolStack.Scope.Declarations, predicates);
-                return result;
-            };
-        }
-
-        public void Select<TSource, TResult>(Expression<Func<TSource, TResult>> selector)
-        {
-            var previousBuildAction = _buildAction;
-            _buildAction = (name, _) =>
-            {
-                var patternBuilder = new PatternBuilder(typeof(TResult), name);
-
-                BuildResult result;
-                using (_symbolStack.Frame())
-                {
-                    var aggregateBuilder = patternBuilder.Aggregate();
-                    var previousResult = previousBuildAction(null, null);
-                    var sourceBuilder = previousResult.Pattern;
-                    var selectorExpression = sourceBuilder.DslPatternExpression(_symbolStack.Scope.Declarations, selector);
-                    aggregateBuilder.Project(selectorExpression);
-                    aggregateBuilder.Pattern(sourceBuilder);
-                    result = new BuildResult(patternBuilder, aggregateBuilder, sourceBuilder);
-                }
-
-                _symbolStack.Scope.Add(patternBuilder.Declaration);
-                return result;
-            };
-        }
-
-        public void SelectMany<TSource, TResult>(Expression<Func<TSource, IEnumerable<TResult>>> selector)
-        {
-            var previousBuildAction = _buildAction;
-            _buildAction = (name, _) =>
-            {
-                var patternBuilder = new PatternBuilder(typeof(TResult), name);
-
-                BuildResult result;
-                using (_symbolStack.Frame())
-                {
-                    var aggregateBuilder = patternBuilder.Aggregate();
-                    var previousResult = previousBuildAction(null, null);
-                    var sourceBuilder = previousResult.Pattern;
-                    var selectorExpression = sourceBuilder.DslPatternExpression(_symbolStack.Scope.Declarations, selector);
-                    aggregateBuilder.Flatten(selectorExpression);
-                    aggregateBuilder.Pattern(sourceBuilder);
-                    result = new BuildResult(patternBuilder, aggregateBuilder, sourceBuilder);
-                }
-
-                _symbolStack.Scope.Add(patternBuilder.Declaration);
-                return result;
-            };
-        }
-
-        public void GroupBy<TSource, TKey, TElement>(Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector)
-        {
-            var previousBuildAction = _buildAction;
-            _buildAction = (name, _) =>
-            {
-                var patternBuilder = new PatternBuilder(typeof(IGrouping<TKey, TElement>), name);
-
-                BuildResult result;
-                using (_symbolStack.Frame())
-                {
-                    var aggregateBuilder = patternBuilder.Aggregate();
-                    var previousResult = previousBuildAction(null, null);
-                    var sourceBuilder = previousResult.Pattern;
-                    var keySelectorExpression = sourceBuilder.DslPatternExpression(_symbolStack.Scope.Declarations, keySelector);
-                    var elementSelectorExpression = sourceBuilder.DslPatternExpression(_symbolStack.Scope.Declarations, elementSelector);
-                    aggregateBuilder.GroupBy(keySelectorExpression, elementSelectorExpression);
-                    aggregateBuilder.Pattern(sourceBuilder);
-                    result = new BuildResult(patternBuilder, aggregateBuilder, sourceBuilder);
-                }
-
-                _symbolStack.Scope.Add(patternBuilder.Declaration);
-                return result;
-            };
-        }
-
-        public void Collect<TSource>()
-        {
-            var previousBuildAction = _buildAction;
-            _buildAction = (name, type) =>
-            {
-                var patternBuilder = new PatternBuilder(type ?? typeof(IEnumerable<TSource>), name);
-
-                BuildResult result;
-                using (_symbolStack.Frame())
-                {
-                    var aggregateBuilder = patternBuilder.Aggregate();
-                    var previousResult = previousBuildAction(null, null);
-                    var sourceBuilder = previousResult.Pattern;
-                    aggregateBuilder.Collect();
-                    aggregateBuilder.Pattern(sourceBuilder);
-
-                    result = new BuildResult(patternBuilder, aggregateBuilder, sourceBuilder);
-                }
-
-                _symbolStack.Scope.Add(patternBuilder.Declaration);
-                return result;
-            };
-        }
-
-        public void ToLookup<TSource, TKey, TElement>(Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector)
-        {
-            var previousBuildAction = _buildAction;
-            _buildAction = (name, _) =>
-            {
-                var result = previousBuildAction(name, typeof(IKeyedLookup<TKey, TElement>));
-                var keySelectorExpression = result.Source.DslPatternExpression(_symbolStack.Scope.Declarations, keySelector);
-                var elementSelectorExpression = result.Source.DslPatternExpression(_symbolStack.Scope.Declarations, elementSelector);
-                result.Aggregate.ToLookup(keySelectorExpression, elementSelectorExpression);
-                return result;
-            };
-        }
-
-        public void OrderBy<TSource, TKey>(Expression<Func<TSource, TKey>> keySelector, SortDirection sortDirection)
-        {
-            var previousBuildAction = _buildAction;
-            _buildAction = (name, type) =>
-            {
-                var result = previousBuildAction(name, type);
-                var keySelectorExpression = result.Source.DslPatternExpression(_symbolStack.Scope.Declarations, keySelector);
-                result.Aggregate.OrderBy(keySelectorExpression, sortDirection);
-                return result;
-            };
-        }
-
-        public void Aggregate<TSource, TResult>(string aggregateName, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions)
-        {
-            Aggregate<TSource, TResult>(aggregateName, expressions, null);
-        }
-
-        public void Aggregate<TSource, TResult>(string aggregateName, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, Type customFactoryType)
-        {
-            var previousBuildAction = _buildAction;
-            _buildAction = (name, _) =>
-            {
-                var patternBuilder = new PatternBuilder(typeof(TResult), name);
-
-                BuildResult result;
-                using (_symbolStack.Frame())
-                {
-                    var aggregateBuilder = patternBuilder.Aggregate();
-                    var previousResult = previousBuildAction(null, null);
-                    var sourceBuilder = previousResult.Pattern;
-
-                    var rewrittenExpressionCollection = new List<KeyValuePair<string, LambdaExpression>>();
-                    foreach (var item in expressions)
-                    {
-                        var expression = sourceBuilder.DslPatternExpression(_symbolStack.Scope.Declarations, item.Value);
-                        rewrittenExpressionCollection.Add(new KeyValuePair<string, LambdaExpression>(item.Key, expression));
-                    }
-
-                    aggregateBuilder.Aggregator(aggregateName, rewrittenExpressionCollection, customFactoryType);
-                    aggregateBuilder.Pattern(sourceBuilder);
-
-                    result = new BuildResult(patternBuilder, aggregateBuilder, sourceBuilder);
-                }
-
-                _symbolStack.Scope.Add(patternBuilder.Declaration);
-                return result;
-            };
-        }
-
-        public PatternBuilder Build()
-        {
-            var patternBuilder = _buildAction(_symbol.Name, null);
-            _groupBuilder.Pattern(patternBuilder.Pattern);
-            return patternBuilder.Pattern;
-        }
-        
-        private class BuildResult
-        {
-            public BuildResult(PatternBuilder pattern, AggregateBuilder aggregate, PatternBuilder source)
-                : this(pattern)
-            {
-                Aggregate = aggregate;
-                Source = source;
+                var aggregateBuilder = patternBuilder.Aggregate();
+                var previousResult = previousBuildAction(null, null);
+                var sourceBuilder = previousResult.Pattern;
+                var selectorExpression = sourceBuilder.DslPatternExpression(_symbolStack.Scope.Declarations, selector);
+                aggregateBuilder.Project(selectorExpression);
+                aggregateBuilder.Pattern(sourceBuilder);
+                result = new BuildResult(patternBuilder, aggregateBuilder, sourceBuilder);
             }
 
-            public BuildResult(PatternBuilder pattern)
+            _symbolStack.Scope.Add(patternBuilder.Declaration);
+            return result;
+        };
+    }
+
+    public void SelectMany<TSource, TResult>(Expression<Func<TSource, IEnumerable<TResult>>> selector)
+    {
+        var previousBuildAction = _buildAction;
+        _buildAction = (name, _) =>
+        {
+            var patternBuilder = new PatternBuilder(typeof(TResult), name);
+
+            BuildResult result;
+            using (_symbolStack.Frame())
             {
-                Pattern = pattern;
+                var aggregateBuilder = patternBuilder.Aggregate();
+                var previousResult = previousBuildAction(null, null);
+                var sourceBuilder = previousResult.Pattern;
+                var selectorExpression = sourceBuilder.DslPatternExpression(_symbolStack.Scope.Declarations, selector);
+                aggregateBuilder.Flatten(selectorExpression);
+                aggregateBuilder.Pattern(sourceBuilder);
+                result = new BuildResult(patternBuilder, aggregateBuilder, sourceBuilder);
             }
 
-            public PatternBuilder Pattern { get; }
-            public AggregateBuilder Aggregate { get; }
-            public PatternBuilder Source { get; }
+            _symbolStack.Scope.Add(patternBuilder.Declaration);
+            return result;
+        };
+    }
+
+    public void GroupBy<TSource, TKey, TElement>(Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector)
+    {
+        var previousBuildAction = _buildAction;
+        _buildAction = (name, _) =>
+        {
+            var patternBuilder = new PatternBuilder(typeof(IGrouping<TKey, TElement>), name);
+
+            BuildResult result;
+            using (_symbolStack.Frame())
+            {
+                var aggregateBuilder = patternBuilder.Aggregate();
+                var previousResult = previousBuildAction(null, null);
+                var sourceBuilder = previousResult.Pattern;
+                var keySelectorExpression = sourceBuilder.DslPatternExpression(_symbolStack.Scope.Declarations, keySelector);
+                var elementSelectorExpression = sourceBuilder.DslPatternExpression(_symbolStack.Scope.Declarations, elementSelector);
+                aggregateBuilder.GroupBy(keySelectorExpression, elementSelectorExpression);
+                aggregateBuilder.Pattern(sourceBuilder);
+                result = new BuildResult(patternBuilder, aggregateBuilder, sourceBuilder);
+            }
+
+            _symbolStack.Scope.Add(patternBuilder.Declaration);
+            return result;
+        };
+    }
+
+    public void Collect<TSource>()
+    {
+        var previousBuildAction = _buildAction;
+        _buildAction = (name, type) =>
+        {
+            var patternBuilder = new PatternBuilder(type ?? typeof(IEnumerable<TSource>), name);
+
+            BuildResult result;
+            using (_symbolStack.Frame())
+            {
+                var aggregateBuilder = patternBuilder.Aggregate();
+                var previousResult = previousBuildAction(null, null);
+                var sourceBuilder = previousResult.Pattern;
+                aggregateBuilder.Collect();
+                aggregateBuilder.Pattern(sourceBuilder);
+
+                result = new BuildResult(patternBuilder, aggregateBuilder, sourceBuilder);
+            }
+
+            _symbolStack.Scope.Add(patternBuilder.Declaration);
+            return result;
+        };
+    }
+
+    public void ToLookup<TSource, TKey, TElement>(Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector)
+    {
+        var previousBuildAction = _buildAction;
+        _buildAction = (name, _) =>
+        {
+            var result = previousBuildAction(name, typeof(IKeyedLookup<TKey, TElement>));
+            var keySelectorExpression = result.Source.DslPatternExpression(_symbolStack.Scope.Declarations, keySelector);
+            var elementSelectorExpression = result.Source.DslPatternExpression(_symbolStack.Scope.Declarations, elementSelector);
+            result.Aggregate.ToLookup(keySelectorExpression, elementSelectorExpression);
+            return result;
+        };
+    }
+
+    public void OrderBy<TSource, TKey>(Expression<Func<TSource, TKey>> keySelector, SortDirection sortDirection)
+    {
+        var previousBuildAction = _buildAction;
+        _buildAction = (name, type) =>
+        {
+            var result = previousBuildAction(name, type);
+            var keySelectorExpression = result.Source.DslPatternExpression(_symbolStack.Scope.Declarations, keySelector);
+            result.Aggregate.OrderBy(keySelectorExpression, sortDirection);
+            return result;
+        };
+    }
+
+    public void Aggregate<TSource, TResult>(string aggregateName, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions)
+    {
+        Aggregate<TSource, TResult>(aggregateName, expressions, null);
+    }
+
+    public void Aggregate<TSource, TResult>(string aggregateName, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, Type customFactoryType)
+    {
+        var previousBuildAction = _buildAction;
+        _buildAction = (name, _) =>
+        {
+            var patternBuilder = new PatternBuilder(typeof(TResult), name);
+
+            BuildResult result;
+            using (_symbolStack.Frame())
+            {
+                var aggregateBuilder = patternBuilder.Aggregate();
+                var previousResult = previousBuildAction(null, null);
+                var sourceBuilder = previousResult.Pattern;
+
+                var rewrittenExpressionCollection = new List<KeyValuePair<string, LambdaExpression>>();
+                foreach (var item in expressions)
+                {
+                    var expression = sourceBuilder.DslPatternExpression(_symbolStack.Scope.Declarations, item.Value);
+                    rewrittenExpressionCollection.Add(new KeyValuePair<string, LambdaExpression>(item.Key, expression));
+                }
+
+                aggregateBuilder.Aggregator(aggregateName, rewrittenExpressionCollection, customFactoryType);
+                aggregateBuilder.Pattern(sourceBuilder);
+
+                result = new BuildResult(patternBuilder, aggregateBuilder, sourceBuilder);
+            }
+
+            _symbolStack.Scope.Add(patternBuilder.Declaration);
+            return result;
+        };
+    }
+
+    public PatternBuilder Build()
+    {
+        var patternBuilder = _buildAction(_symbol.Name, null);
+        _groupBuilder.Pattern(patternBuilder.Pattern);
+        return patternBuilder.Pattern;
+    }
+    
+    private class BuildResult
+    {
+        public BuildResult(PatternBuilder pattern, AggregateBuilder aggregate, PatternBuilder source)
+            : this(pattern)
+        {
+            Aggregate = aggregate;
+            Source = source;
         }
+
+        public BuildResult(PatternBuilder pattern)
+        {
+            Pattern = pattern;
+        }
+
+        public PatternBuilder Pattern { get; }
+        public AggregateBuilder Aggregate { get; }
+        public PatternBuilder Source { get; }
     }
 }

--- a/src/NRules/NRules.Fluent/Expressions/RightHandSideExpression.cs
+++ b/src/NRules/NRules.Fluent/Expressions/RightHandSideExpression.cs
@@ -5,84 +5,83 @@ using NRules.Fluent.Dsl;
 using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 
-namespace NRules.Fluent.Expressions
+namespace NRules.Fluent.Expressions;
+
+internal class RightHandSideExpression : IRightHandSideExpression
 {
-    internal class RightHandSideExpression : IRightHandSideExpression
+    private static readonly MethodInfo GetLinkedMethod = typeof(IContext).GetMethod(nameof(IContext.GetLinked));
+    private static readonly MethodInfo InsertLinkedMethod = typeof(IContext).GetMethod(nameof(IContext.InsertLinked));
+    private static readonly MethodInfo UpdateLinkedMethod = typeof(IContext).GetMethod(nameof(IContext.UpdateLinked));
+
+    private int _linkedCount = 0;
+    private readonly ActionGroupBuilder _builder;
+    private readonly SymbolStack _symbolStack;
+
+    public RightHandSideExpression(ActionGroupBuilder builder, SymbolStack symbolStack)
     {
-        private static readonly MethodInfo GetLinkedMethod = typeof(IContext).GetMethod(nameof(IContext.GetLinked));
-        private static readonly MethodInfo InsertLinkedMethod = typeof(IContext).GetMethod(nameof(IContext.InsertLinked));
-        private static readonly MethodInfo UpdateLinkedMethod = typeof(IContext).GetMethod(nameof(IContext.UpdateLinked));
+        _builder = builder;
+        _symbolStack = symbolStack;
+    }
 
-        private int _linkedCount = 0;
-        private readonly ActionGroupBuilder _builder;
-        private readonly SymbolStack _symbolStack;
+    public IRightHandSideExpression Action(Expression<Action<IContext>> action, ActionTrigger actionTrigger)
+    {
+        _builder.DslAction(_symbolStack.Scope.Declarations, action, actionTrigger);
+        return this;
+    }
 
-        public RightHandSideExpression(ActionGroupBuilder builder, SymbolStack symbolStack)
-        {
-            _builder = builder;
-            _symbolStack = symbolStack;
-        }
+    public IRightHandSideExpression Do(Expression<Action<IContext>> action)
+    {
+        return Action(action, ActionTrigger.Activated | ActionTrigger.Reactivated);
+    }
 
-        public IRightHandSideExpression Action(Expression<Action<IContext>> action, ActionTrigger actionTrigger)
-        {
-            _builder.DslAction(_symbolStack.Scope.Declarations, action, actionTrigger);
-            return this;
-        }
+    public IRightHandSideExpression Undo(Expression<Action<IContext>> action)
+    {
+        return Action(action, ActionTrigger.Deactivated);
+    }
 
-        public IRightHandSideExpression Do(Expression<Action<IContext>> action)
-        {
-            return Action(action, ActionTrigger.Activated | ActionTrigger.Reactivated);
-        }
+    public IRightHandSideExpression Yield<TFact>(Expression<Func<IContext, TFact>> yield)
+    {
+        var context = yield.Parameters[0];
+        var linkedFact = Expression.Parameter(typeof(TFact));
+        var yieldUpdate = Expression.Lambda<Func<IContext, TFact, TFact>>(yield.Body, context, linkedFact);
+        var action = CreateYieldAction(yield, yieldUpdate);
+        return Do(action);
+    }
 
-        public IRightHandSideExpression Undo(Expression<Action<IContext>> action)
-        {
-            return Action(action, ActionTrigger.Deactivated);
-        }
+    public IRightHandSideExpression Yield<TFact>(Expression<Func<IContext, TFact>> yieldInsert, Expression<Func<IContext, TFact, TFact>> yieldUpdate)
+    {
+        var action = CreateYieldAction(yieldInsert, yieldUpdate);
+        return Do(action);
+    }
 
-        public IRightHandSideExpression Yield<TFact>(Expression<Func<IContext, TFact>> yield)
-        {
-            var context = yield.Parameters[0];
-            var linkedFact = Expression.Parameter(typeof(TFact));
-            var yieldUpdate = Expression.Lambda<Func<IContext, TFact, TFact>>(yield.Body, context, linkedFact);
-            var action = CreateYieldAction(yield, yieldUpdate);
-            return Do(action);
-        }
+    public Expression<Action<IContext>> CreateYieldAction<TFact>(Expression<Func<IContext, TFact>> yieldInsert, Expression<Func<IContext, TFact, TFact>> yieldUpdate)
+    {
+        _linkedCount++;
+        var context = yieldInsert.Parameters[0];
+        var linkedFact = Expression.Parameter(typeof(TFact));
+        var linkedKey = Expression.Constant($"$linkedkey{_linkedCount}$");
 
-        public IRightHandSideExpression Yield<TFact>(Expression<Func<IContext, TFact>> yieldInsert, Expression<Func<IContext, TFact, TFact>> yieldUpdate)
-        {
-            var action = CreateYieldAction(yieldInsert, yieldUpdate);
-            return Do(action);
-        }
-
-        public Expression<Action<IContext>> CreateYieldAction<TFact>(Expression<Func<IContext, TFact>> yieldInsert, Expression<Func<IContext, TFact, TFact>> yieldUpdate)
-        {
-            _linkedCount++;
-            var context = yieldInsert.Parameters[0];
-            var linkedFact = Expression.Parameter(typeof(TFact));
-            var linkedKey = Expression.Constant($"$linkedkey{_linkedCount}$");
-
-            var action = Expression.Lambda<Action<IContext>>(
-                Expression.Block(
-                    new[] {linkedFact},
-                    Expression.Assign(linkedFact,
-                        Expression.Convert(
-                            Expression.Call(context,
-                                GetLinkedMethod,
-                                linkedKey),
-                            typeof(TFact))),
-                    Expression.IfThenElse(
-                        Expression.Equal(linkedFact, Expression.Constant(null)),
+        var action = Expression.Lambda<Action<IContext>>(
+            Expression.Block(
+                new[] {linkedFact},
+                Expression.Assign(linkedFact,
+                    Expression.Convert(
                         Expression.Call(context,
-                            InsertLinkedMethod, linkedKey,
-                            yieldInsert.Body),
-                        Expression.Block(
-                            Expression.Assign(linkedFact, Expression.Invoke(yieldUpdate, context, linkedFact)),
-                            Expression.Call(context,
-                                UpdateLinkedMethod,
-                                linkedKey, linkedFact)))
-                ),
-                context);
-            return action;
-        }
+                            GetLinkedMethod,
+                            linkedKey),
+                        typeof(TFact))),
+                Expression.IfThenElse(
+                    Expression.Equal(linkedFact, Expression.Constant(null)),
+                    Expression.Call(context,
+                        InsertLinkedMethod, linkedKey,
+                        yieldInsert.Body),
+                    Expression.Block(
+                        Expression.Assign(linkedFact, Expression.Invoke(yieldUpdate, context, linkedFact)),
+                        Expression.Call(context,
+                            UpdateLinkedMethod,
+                            linkedKey, linkedFact)))
+            ),
+            context);
+        return action;
     }
 }

--- a/src/NRules/NRules.Fluent/Expressions/SymbolStack.cs
+++ b/src/NRules/NRules.Fluent/Expressions/SymbolStack.cs
@@ -1,49 +1,48 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace NRules.Fluent.Expressions
+namespace NRules.Fluent.Expressions;
+
+internal class SymbolStack
 {
-    internal class SymbolStack
+    private readonly Stack<SymbolTable> _frames = new();
+
+    public SymbolStack()
     {
-        private readonly Stack<SymbolTable> _frames = new();
+        _frames.Push(new SymbolTable());
+    }
 
-        public SymbolStack()
+    public SymbolTable Scope => _frames.Peek();
+
+    public IDisposable Frame()
+    {
+        PushFrame();
+        return new StackGuard(this);
+    }
+
+    private void PushFrame()
+    {
+        var symbolTable = new SymbolTable(Scope);
+        _frames.Push(symbolTable);
+    }
+
+    private void PopFrame()
+    {
+        _frames.Pop();
+    }
+
+    private class StackGuard : IDisposable
+    {
+        private readonly SymbolStack _symbolStack;
+
+        public StackGuard(SymbolStack symbolStack)
         {
-            _frames.Push(new SymbolTable());
+            _symbolStack = symbolStack;
         }
 
-        public SymbolTable Scope => _frames.Peek();
-
-        public IDisposable Frame()
+        public void Dispose()
         {
-            PushFrame();
-            return new StackGuard(this);
-        }
-
-        private void PushFrame()
-        {
-            var symbolTable = new SymbolTable(Scope);
-            _frames.Push(symbolTable);
-        }
-
-        private void PopFrame()
-        {
-            _frames.Pop();
-        }
-
-        private class StackGuard : IDisposable
-        {
-            private readonly SymbolStack _symbolStack;
-
-            public StackGuard(SymbolStack symbolStack)
-            {
-                _symbolStack = symbolStack;
-            }
-
-            public void Dispose()
-            {
-                _symbolStack.PopFrame();
-            }
+            _symbolStack.PopFrame();
         }
     }
 }

--- a/src/NRules/NRules.Fluent/Expressions/SymbolTable.cs
+++ b/src/NRules/NRules.Fluent/Expressions/SymbolTable.cs
@@ -2,29 +2,28 @@
 using System.Linq;
 using NRules.RuleModel;
 
-namespace NRules.Fluent.Expressions
+namespace NRules.Fluent.Expressions;
+
+internal class SymbolTable
 {
-    internal class SymbolTable
+    private readonly HashSet<Declaration> _declarations;
+    private readonly SymbolTable _parentScope;
+
+    internal SymbolTable()
     {
-        private readonly HashSet<Declaration> _declarations;
-        private readonly SymbolTable _parentScope;
+        _declarations = new HashSet<Declaration>();
+    }
 
-        internal SymbolTable()
-        {
-            _declarations = new HashSet<Declaration>();
-        }
+    internal SymbolTable(SymbolTable parentScope)
+        : this()
+    {
+        _parentScope = parentScope;
+    }
 
-        internal SymbolTable(SymbolTable parentScope)
-            : this()
-        {
-            _parentScope = parentScope;
-        }
+    public IEnumerable<Declaration> Declarations => _parentScope?.Declarations.Union(_declarations) ?? _declarations;
 
-        public IEnumerable<Declaration> Declarations => _parentScope?.Declarations.Union(_declarations) ?? _declarations;
-
-        public void Add(Declaration declaration)
-        {
-            _declarations.Add(declaration);
-        }
+    public void Add(Declaration declaration)
+    {
+        _declarations.Add(declaration);
     }
 }

--- a/src/NRules/NRules.Fluent/NRules.Fluent.csproj
+++ b/src/NRules/NRules.Fluent/NRules.Fluent.csproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NRules/NRules.Fluent/RuleActivationException.cs
+++ b/src/NRules/NRules.Fluent/RuleActivationException.cs
@@ -1,54 +1,53 @@
 ﻿using System;
 
-namespace NRules.Fluent
+namespace NRules.Fluent;
+
+/// <summary>
+/// Represents errors that occur when instantiating rule classes.
+/// </summary>
+[Serializable]
+public class RuleActivationException : Exception
 {
-    /// <summary>
-    /// Represents errors that occur when instantiating rule classes.
-    /// </summary>
-    [Serializable]
-    public class RuleActivationException : Exception
+    internal RuleActivationException(string message, Type ruleType, Exception innerException)
+        : base(message, innerException)
     {
-        internal RuleActivationException(string message, Type ruleType, Exception innerException)
-            : base(message, innerException)
+        RuleTypeName = ruleType.AssemblyQualifiedName;
+    }
+
+    [System.Security.SecuritySafeCritical]
+    protected RuleActivationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+        : base(info, context)
+    {
+        RuleTypeName = info.GetString("RuleTypeName");
+    }
+
+    [System.Security.SecurityCritical]
+    public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+    {
+        if (info == null)
         {
-            RuleTypeName = ruleType.AssemblyQualifiedName;
+            throw new ArgumentNullException(nameof(info));
         }
+        base.GetObjectData(info, context);
+        info.AddValue("RuleTypeName", RuleTypeName, typeof(string));
+    }
 
-        [System.Security.SecuritySafeCritical]
-        protected RuleActivationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
+    /// <summary>
+    /// Rule CLR type that caused exception.
+    /// </summary>
+    public Type RuleType => Type.GetType(RuleTypeName);
+
+    /// <summary>
+    /// Rule CLR type name that caused exception.
+    /// </summary>
+    public string RuleTypeName { get; }
+
+    public override string Message
+    {
+        get
         {
-            RuleTypeName = info.GetString("RuleTypeName");
-        }
-
-        [System.Security.SecurityCritical]
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-        {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
-            base.GetObjectData(info, context);
-            info.AddValue("RuleTypeName", RuleTypeName, typeof(string));
-        }
-
-        /// <summary>
-        /// Rule CLR type that caused exception.
-        /// </summary>
-        public Type RuleType => Type.GetType(RuleTypeName);
-
-        /// <summary>
-        /// Rule CLR type name that caused exception.
-        /// </summary>
-        public string RuleTypeName { get; }
-
-        public override string Message
-        {
-            get
-            {
-                string message = base.Message + Environment.NewLine + RuleTypeName;
-                return message;
-            }
+            string message = base.Message + Environment.NewLine + RuleTypeName;
+            return message;
         }
     }
 }

--- a/src/NRules/NRules.Fluent/RuleActivator.cs
+++ b/src/NRules/NRules.Fluent/RuleActivator.cs
@@ -2,33 +2,32 @@
 using System.Collections.Generic;
 using NRules.Fluent.Dsl;
 
-namespace NRules.Fluent
+namespace NRules.Fluent;
+
+/// <summary>
+/// Rule activator that instantiates rules based on the CLR types.
+/// Default activator uses reflection activator.
+/// An instance of <c>IRuleActivator</c> can be assigned to <see cref="RuleRepository.Activator"/>,
+/// so that all rule instantiation requests are delegated to the rule activator.
+/// </summary>
+public interface IRuleActivator
 {
     /// <summary>
-    /// Rule activator that instantiates rules based on the CLR types.
-    /// Default activator uses reflection activator.
-    /// An instance of <c>IRuleActivator</c> can be assigned to <see cref="RuleRepository.Activator"/>,
-    /// so that all rule instantiation requests are delegated to the rule activator.
+    /// Creates rule's instances from a CLR type.
     /// </summary>
-    public interface IRuleActivator
-    {
-        /// <summary>
-        /// Creates rule's instances from a CLR type.
-        /// </summary>
-        /// <param name="type">Rule CLR type.</param>
-        /// <returns>Rule instances.</returns>
-        /// <remarks>
-        /// The same rule type may be instantiated multiple times with different parameters. 
-        /// Each instance is considered as separate rule, and should have a unique name.
-        /// </remarks>
-        IEnumerable<Rule> Activate(Type type);
-    }
+    /// <param name="type">Rule CLR type.</param>
+    /// <returns>Rule instances.</returns>
+    /// <remarks>
+    /// The same rule type may be instantiated multiple times with different parameters. 
+    /// Each instance is considered as separate rule, and should have a unique name.
+    /// </remarks>
+    IEnumerable<Rule> Activate(Type type);
+}
 
-    internal class RuleActivator : IRuleActivator
+internal class RuleActivator : IRuleActivator
+{
+    public IEnumerable<Rule> Activate(Type type)
     {
-        public IEnumerable<Rule> Activate(Type type)
-        {
-            yield return (Rule) Activator.CreateInstance(type);
-        }
+        yield return (Rule) Activator.CreateInstance(type);
     }
 }

--- a/src/NRules/NRules.Fluent/RuleDefinitionException.cs
+++ b/src/NRules/NRules.Fluent/RuleDefinitionException.cs
@@ -1,54 +1,53 @@
 ﻿using System;
 
-namespace NRules.Fluent
+namespace NRules.Fluent;
+
+/// <summary>
+/// Represents errors that occur while building rule definition using fluent DSL.
+/// </summary>
+[Serializable]
+public class RuleDefinitionException : Exception
 {
-    /// <summary>
-    /// Represents errors that occur while building rule definition using fluent DSL.
-    /// </summary>
-    [Serializable]
-    public class RuleDefinitionException : Exception
+    internal RuleDefinitionException(string message, Type ruleType, Exception innerException)
+        : base(message, innerException)
     {
-        internal RuleDefinitionException(string message, Type ruleType, Exception innerException)
-            : base(message, innerException)
+        RuleTypeName = ruleType.AssemblyQualifiedName;
+    }
+
+    [System.Security.SecuritySafeCritical]
+    protected RuleDefinitionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+        : base(info, context)
+    {
+        RuleTypeName = info.GetString("RuleTypeName");
+    }
+
+    [System.Security.SecurityCritical]
+    public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+    {
+        if (info == null)
         {
-            RuleTypeName = ruleType.AssemblyQualifiedName;
+            throw new ArgumentNullException(nameof(info));
         }
+        base.GetObjectData(info, context);
+        info.AddValue("RuleTypeName", RuleTypeName, typeof(string));
+    }
 
-        [System.Security.SecuritySafeCritical]
-        protected RuleDefinitionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
+    /// <summary>
+    /// Rule CLR type that caused exception.
+    /// </summary>
+    public Type RuleType => Type.GetType(RuleTypeName);
+
+    /// <summary>
+    /// Rule CLR type name that caused exception.
+    /// </summary>
+    public string RuleTypeName { get; }
+
+    public override string Message
+    {
+        get
         {
-            RuleTypeName = info.GetString("RuleTypeName");
-        }
-
-        [System.Security.SecurityCritical]
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-        {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
-            base.GetObjectData(info, context);
-            info.AddValue("RuleTypeName", RuleTypeName, typeof(string));
-        }
-
-        /// <summary>
-        /// Rule CLR type that caused exception.
-        /// </summary>
-        public Type RuleType => Type.GetType(RuleTypeName);
-
-        /// <summary>
-        /// Rule CLR type name that caused exception.
-        /// </summary>
-        public string RuleTypeName { get; }
-
-        public override string Message
-        {
-            get
-            {
-                string message = base.Message + Environment.NewLine + RuleTypeName;
-                return message;
-            }
+            string message = base.Message + Environment.NewLine + RuleTypeName;
+            return message;
         }
     }
 }

--- a/src/NRules/NRules.Fluent/RuleDefinitionFactory.cs
+++ b/src/NRules/NRules.Fluent/RuleDefinitionFactory.cs
@@ -3,45 +3,44 @@ using System.Collections.Generic;
 using NRules.Fluent.Dsl;
 using NRules.RuleModel;
 
-namespace NRules.Fluent
+namespace NRules.Fluent;
+
+/// <summary>
+/// Creates instances of <see cref="IRuleDefinition"/> from the fluent DSL <see cref="Rule"/> instances.
+/// </summary>
+public class RuleDefinitionFactory
 {
     /// <summary>
     /// Creates instances of <see cref="IRuleDefinition"/> from the fluent DSL <see cref="Rule"/> instances.
     /// </summary>
-    public class RuleDefinitionFactory
+    /// <param name="rules">Fluent DSL <see cref="Rule"/> instances.</param>
+    /// <returns>Corresponding instances of <see cref="IRuleDefinition"/>.</returns>
+    public IEnumerable<IRuleDefinition> Create(IEnumerable<Rule> rules)
     {
-        /// <summary>
-        /// Creates instances of <see cref="IRuleDefinition"/> from the fluent DSL <see cref="Rule"/> instances.
-        /// </summary>
-        /// <param name="rules">Fluent DSL <see cref="Rule"/> instances.</param>
-        /// <returns>Corresponding instances of <see cref="IRuleDefinition"/>.</returns>
-        public IEnumerable<IRuleDefinition> Create(IEnumerable<Rule> rules)
+        var ruleDefinitions = new List<IRuleDefinition>();
+        foreach (var rule in rules)
         {
-            var ruleDefinitions = new List<IRuleDefinition>();
-            foreach (var rule in rules)
-            {
-                var ruleDefinition = Create(rule);
-                ruleDefinitions.Add(ruleDefinition);
-            }
-
-            return ruleDefinitions;
+            var ruleDefinition = Create(rule);
+            ruleDefinitions.Add(ruleDefinition);
         }
 
-        /// <summary>
-        /// Creates a <see cref="IRuleDefinition"/> for an instance of a fluent DSL <see cref="Rule"/>.
-        /// </summary>
-        /// <param name="rule">Fluent DSL <see cref="Rule"/> instance.</param>
-        /// <returns>Corresponding instance of <see cref="IRuleDefinition"/>.</returns>
-        public IRuleDefinition Create(Rule rule)
+        return ruleDefinitions;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="IRuleDefinition"/> for an instance of a fluent DSL <see cref="Rule"/>.
+    /// </summary>
+    /// <param name="rule">Fluent DSL <see cref="Rule"/> instance.</param>
+    /// <returns>Corresponding instance of <see cref="IRuleDefinition"/>.</returns>
+    public IRuleDefinition Create(Rule rule)
+    {
+        try
         {
-            try
-            {
-                return rule.GetDefinition();
-            }
-            catch (Exception e)
-            {
-                throw new RuleDefinitionException("Failed to build rule definition", rule.GetType(), e);
-            }
+            return rule.GetDefinition();
+        }
+        catch (Exception e)
+        {
+            throw new RuleDefinitionException("Failed to build rule definition", rule.GetType(), e);
         }
     }
 }

--- a/src/NRules/NRules.Fluent/RuleLoadSpec.cs
+++ b/src/NRules/NRules.Fluent/RuleLoadSpec.cs
@@ -5,190 +5,189 @@ using System.Reflection;
 using NRules.Fluent.Dsl;
 using NRules.RuleModel;
 
-namespace NRules.Fluent
+namespace NRules.Fluent;
+
+/// <summary>
+/// Fluent specification to load rule definitions via reflection.
+/// </summary>
+public interface IRuleLoadSpec
 {
     /// <summary>
-    /// Fluent specification to load rule definitions via reflection.
+    /// Enables/disables discovery of private rule classes.
+    /// Default is off.
     /// </summary>
-    public interface IRuleLoadSpec
+    /// <param name="include">Include private types if <c>true</c>, don't include otherwise.</param>
+    /// <returns>Spec to continue fluent configuration.</returns>
+    IRuleLoadSpec PrivateTypes(bool include = true);
+
+    /// <summary>
+    /// Enables/disables discovery of nested rule classes.
+    /// Default is off.
+    /// </summary>
+    /// <param name="include">Include nested types if <c>true</c>, don't include otherwise.</param>
+    /// <returns>Spec to continue fluent configuration.</returns>
+    IRuleLoadSpec NestedTypes(bool include = true);
+
+    /// <summary>
+    /// Specifies to load all rule definitions from a given collection of assemblies.
+    /// </summary>
+    /// <param name="assemblies">Assemblies to load from.</param>
+    /// <returns>Spec to continue fluent configuration.</returns>
+    IRuleLoadSpec From(params Assembly[] assemblies);
+    
+    /// <summary>
+    /// Specifies to load all rule definitions from a given collection of assemblies.
+    /// </summary>
+    /// <param name="assemblies">Assemblies to load from.</param>
+    /// <returns>Spec to continue fluent configuration.</returns>
+    IRuleLoadSpec From(IEnumerable<Assembly> assemblies);
+
+    /// <summary>
+    /// Specifies to load rule definitions from a given collection of types.
+    /// </summary>
+    /// <param name="types">Types that represent rule definitions.</param>
+    /// <returns>Spec to continue fluent configuration.</returns>
+    IRuleLoadSpec From(params Type[] types);
+
+    /// <summary>
+    /// Specifies to load rule definitions from a given collection of types.
+    /// </summary>
+    /// <param name="types">Types that represent rule definitions.</param>
+    /// <returns>Spec to continue fluent configuration.</returns>
+    IRuleLoadSpec From(IEnumerable<Type> types);
+
+    /// <summary>
+    /// Specifies to load rule definitions by scanning types/assemblies.
+    /// </summary>
+    /// <param name="scanAction">Assembly/type scan action.</param>
+    /// <returns>Spec to continue fluent configuration.</returns>
+    IRuleLoadSpec From(Action<IRuleTypeScanner> scanAction);
+
+    /// <summary>
+    /// Specifies which rules to load by filtering on rule's metadata.
+    /// </summary>
+    /// <param name="filter">Filter condition based on rule's metadata.</param>
+    /// <returns>Spec to continue fluent configuration.</returns>
+    IRuleLoadSpec Where(Func<IRuleMetadata, bool> filter);
+
+    /// <summary>
+    /// Specifies the name of the rule set where the rules are loaded to.
+    /// If not provided, loads rules into default rule set.
+    /// </summary>
+    /// <param name="ruleSetName">Name of the rule set to load rules to.</param>
+    /// <returns>Spec to continue fluent configuration.</returns>
+    IRuleLoadSpec To(string ruleSetName);
+}
+
+internal class RuleLoadSpec : IRuleLoadSpec
+{
+    private readonly IRuleActivator _activator;
+    private readonly RuleTypeScanner _typeScanner = new();
+    private Func<IRuleMetadata, bool> _filter;
+
+    public RuleLoadSpec(IRuleActivator activator)
     {
-        /// <summary>
-        /// Enables/disables discovery of private rule classes.
-        /// Default is off.
-        /// </summary>
-        /// <param name="include">Include private types if <c>true</c>, don't include otherwise.</param>
-        /// <returns>Spec to continue fluent configuration.</returns>
-        IRuleLoadSpec PrivateTypes(bool include = true);
-
-        /// <summary>
-        /// Enables/disables discovery of nested rule classes.
-        /// Default is off.
-        /// </summary>
-        /// <param name="include">Include nested types if <c>true</c>, don't include otherwise.</param>
-        /// <returns>Spec to continue fluent configuration.</returns>
-        IRuleLoadSpec NestedTypes(bool include = true);
-
-        /// <summary>
-        /// Specifies to load all rule definitions from a given collection of assemblies.
-        /// </summary>
-        /// <param name="assemblies">Assemblies to load from.</param>
-        /// <returns>Spec to continue fluent configuration.</returns>
-        IRuleLoadSpec From(params Assembly[] assemblies);
-        
-        /// <summary>
-        /// Specifies to load all rule definitions from a given collection of assemblies.
-        /// </summary>
-        /// <param name="assemblies">Assemblies to load from.</param>
-        /// <returns>Spec to continue fluent configuration.</returns>
-        IRuleLoadSpec From(IEnumerable<Assembly> assemblies);
-
-        /// <summary>
-        /// Specifies to load rule definitions from a given collection of types.
-        /// </summary>
-        /// <param name="types">Types that represent rule definitions.</param>
-        /// <returns>Spec to continue fluent configuration.</returns>
-        IRuleLoadSpec From(params Type[] types);
-
-        /// <summary>
-        /// Specifies to load rule definitions from a given collection of types.
-        /// </summary>
-        /// <param name="types">Types that represent rule definitions.</param>
-        /// <returns>Spec to continue fluent configuration.</returns>
-        IRuleLoadSpec From(IEnumerable<Type> types);
-
-        /// <summary>
-        /// Specifies to load rule definitions by scanning types/assemblies.
-        /// </summary>
-        /// <param name="scanAction">Assembly/type scan action.</param>
-        /// <returns>Spec to continue fluent configuration.</returns>
-        IRuleLoadSpec From(Action<IRuleTypeScanner> scanAction);
-
-        /// <summary>
-        /// Specifies which rules to load by filtering on rule's metadata.
-        /// </summary>
-        /// <param name="filter">Filter condition based on rule's metadata.</param>
-        /// <returns>Spec to continue fluent configuration.</returns>
-        IRuleLoadSpec Where(Func<IRuleMetadata, bool> filter);
-
-        /// <summary>
-        /// Specifies the name of the rule set where the rules are loaded to.
-        /// If not provided, loads rules into default rule set.
-        /// </summary>
-        /// <param name="ruleSetName">Name of the rule set to load rules to.</param>
-        /// <returns>Spec to continue fluent configuration.</returns>
-        IRuleLoadSpec To(string ruleSetName);
+        _activator = activator;
     }
 
-    internal class RuleLoadSpec : IRuleLoadSpec
+    public string RuleSetName { get; private set; }
+
+    public IRuleLoadSpec PrivateTypes(bool include = true)
     {
-        private readonly IRuleActivator _activator;
-        private readonly RuleTypeScanner _typeScanner = new();
-        private Func<IRuleMetadata, bool> _filter;
+        _typeScanner.PrivateTypes(include);
+        return this;
+    }
 
-        public RuleLoadSpec(IRuleActivator activator)
+    public IRuleLoadSpec NestedTypes(bool include = true)
+    {
+        _typeScanner.NestedTypes(include);
+        return this;
+    }
+
+    public IRuleLoadSpec From(params Assembly[] assemblies)
+    {
+        _typeScanner.Assembly(assemblies);
+        return this;
+    }
+
+    public IRuleLoadSpec From(IEnumerable<Assembly> assemblies)
+    {
+        _typeScanner.Assembly(assemblies.ToArray());
+        return this;
+    }
+
+    public IRuleLoadSpec From(params Type[] types)
+    {
+        _typeScanner.Type(types);
+        return this;
+    }
+
+    public IRuleLoadSpec From(IEnumerable<Type> types)
+    {
+        _typeScanner.Type(types.ToArray());
+        return this;
+    }
+
+    public IRuleLoadSpec From(Action<IRuleTypeScanner> scanAction)
+    {
+        scanAction(_typeScanner);
+        return this;
+    }
+
+    public IRuleLoadSpec Where(Func<IRuleMetadata, bool> filter)
+    {
+        if (IsFilterSet())
+            throw new InvalidOperationException("Rule load specification can only have a single 'Where' clause");
+        
+        _filter = filter;
+        return this;
+    }
+
+    public IRuleLoadSpec To(string ruleSetName)
+    {
+        if (RuleSetName != null)
+            throw new InvalidOperationException("Rule load specification can only have a single 'To' clause");
+        
+        RuleSetName = ruleSetName;
+        return this;
+    }
+
+    public IEnumerable<IRuleDefinition> Load()
+    {
+        var rules = GetRuleTypes()
+            .SelectMany(Activate);
+        var factory = new RuleDefinitionFactory();
+        var ruleDefinitions = factory.Create(rules);
+        return ruleDefinitions;
+    }
+
+    private IEnumerable<Type> GetRuleTypes()
+    {
+        var ruleTypes = _typeScanner.GetRuleTypes();
+        if (IsFilterSet())
         {
-            _activator = activator;
+            var metadata = ruleTypes.Select(ruleType => new RuleMetadata(ruleType));
+            var filteredTypes = metadata.Where(x => _filter(x)).Select(x => x.RuleType);
+            ruleTypes = filteredTypes.ToArray();
         }
+        return ruleTypes;
+    }
 
-        public string RuleSetName { get; private set; }
-
-        public IRuleLoadSpec PrivateTypes(bool include = true)
+    private IEnumerable<Rule> Activate(Type type)
+    {
+        try
         {
-            _typeScanner.PrivateTypes(include);
-            return this;
+            var ruleInstances = _activator.Activate(type);
+            return ruleInstances.ToList();
         }
-
-        public IRuleLoadSpec NestedTypes(bool include = true)
+        catch (Exception e)
         {
-            _typeScanner.NestedTypes(include);
-            return this;
+            throw new RuleActivationException("Failed to activate rule type", type, e);
         }
+    }
 
-        public IRuleLoadSpec From(params Assembly[] assemblies)
-        {
-            _typeScanner.Assembly(assemblies);
-            return this;
-        }
-
-        public IRuleLoadSpec From(IEnumerable<Assembly> assemblies)
-        {
-            _typeScanner.Assembly(assemblies.ToArray());
-            return this;
-        }
-
-        public IRuleLoadSpec From(params Type[] types)
-        {
-            _typeScanner.Type(types);
-            return this;
-        }
-
-        public IRuleLoadSpec From(IEnumerable<Type> types)
-        {
-            _typeScanner.Type(types.ToArray());
-            return this;
-        }
-
-        public IRuleLoadSpec From(Action<IRuleTypeScanner> scanAction)
-        {
-            scanAction(_typeScanner);
-            return this;
-        }
-
-        public IRuleLoadSpec Where(Func<IRuleMetadata, bool> filter)
-        {
-            if (IsFilterSet())
-                throw new InvalidOperationException("Rule load specification can only have a single 'Where' clause");
-            
-            _filter = filter;
-            return this;
-        }
-
-        public IRuleLoadSpec To(string ruleSetName)
-        {
-            if (RuleSetName != null)
-                throw new InvalidOperationException("Rule load specification can only have a single 'To' clause");
-            
-            RuleSetName = ruleSetName;
-            return this;
-        }
-
-        public IEnumerable<IRuleDefinition> Load()
-        {
-            var rules = GetRuleTypes()
-                .SelectMany(Activate);
-            var factory = new RuleDefinitionFactory();
-            var ruleDefinitions = factory.Create(rules);
-            return ruleDefinitions;
-        }
-
-        private IEnumerable<Type> GetRuleTypes()
-        {
-            var ruleTypes = _typeScanner.GetRuleTypes();
-            if (IsFilterSet())
-            {
-                var metadata = ruleTypes.Select(ruleType => new RuleMetadata(ruleType));
-                var filteredTypes = metadata.Where(x => _filter(x)).Select(x => x.RuleType);
-                ruleTypes = filteredTypes.ToArray();
-            }
-            return ruleTypes;
-        }
-
-        private IEnumerable<Rule> Activate(Type type)
-        {
-            try
-            {
-                var ruleInstances = _activator.Activate(type);
-                return ruleInstances.ToList();
-            }
-            catch (Exception e)
-            {
-                throw new RuleActivationException("Failed to activate rule type", type, e);
-            }
-        }
-
-        private bool IsFilterSet()
-        {
-            return _filter != null;
-        }
+    private bool IsFilterSet()
+    {
+        return _filter != null;
     }
 }

--- a/src/NRules/NRules.Fluent/RuleMetadata.cs
+++ b/src/NRules/NRules.Fluent/RuleMetadata.cs
@@ -3,82 +3,81 @@ using System.Linq;
 using NRules.Fluent.Dsl;
 using NRules.RuleModel;
 
-namespace NRules.Fluent
+namespace NRules.Fluent;
+
+/// <summary>
+/// Metadata associated with a rule defined using internal DSL.
+/// </summary>
+public interface IRuleMetadata
 {
     /// <summary>
-    /// Metadata associated with a rule defined using internal DSL.
+    /// Rule's CLR type.
     /// </summary>
-    public interface IRuleMetadata
+    Type RuleType { get; }
+
+    /// <summary>
+    /// Rule's name.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Rule's description.
+    /// </summary>
+    string Description { get; }
+
+    /// <summary>
+    /// Tags applied to the rule.
+    /// </summary>
+    string[] Tags { get; }
+}
+
+/// <summary>
+/// Metadata associated with a rule defined using internal DSL.
+/// </summary>
+public class RuleMetadata : IRuleMetadata
+{
+    public RuleMetadata(Type ruleType)
     {
-        /// <summary>
-        /// Rule's CLR type.
-        /// </summary>
-        Type RuleType { get; }
-
-        /// <summary>
-        /// Rule's name.
-        /// </summary>
-        string Name { get; }
-
-        /// <summary>
-        /// Rule's description.
-        /// </summary>
-        string Description { get; }
-
-        /// <summary>
-        /// Tags applied to the rule.
-        /// </summary>
-        string[] Tags { get; }
+        RuleType = ruleType;
+        Name = GetAttributes<NameAttribute>().Select(a => a.Value).SingleOrDefault() ?? RuleType.FullName;
+        Description = GetAttributes<DescriptionAttribute>().Select(a => a.Value).SingleOrDefault() ?? string.Empty;
+        Tags = GetAttributes<TagAttribute>().Select(a => a.Value).ToArray();
+        Priority = GetAttributes<PriorityAttribute>().SingleNullable(a => a.Value);
+        Repeatability = GetAttributes<RepeatabilityAttribute>().SingleNullable(a => a.Value);
     }
 
     /// <summary>
-    /// Metadata associated with a rule defined using internal DSL.
+    /// Rule's CLR type.
     /// </summary>
-    public class RuleMetadata : IRuleMetadata
+    public Type RuleType { get; }
+
+    /// <summary>
+    /// Rule's name.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Rule's description.
+    /// </summary>
+    public string Description { get; }
+
+    /// <summary>
+    /// Tags applied to the rule.
+    /// </summary>
+    public string[] Tags { get; }
+
+    /// <summary>
+    /// Rule's priority.
+    /// </summary>
+    public int? Priority { get; }
+
+    /// <summary>
+    /// Rule's repeatability.
+    /// </summary>
+    public RuleRepeatability? Repeatability { get; }
+
+    private T[] GetAttributes<T>() where T : Attribute
     {
-        public RuleMetadata(Type ruleType)
-        {
-            RuleType = ruleType;
-            Name = GetAttributes<NameAttribute>().Select(a => a.Value).SingleOrDefault() ?? RuleType.FullName;
-            Description = GetAttributes<DescriptionAttribute>().Select(a => a.Value).SingleOrDefault() ?? string.Empty;
-            Tags = GetAttributes<TagAttribute>().Select(a => a.Value).ToArray();
-            Priority = GetAttributes<PriorityAttribute>().SingleNullable(a => a.Value);
-            Repeatability = GetAttributes<RepeatabilityAttribute>().SingleNullable(a => a.Value);
-        }
-
-        /// <summary>
-        /// Rule's CLR type.
-        /// </summary>
-        public Type RuleType { get; }
-
-        /// <summary>
-        /// Rule's name.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Rule's description.
-        /// </summary>
-        public string Description { get; }
-
-        /// <summary>
-        /// Tags applied to the rule.
-        /// </summary>
-        public string[] Tags { get; }
-
-        /// <summary>
-        /// Rule's priority.
-        /// </summary>
-        public int? Priority { get; }
-
-        /// <summary>
-        /// Rule's repeatability.
-        /// </summary>
-        public RuleRepeatability? Repeatability { get; }
-
-        private T[] GetAttributes<T>() where T : Attribute
-        {
-            return RuleType.GetCustomAttributes(true).OfType<T>().ToArray();
-        }
+        return RuleType.GetCustomAttributes(true).OfType<T>().ToArray();
     }
 }

--- a/src/NRules/NRules.Fluent/RuleMetadataExtensions.cs
+++ b/src/NRules/NRules.Fluent/RuleMetadataExtensions.cs
@@ -1,18 +1,17 @@
 using System.Linq;
 
-namespace NRules.Fluent
+namespace NRules.Fluent;
+
+public static class RuleMetadataExtensions
 {
-    public static class RuleMetadataExtensions
+    /// <summary>
+    /// Tests if the rule is tagged with a given tag.
+    /// </summary>
+    /// <param name="metadata">Rule metadata instance.</param>
+    /// <param name="tag">Tag to test.</param>
+    /// <returns><c>true</c> if the rule is tagged, <c>false</c> otherwise.</returns>
+    public static bool IsTagged(this IRuleMetadata metadata, string tag)
     {
-        /// <summary>
-        /// Tests if the rule is tagged with a given tag.
-        /// </summary>
-        /// <param name="metadata">Rule metadata instance.</param>
-        /// <param name="tag">Tag to test.</param>
-        /// <returns><c>true</c> if the rule is tagged, <c>false</c> otherwise.</returns>
-        public static bool IsTagged(this IRuleMetadata metadata, string tag)
-        {
-            return metadata.Tags.Contains(tag);
-        }
+        return metadata.Tags.Contains(tag);
     }
 }

--- a/src/NRules/NRules.Fluent/RuleProperties.cs
+++ b/src/NRules/NRules.Fluent/RuleProperties.cs
@@ -1,13 +1,12 @@
-﻿namespace NRules.Fluent
+﻿namespace NRules.Fluent;
+
+/// <summary>
+/// Rule property names.
+/// </summary>
+public static class RuleProperties
 {
     /// <summary>
-    /// Rule property names.
+    /// CLR Type of the fluent DSL rule class.
     /// </summary>
-    public static class RuleProperties
-    {
-        /// <summary>
-        /// CLR Type of the fluent DSL rule class.
-        /// </summary>
-        public const string ClrType = "Fluent::ClrType";
-    }
+    public const string ClrType = "Fluent::ClrType";
 }

--- a/src/NRules/NRules.Fluent/RuleRepository.cs
+++ b/src/NRules/NRules.Fluent/RuleRepository.cs
@@ -3,78 +3,77 @@ using System.Collections.Generic;
 using System.Linq;
 using NRules.RuleModel;
 
-namespace NRules.Fluent
+namespace NRules.Fluent;
+
+/// <summary>
+/// Rules repository based on the rules defined inline using internal DSL.
+/// Use <see cref="Load"/> method to fluently load rules into the repository.
+/// </summary>
+public class RuleRepository : IRuleRepository
 {
+    private const string DefaultRuleSetName = "default";
+    private readonly List<IRuleSet> _ruleSets = new();
+
     /// <summary>
-    /// Rules repository based on the rules defined inline using internal DSL.
-    /// Use <see cref="Load"/> method to fluently load rules into the repository.
+    /// Creates an empty rule repository.
     /// </summary>
-    public class RuleRepository : IRuleRepository
+    public RuleRepository()
     {
-        private const string DefaultRuleSetName = "default";
-        private readonly List<IRuleSet> _ruleSets = new();
+        Activator = new RuleActivator();
+    }
 
-        /// <summary>
-        /// Creates an empty rule repository.
-        /// </summary>
-        public RuleRepository()
+    /// <summary>
+    /// Rules activator that instantiates rules based on a CLR type.
+    /// </summary>
+    public IRuleActivator Activator { get; set; }
+
+    /// <summary>
+    /// Retrieves all rule sets contained in the repository.
+    /// </summary>
+    /// <returns>Collection of rule sets.</returns>
+    public IEnumerable<IRuleSet> GetRuleSets()
+    {
+        return _ruleSets;
+    }
+
+    /// <summary>
+    /// Loads rules into a rule set using provided loader specification.
+    /// <seealso cref="IRuleLoadSpec"/>
+    /// </summary>
+    /// <param name="specAction">Rule loader specification.</param>
+    public void Load(Action<IRuleLoadSpec> specAction)
+    {
+        var spec = new RuleLoadSpec(Activator);
+        specAction(spec);
+
+        var ruleSetName = spec.RuleSetName ?? DefaultRuleSetName;
+        var ruleSet = GetRuleSet(ruleSetName);
+
+        var rules = spec.Load();
+        ruleSet.Add(rules);
+    }
+
+    /// <summary>
+    /// Adds a new rule set to the rule repository.
+    /// </summary>
+    /// <param name="ruleSet">Rule set to add.</param>
+    /// <exception cref="ArgumentException">A rule set with the same name already exists.</exception>
+    public void Add(IRuleSet ruleSet)
+    {
+        if (_ruleSets.Any(x => x.Name == ruleSet.Name))
+            throw new ArgumentException($"Rule set with the same name already exists. Name={ruleSet.Name}");
+
+        _ruleSets.Add(ruleSet);
+    }
+
+    private IRuleSet GetRuleSet(string ruleSetName)
+    {
+        IRuleSet ruleSet = _ruleSets.SingleOrDefault(rs => rs.Name == ruleSetName);
+        if (ruleSet == null)
         {
-            Activator = new RuleActivator();
-        }
-
-        /// <summary>
-        /// Rules activator that instantiates rules based on a CLR type.
-        /// </summary>
-        public IRuleActivator Activator { get; set; }
-
-        /// <summary>
-        /// Retrieves all rule sets contained in the repository.
-        /// </summary>
-        /// <returns>Collection of rule sets.</returns>
-        public IEnumerable<IRuleSet> GetRuleSets()
-        {
-            return _ruleSets;
-        }
-
-        /// <summary>
-        /// Loads rules into a rule set using provided loader specification.
-        /// <seealso cref="IRuleLoadSpec"/>
-        /// </summary>
-        /// <param name="specAction">Rule loader specification.</param>
-        public void Load(Action<IRuleLoadSpec> specAction)
-        {
-            var spec = new RuleLoadSpec(Activator);
-            specAction(spec);
-
-            var ruleSetName = spec.RuleSetName ?? DefaultRuleSetName;
-            var ruleSet = GetRuleSet(ruleSetName);
-
-            var rules = spec.Load();
-            ruleSet.Add(rules);
-        }
-
-        /// <summary>
-        /// Adds a new rule set to the rule repository.
-        /// </summary>
-        /// <param name="ruleSet">Rule set to add.</param>
-        /// <exception cref="ArgumentException">A rule set with the same name already exists.</exception>
-        public void Add(IRuleSet ruleSet)
-        {
-            if (_ruleSets.Any(x => x.Name == ruleSet.Name))
-                throw new ArgumentException($"Rule set with the same name already exists. Name={ruleSet.Name}");
-
+            ruleSet = new RuleSet(ruleSetName);
             _ruleSets.Add(ruleSet);
         }
-
-        private IRuleSet GetRuleSet(string ruleSetName)
-        {
-            IRuleSet ruleSet = _ruleSets.SingleOrDefault(rs => rs.Name == ruleSetName);
-            if (ruleSet == null)
-            {
-                ruleSet = new RuleSet(ruleSetName);
-                _ruleSets.Add(ruleSet);
-            }
-            return ruleSet;
-        }
+        return ruleSet;
     }
 }

--- a/src/NRules/NRules.Fluent/RuleTypeScanner.cs
+++ b/src/NRules/NRules.Fluent/RuleTypeScanner.cs
@@ -4,170 +4,169 @@ using System.Linq;
 using System.Reflection;
 using NRules.Fluent.Dsl;
 
-namespace NRules.Fluent
+namespace NRules.Fluent;
+
+/// <summary>
+/// Assembly scanner that finds fluent rule classes.
+/// </summary>
+public interface IRuleTypeScanner
 {
     /// <summary>
-    /// Assembly scanner that finds fluent rule classes.
+    /// Enables/disables discovery of private rule classes.
+    /// Default is off.
     /// </summary>
-    public interface IRuleTypeScanner
+    /// <param name="include">Include private types if <c>true</c>, don't include otherwise.</param>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    IRuleTypeScanner PrivateTypes(bool include = true);
+
+    /// <summary>
+    /// Enables/disables discovery of nested rule classes.
+    /// Default is off.
+    /// </summary>
+    /// <param name="include">Include nested types if <c>true</c>, don't include otherwise.</param>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    IRuleTypeScanner NestedTypes(bool include = true);
+
+    /// <summary>
+    /// Finds rule types in the specified assemblies.
+    /// </summary>
+    /// <param name="assemblies">Assemblies to scan.</param>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    IRuleTypeScanner Assembly(params Assembly[] assemblies);
+
+    /// <summary>
+    /// Finds rule types in the assembly of the specified type.
+    /// </summary>
+    /// <typeparam name="T">Type, whose assembly to scan.</typeparam>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    IRuleTypeScanner AssemblyOf<T>();
+
+    /// <summary>
+    /// Finds rule types in the assembly of the specified type.
+    /// </summary>
+    /// <param name="type">Type, whose assembly to scan.</param>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    IRuleTypeScanner AssemblyOf(Type type);
+
+    /// <summary>
+    /// Finds rule types in the specifies types.
+    /// </summary>
+    /// <param name="types">Types to scan.</param>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    IRuleTypeScanner Type(params Type[] types);
+}
+
+/// <summary>
+/// Assembly scanner that finds fluent rule classes.
+/// </summary>
+public class RuleTypeScanner : IRuleTypeScanner
+{
+    private readonly List<Type> _ruleTypes = new();
+    private bool _nestedTypes = false;
+    private bool _privateTypes = false;
+
+    /// <summary>
+    /// Enables/disables discovery of private rule classes.
+    /// Default is off.
+    /// </summary>
+    /// <param name="include">Include private types if <c>true</c>, don't include otherwise.</param>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    public IRuleTypeScanner PrivateTypes(bool include = true)
     {
-        /// <summary>
-        /// Enables/disables discovery of private rule classes.
-        /// Default is off.
-        /// </summary>
-        /// <param name="include">Include private types if <c>true</c>, don't include otherwise.</param>
-        /// <returns>Rule type scanner to continue scanning specification.</returns>
-        IRuleTypeScanner PrivateTypes(bool include = true);
-
-        /// <summary>
-        /// Enables/disables discovery of nested rule classes.
-        /// Default is off.
-        /// </summary>
-        /// <param name="include">Include nested types if <c>true</c>, don't include otherwise.</param>
-        /// <returns>Rule type scanner to continue scanning specification.</returns>
-        IRuleTypeScanner NestedTypes(bool include = true);
-
-        /// <summary>
-        /// Finds rule types in the specified assemblies.
-        /// </summary>
-        /// <param name="assemblies">Assemblies to scan.</param>
-        /// <returns>Rule type scanner to continue scanning specification.</returns>
-        IRuleTypeScanner Assembly(params Assembly[] assemblies);
-
-        /// <summary>
-        /// Finds rule types in the assembly of the specified type.
-        /// </summary>
-        /// <typeparam name="T">Type, whose assembly to scan.</typeparam>
-        /// <returns>Rule type scanner to continue scanning specification.</returns>
-        IRuleTypeScanner AssemblyOf<T>();
-
-        /// <summary>
-        /// Finds rule types in the assembly of the specified type.
-        /// </summary>
-        /// <param name="type">Type, whose assembly to scan.</param>
-        /// <returns>Rule type scanner to continue scanning specification.</returns>
-        IRuleTypeScanner AssemblyOf(Type type);
-
-        /// <summary>
-        /// Finds rule types in the specifies types.
-        /// </summary>
-        /// <param name="types">Types to scan.</param>
-        /// <returns>Rule type scanner to continue scanning specification.</returns>
-        IRuleTypeScanner Type(params Type[] types);
+        _privateTypes = include;
+        return this;
     }
 
     /// <summary>
-    /// Assembly scanner that finds fluent rule classes.
+    /// Enables/disables discovery of nested rule classes.
+    /// Default is off.
     /// </summary>
-    public class RuleTypeScanner : IRuleTypeScanner
+    /// <param name="include">Include nested types if <c>true</c>, don't include otherwise.</param>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    public IRuleTypeScanner NestedTypes(bool include = true)
     {
-        private readonly List<Type> _ruleTypes = new();
-        private bool _nestedTypes = false;
-        private bool _privateTypes = false;
+        _nestedTypes = include;
+        return this;
+    }
 
-        /// <summary>
-        /// Enables/disables discovery of private rule classes.
-        /// Default is off.
-        /// </summary>
-        /// <param name="include">Include private types if <c>true</c>, don't include otherwise.</param>
-        /// <returns>Rule type scanner to continue scanning specification.</returns>
-        public IRuleTypeScanner PrivateTypes(bool include = true)
-        {
-            _privateTypes = include;
-            return this;
-        }
+    /// <summary>
+    /// Finds rule types in the specified assemblies.
+    /// </summary>
+    /// <param name="assemblies">Assemblies to scan.</param>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    public IRuleTypeScanner Assembly(params Assembly[] assemblies)
+    {
+        var ruleTypes = assemblies.SelectMany(a => a.DefinedTypes.Where(IsRuleType));
+        _ruleTypes.AddRange(ruleTypes);
+        return this;
+    }
 
-        /// <summary>
-        /// Enables/disables discovery of nested rule classes.
-        /// Default is off.
-        /// </summary>
-        /// <param name="include">Include nested types if <c>true</c>, don't include otherwise.</param>
-        /// <returns>Rule type scanner to continue scanning specification.</returns>
-        public IRuleTypeScanner NestedTypes(bool include = true)
-        {
-            _nestedTypes = include;
-            return this;
-        }
+    /// <summary>
+    /// Finds rule types in the assembly of the specified type.
+    /// </summary>
+    /// <typeparam name="T">Type, whose assembly to scan.</typeparam>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    public IRuleTypeScanner AssemblyOf<T>()
+    {
+        return AssemblyOf(typeof(T));
+    }
 
-        /// <summary>
-        /// Finds rule types in the specified assemblies.
-        /// </summary>
-        /// <param name="assemblies">Assemblies to scan.</param>
-        /// <returns>Rule type scanner to continue scanning specification.</returns>
-        public IRuleTypeScanner Assembly(params Assembly[] assemblies)
-        {
-            var ruleTypes = assemblies.SelectMany(a => a.DefinedTypes.Where(IsRuleType));
-            _ruleTypes.AddRange(ruleTypes);
-            return this;
-        }
+    /// <summary>
+    /// Finds rule types in the assembly of the specified type.
+    /// </summary>
+    /// <param name="type">Type, whose assembly to scan.</param>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    public IRuleTypeScanner AssemblyOf(Type type)
+    {
+        return Assembly(type.Assembly);
+    }
 
-        /// <summary>
-        /// Finds rule types in the assembly of the specified type.
-        /// </summary>
-        /// <typeparam name="T">Type, whose assembly to scan.</typeparam>
-        /// <returns>Rule type scanner to continue scanning specification.</returns>
-        public IRuleTypeScanner AssemblyOf<T>()
-        {
-            return AssemblyOf(typeof(T));
-        }
+    /// <summary>
+    /// Finds rule types in the specifies types.
+    /// </summary>
+    /// <param name="types">Types to scan.</param>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    public IRuleTypeScanner Type(params Type[] types)
+    {
+        var ruleTypes = types
+            .Where(IsRuleType);
+        _ruleTypes.AddRange(ruleTypes);
+        return this;
+    }
 
-        /// <summary>
-        /// Finds rule types in the assembly of the specified type.
-        /// </summary>
-        /// <param name="type">Type, whose assembly to scan.</param>
-        /// <returns>Rule type scanner to continue scanning specification.</returns>
-        public IRuleTypeScanner AssemblyOf(Type type)
-        {
-            return Assembly(type.Assembly);
-        }
+    /// <summary>
+    /// Retrieves found types.
+    /// </summary>
+    /// <returns>Rule types.</returns>
+    public Type[] GetRuleTypes()
+    {
+        var ruleTypes = _ruleTypes
+            .Where(t => _privateTypes || !t.IsNotPublic)
+            .Where(t => _nestedTypes || !t.IsNested);
+        return ruleTypes.ToArray();
+    }
 
-        /// <summary>
-        /// Finds rule types in the specifies types.
-        /// </summary>
-        /// <param name="types">Types to scan.</param>
-        /// <returns>Rule type scanner to continue scanning specification.</returns>
-        public IRuleTypeScanner Type(params Type[] types)
-        {
-            var ruleTypes = types
-                .Where(IsRuleType);
-            _ruleTypes.AddRange(ruleTypes);
-            return this;
-        }
-
-        /// <summary>
-        /// Retrieves found types.
-        /// </summary>
-        /// <returns>Rule types.</returns>
-        public Type[] GetRuleTypes()
-        {
-            var ruleTypes = _ruleTypes
-                .Where(t => _privateTypes || !t.IsNotPublic)
-                .Where(t => _nestedTypes || !t.IsNested);
-            return ruleTypes.ToArray();
-        }
-
-        /// <summary>
-        /// Determines if a given CLR type is a rule type.
-        /// </summary>
-        /// <param name="type">Type to check.</param>
-        /// <returns>Result of the check.</returns>
-        public static bool IsRuleType(Type type)
-        {
-            var ruleType = typeof(Rule);
-            if (IsConcrete(type) &&
-                ruleType.IsAssignableFrom(type))
-                return true;
-
-            return false;
-        }
-
-        private static bool IsConcrete(Type type)
-        {
-            if (type.IsAbstract) return false;
-            if (type.IsInterface) return false;
-            if (type.IsGenericTypeDefinition) return false;
-
+    /// <summary>
+    /// Determines if a given CLR type is a rule type.
+    /// </summary>
+    /// <param name="type">Type to check.</param>
+    /// <returns>Result of the check.</returns>
+    public static bool IsRuleType(Type type)
+    {
+        var ruleType = typeof(Rule);
+        if (IsConcrete(type) &&
+            ruleType.IsAssignableFrom(type))
             return true;
-        }
+
+        return false;
+    }
+
+    private static bool IsConcrete(Type type)
+    {
+        if (type.IsAbstract) return false;
+        if (type.IsInterface) return false;
+        if (type.IsGenericTypeDefinition) return false;
+
+        return true;
     }
 }

--- a/src/NRules/NRules.Json/Converters/ExpressionConverter.cs
+++ b/src/NRules/NRules.Json/Converters/ExpressionConverter.cs
@@ -6,471 +6,470 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using NRules.Json.Utilities;
 
-namespace NRules.Json.Converters
+namespace NRules.Json.Converters;
+
+internal class ExpressionConverter : JsonConverter<Expression>
 {
-    internal class ExpressionConverter : JsonConverter<Expression>
+    public override bool CanConvert(Type typeToConvert) =>
+        typeof(Expression).IsAssignableFrom(typeToConvert);
+
+    public override Expression Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        public override bool CanConvert(Type typeToConvert) =>
-            typeof(Expression).IsAssignableFrom(typeToConvert);
+        reader.ReadStartObject();
+        var nodeType = reader.ReadEnumProperty<ExpressionType>(nameof(Expression.NodeType), options);
 
-        public override Expression Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        switch (nodeType)
         {
-            reader.ReadStartObject();
-            var nodeType = reader.ReadEnumProperty<ExpressionType>(nameof(Expression.NodeType), options);
+            case ExpressionType.Lambda:
+                return ReadLambda(ref reader, options);
+            case ExpressionType.Parameter:
+                return ReadParameter(ref reader, options);
+            case ExpressionType.Constant:
+                return ReadConstant(ref reader, options);
+            case ExpressionType.MemberAccess:
+                return ReadMember(ref reader, options);
+            case ExpressionType.Call:
+                return ReadMethodCall(ref reader, options);
+            case ExpressionType.Equal:
+            case ExpressionType.NotEqual:
+            case ExpressionType.GreaterThanOrEqual:
+            case ExpressionType.GreaterThan:
+            case ExpressionType.LessThanOrEqual:
+            case ExpressionType.LessThan:
+            case ExpressionType.AndAlso:
+            case ExpressionType.OrElse:
+            case ExpressionType.And:
+            case ExpressionType.Or:
+            case ExpressionType.ExclusiveOr:
+            case ExpressionType.Add:
+            case ExpressionType.AddChecked:
+            case ExpressionType.Divide:
+            case ExpressionType.Modulo:
+            case ExpressionType.Multiply:
+            case ExpressionType.MultiplyChecked:
+            case ExpressionType.Power:
+            case ExpressionType.Subtract:
+            case ExpressionType.SubtractChecked:
+            case ExpressionType.Coalesce:
+            case ExpressionType.ArrayIndex:
+            case ExpressionType.LeftShift:
+            case ExpressionType.RightShift:
+                return ReadBinaryExpression(ref reader, options, nodeType);
+            case ExpressionType.Not:
+            case ExpressionType.Negate:
+            case ExpressionType.NegateChecked:
+            case ExpressionType.UnaryPlus:
+            case ExpressionType.Convert:
+            case ExpressionType.ConvertChecked:
+            case ExpressionType.TypeAs:
+                return ReadUnaryExpression(ref reader, options, nodeType);
+            case ExpressionType.Invoke:
+                return ReadInvocationExpression(ref reader, options);
+            case ExpressionType.TypeIs:
+                return ReadTypeBinaryExpression(ref reader, options);
+            case ExpressionType.New:
+                return ReadNewExpression(ref reader, options);
+            case ExpressionType.NewArrayInit:
+                return ReadNewArrayInitExpression(ref reader, options);
+            case ExpressionType.MemberInit:
+                return ReadMemberInitExpression(ref reader, options);
+            case ExpressionType.ListInit:
+                return ReadListInitExpression(ref reader, options);
+            case ExpressionType.Conditional:
+                return ReadConditionalExpression(ref reader, options);
+            case ExpressionType.Default:
+                return ReadDefaultExpression(ref reader, options);
+            default:
+                throw new NotSupportedException($"Unsupported expression type. NodeType={nodeType}");
+        }
+    }
 
-            switch (nodeType)
-            {
-                case ExpressionType.Lambda:
-                    return ReadLambda(ref reader, options);
-                case ExpressionType.Parameter:
-                    return ReadParameter(ref reader, options);
-                case ExpressionType.Constant:
-                    return ReadConstant(ref reader, options);
-                case ExpressionType.MemberAccess:
-                    return ReadMember(ref reader, options);
-                case ExpressionType.Call:
-                    return ReadMethodCall(ref reader, options);
-                case ExpressionType.Equal:
-                case ExpressionType.NotEqual:
-                case ExpressionType.GreaterThanOrEqual:
-                case ExpressionType.GreaterThan:
-                case ExpressionType.LessThanOrEqual:
-                case ExpressionType.LessThan:
-                case ExpressionType.AndAlso:
-                case ExpressionType.OrElse:
-                case ExpressionType.And:
-                case ExpressionType.Or:
-                case ExpressionType.ExclusiveOr:
-                case ExpressionType.Add:
-                case ExpressionType.AddChecked:
-                case ExpressionType.Divide:
-                case ExpressionType.Modulo:
-                case ExpressionType.Multiply:
-                case ExpressionType.MultiplyChecked:
-                case ExpressionType.Power:
-                case ExpressionType.Subtract:
-                case ExpressionType.SubtractChecked:
-                case ExpressionType.Coalesce:
-                case ExpressionType.ArrayIndex:
-                case ExpressionType.LeftShift:
-                case ExpressionType.RightShift:
-                    return ReadBinaryExpression(ref reader, options, nodeType);
-                case ExpressionType.Not:
-                case ExpressionType.Negate:
-                case ExpressionType.NegateChecked:
-                case ExpressionType.UnaryPlus:
-                case ExpressionType.Convert:
-                case ExpressionType.ConvertChecked:
-                case ExpressionType.TypeAs:
-                    return ReadUnaryExpression(ref reader, options, nodeType);
-                case ExpressionType.Invoke:
-                    return ReadInvocationExpression(ref reader, options);
-                case ExpressionType.TypeIs:
-                    return ReadTypeBinaryExpression(ref reader, options);
-                case ExpressionType.New:
-                    return ReadNewExpression(ref reader, options);
-                case ExpressionType.NewArrayInit:
-                    return ReadNewArrayInitExpression(ref reader, options);
-                case ExpressionType.MemberInit:
-                    return ReadMemberInitExpression(ref reader, options);
-                case ExpressionType.ListInit:
-                    return ReadListInitExpression(ref reader, options);
-                case ExpressionType.Conditional:
-                    return ReadConditionalExpression(ref reader, options);
-                case ExpressionType.Default:
-                    return ReadDefaultExpression(ref reader, options);
-                default:
-                    throw new NotSupportedException($"Unsupported expression type. NodeType={nodeType}");
-            }
+    public override void Write(Utf8JsonWriter writer, Expression value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteEnumProperty(nameof(value.NodeType), value.NodeType, options);
+
+        switch (value)
+        {
+            case LambdaExpression le:
+                WriteLambda(writer, options, le);
+                break;
+            case ParameterExpression pe:
+                WriteParameter(writer, options, pe);
+                break;
+            case ConstantExpression ce:
+                WriteConstant(writer, options, ce);
+                break;
+            case MemberExpression me:
+                WriteMember(writer, options, me);
+                break;
+            case MethodCallExpression mce:
+                WriteMethodCall(writer, options, mce);
+                break;
+            case BinaryExpression be:
+                WriteBinaryExpression(writer, options, be);
+                break;
+            case UnaryExpression ue:
+                WriteUnaryExpression(writer, options, ue);
+                break;
+            case InvocationExpression ie:
+                WriteInvocationExpression(writer, options, ie);
+                break;
+            case TypeBinaryExpression tbe:
+                WriteTypeBinaryExpression(writer, options, tbe);
+                break;
+            case NewExpression ne:
+                WriteNewExpression(writer, options, ne);
+                break;
+            case NewArrayExpression nae:
+                WriteNewArrayInitExpression(writer, options, nae);
+                break;
+            case MemberInitExpression mie:
+                WriteMemberInitExpression(writer, options, mie);
+                break;
+            case ListInitExpression lie:
+                WriteListInitExpression(writer, options, lie);
+                break;
+            case ConditionalExpression ce:
+                WriteConditionalExpression(writer, options, ce);
+                break;
+            case DefaultExpression de:
+                WriteDefaultExpression(writer, options, de);
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported expression type. NodeType={value.NodeType}");
         }
 
-        public override void Write(Utf8JsonWriter writer, Expression value, JsonSerializerOptions options)
-        {
-            writer.WriteStartObject();
-            writer.WriteEnumProperty(nameof(value.NodeType), value.NodeType, options);
+        writer.WriteEndObject();
+    }
 
-            switch (value)
-            {
-                case LambdaExpression le:
-                    WriteLambda(writer, options, le);
-                    break;
-                case ParameterExpression pe:
-                    WriteParameter(writer, options, pe);
-                    break;
-                case ConstantExpression ce:
-                    WriteConstant(writer, options, ce);
-                    break;
-                case MemberExpression me:
-                    WriteMember(writer, options, me);
-                    break;
-                case MethodCallExpression mce:
-                    WriteMethodCall(writer, options, mce);
-                    break;
-                case BinaryExpression be:
-                    WriteBinaryExpression(writer, options, be);
-                    break;
-                case UnaryExpression ue:
-                    WriteUnaryExpression(writer, options, ue);
-                    break;
-                case InvocationExpression ie:
-                    WriteInvocationExpression(writer, options, ie);
-                    break;
-                case TypeBinaryExpression tbe:
-                    WriteTypeBinaryExpression(writer, options, tbe);
-                    break;
-                case NewExpression ne:
-                    WriteNewExpression(writer, options, ne);
-                    break;
-                case NewArrayExpression nae:
-                    WriteNewArrayInitExpression(writer, options, nae);
-                    break;
-                case MemberInitExpression mie:
-                    WriteMemberInitExpression(writer, options, mie);
-                    break;
-                case ListInitExpression lie:
-                    WriteListInitExpression(writer, options, lie);
-                    break;
-                case ConditionalExpression ce:
-                    WriteConditionalExpression(writer, options, ce);
-                    break;
-                case DefaultExpression de:
-                    WriteDefaultExpression(writer, options, de);
-                    break;
-                default:
-                    throw new NotSupportedException($"Unsupported expression type. NodeType={value.NodeType}");
-            }
+    private LambdaExpression ReadLambda(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        reader.TryReadProperty<Type>(nameof(LambdaExpression.Type), options, out var type);
+        reader.TryReadObjectArrayProperty(nameof(LambdaExpression.Parameters), options, ReadParameter, out var parameters);
+        var body = reader.ReadProperty<Expression>(nameof(LambdaExpression.Body), options);
 
-            writer.WriteEndObject();
-        }
+        var expression = type != null
+            ? Expression.Lambda(type, body, parameters)
+            : Expression.Lambda(body, parameters);
 
-        private LambdaExpression ReadLambda(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            reader.TryReadProperty<Type>(nameof(LambdaExpression.Type), options, out var type);
-            reader.TryReadObjectArrayProperty(nameof(LambdaExpression.Parameters), options, ReadParameter, out var parameters);
-            var body = reader.ReadProperty<Expression>(nameof(LambdaExpression.Body), options);
+        var parameterCompactor = new ExpressionParameterCompactor();
+        var result = parameterCompactor.Compact(expression);
 
-            var expression = type != null
-                ? Expression.Lambda(type, body, parameters)
-                : Expression.Lambda(body, parameters);
+        return result;
+    }
 
-            var parameterCompactor = new ExpressionParameterCompactor();
-            var result = parameterCompactor.Compact(expression);
-
-            return result;
-        }
-
-        private void WriteLambda(Utf8JsonWriter writer, JsonSerializerOptions options, LambdaExpression value)
-        {
-            var impliedDelegateType = value.GetImpliedDelegateType();
-            if (value.Type != impliedDelegateType)
-                writer.WriteProperty(nameof(value.Type), value.Type, options);
-            if (value.Parameters.Any())
-                writer.WriteObjectArrayProperty(nameof(value.Parameters), value.Parameters, options, pe =>
-                {
-                    WriteParameter(writer, options, pe);
-                });
-            writer.WriteProperty(nameof(value.Body), value.Body, options);
-        }
-
-        private ConstantExpression ReadConstant(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var type = reader.ReadProperty<Type>(nameof(ConstantExpression.Type), options);
-            var value = reader.ReadProperty(nameof(ConstantExpression.Value), type, options);
-            return Expression.Constant(value, type);
-        }
-
-        private void WriteConstant(Utf8JsonWriter writer, JsonSerializerOptions options, ConstantExpression value)
-        {
+    private void WriteLambda(Utf8JsonWriter writer, JsonSerializerOptions options, LambdaExpression value)
+    {
+        var impliedDelegateType = value.GetImpliedDelegateType();
+        if (value.Type != impliedDelegateType)
             writer.WriteProperty(nameof(value.Type), value.Type, options);
-            writer.WriteProperty(nameof(value.Value), value.Value, value.Type, options);
-        }
-
-        private ParameterExpression ReadParameter(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var name = reader.ReadStringProperty(nameof(ParameterExpression.Name), options);
-            var type = reader.ReadProperty<Type>(nameof(ParameterExpression.Type), options);
-            return Expression.Parameter(type, name);
-        }
-
-        private void WriteParameter(Utf8JsonWriter writer, JsonSerializerOptions options, ParameterExpression value)
-        {
-            writer.WriteStringProperty(nameof(value.Name), value.Name, options);
-            writer.WriteProperty(nameof(value.Type), value.Type, options);
-        }
-
-        private MemberExpression ReadMember(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var member = reader.ReadMemberInfo(options);
-            reader.TryReadProperty<Expression>(nameof(MemberExpression.Expression), options, out var expression);
-            return Expression.MakeMemberAccess(expression, member);
-        }
-
-        private void WriteMember(Utf8JsonWriter writer, JsonSerializerOptions options, MemberExpression value)
-        {
-            writer.WriteMemberInfo(options, value.Member);
-            if (value.Expression != null)
-                writer.WriteProperty(nameof(value.Expression), value.Expression, options);
-        }
-
-        private MethodCallExpression ReadMethodCall(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            reader.TryReadProperty<Expression>(nameof(MethodCallExpression.Object), options, out var @object);
-            var methodRecord = reader.ReadMethodInfo(options);
-            reader.TryReadArrayProperty<Expression>(nameof(MethodCallExpression.Arguments), options, out var arguments);
-            var method = methodRecord.GetMethod(arguments.Select(x => x.Type).ToArray(), @object?.Type);
-            return Expression.Call(@object, method, arguments);
-        }
-
-        private void WriteMethodCall(Utf8JsonWriter writer, JsonSerializerOptions options, MethodCallExpression value)
-        {
-            if (value.Object != null)
-                writer.WriteProperty(nameof(value.Object), value.Object, options);
-            writer.WriteMethodInfo(options, value.Method, value.Object?.Type);
-            if (value.Arguments.Any())
-                writer.WriteArrayProperty(nameof(value.Arguments), value.Arguments, options);
-        }
-
-        private BinaryExpression ReadBinaryExpression(ref Utf8JsonReader reader, JsonSerializerOptions options, ExpressionType expressionType)
-        {
-            var left = reader.ReadProperty<Expression>(nameof(BinaryExpression.Left), options);
-            var right = reader.ReadProperty<Expression>(nameof(BinaryExpression.Right), options);
-
-            MethodInfo method = default;
-            if (reader.TryReadMethodInfo(options, out var methodRecord))
-                method = methodRecord.GetMethod(new[] { left.Type, right.Type }, left.Type);
-            
-            switch (expressionType)
+        if (value.Parameters.Any())
+            writer.WriteObjectArrayProperty(nameof(value.Parameters), value.Parameters, options, pe =>
             {
-                case ExpressionType.Equal:
-                    return Expression.Equal(left, right, false, method);
-                case ExpressionType.NotEqual:
-                    return Expression.NotEqual(left, right, false, method);
-                case ExpressionType.LessThanOrEqual:
-                    return Expression.LessThanOrEqual(left, right, false, method);
-                case ExpressionType.LessThan:
-                    return Expression.LessThan(left, right, false, method);
-                case ExpressionType.GreaterThanOrEqual:
-                    return Expression.GreaterThanOrEqual(left, right, false, method);
-                case ExpressionType.GreaterThan:
-                    return Expression.GreaterThan(left, right, false, method);
-                case ExpressionType.AndAlso:
-                    return Expression.AndAlso(left, right, method);
-                case ExpressionType.OrElse:
-                    return Expression.OrElse(left, right, method);
-                case ExpressionType.And:
-                    return Expression.And(left, right, method);
-                case ExpressionType.Or:
-                    return Expression.Or(left, right, method);
-                case ExpressionType.ExclusiveOr:
-                    return Expression.ExclusiveOr(left, right, method);
-                case ExpressionType.Add:
-                    return Expression.Add(left, right, method);
-                case ExpressionType.AddChecked:
-                    return Expression.AddChecked(left, right, method);
-                case ExpressionType.Divide:
-                    return Expression.Divide(left, right, method);
-                case ExpressionType.Modulo:
-                    return Expression.Modulo(left, right, method);
-                case ExpressionType.Multiply:
-                    return Expression.Multiply(left, right, method);
-                case ExpressionType.MultiplyChecked:
-                    return Expression.MultiplyChecked(left, right, method);
-                case ExpressionType.Power:
-                    return Expression.Power(left, right, method);
-                case ExpressionType.Subtract:
-                    return Expression.Subtract(left, right, method);
-                case ExpressionType.SubtractChecked:
-                    return Expression.SubtractChecked(left, right, method);
-                case ExpressionType.Coalesce:
-                    return Expression.Coalesce(left, right);
-                case ExpressionType.ArrayIndex:
-                    return Expression.ArrayIndex(left, right);
-                case ExpressionType.LeftShift:
-                    return Expression.LeftShift(left, right, method);
-                case ExpressionType.RightShift:
-                    return Expression.RightShift(left, right, method);
-                default:
-                    throw new NotSupportedException($"Unrecognized binary expression: {expressionType}");
-            }
-        }
-
-        private void WriteBinaryExpression(Utf8JsonWriter writer, JsonSerializerOptions options, BinaryExpression value)
-        {
-            writer.WriteProperty(nameof(BinaryExpression.Left), value.Left, options);
-            writer.WriteProperty(nameof(BinaryExpression.Right), value.Right, options);
-
-            if (value.Method != null && !value.Method.IsSpecialName)
-                writer.WriteMethodInfo(options, value.Method, value.Left.Type);
-        }
-
-        private UnaryExpression ReadUnaryExpression(ref Utf8JsonReader reader, JsonSerializerOptions options, ExpressionType expressionType)
-        {
-            var operand = reader.ReadProperty<Expression>(nameof(UnaryExpression.Operand), options);
-            reader.TryReadProperty<Type>(nameof(UnaryExpression.Type), options, out var type);
-
-            MethodInfo method = default;
-            if (reader.TryReadMethodInfo(options, out var methodRecord))
-                method = methodRecord.GetMethod(new[] { operand.Type }, operand.Type);
-
-            switch (expressionType)
-            {
-                case ExpressionType.Not:
-                    return Expression.Not(operand, method);
-                case ExpressionType.Negate:
-                    return Expression.Negate(operand, method);
-                case ExpressionType.NegateChecked:
-                    return Expression.NegateChecked(operand, method);
-                case ExpressionType.UnaryPlus:
-                    return Expression.UnaryPlus(operand, method);
-                case ExpressionType.Convert:
-                    return Expression.Convert(operand, type, method);
-                case ExpressionType.ConvertChecked:
-                    return Expression.ConvertChecked(operand, type, method);
-                case ExpressionType.TypeAs:
-                    return Expression.TypeAs(operand, type);
-                default:
-                    throw new NotSupportedException($"Unrecognized unary expression: {expressionType}");
-            }
-        }
-
-        private void WriteUnaryExpression(Utf8JsonWriter writer, JsonSerializerOptions options, UnaryExpression value)
-        {
-            writer.WriteProperty(nameof(UnaryExpression.Operand), value.Operand, options);
-            if (value.Type != value.Operand.Type)
-                writer.WriteProperty(nameof(UnaryExpression.Type), value.Type, options);
-            if (value.Method != null && !value.Method.IsSpecialName)
-                writer.WriteMethodInfo(options, value.Method, value.Operand.Type);
-        }
-
-        private InvocationExpression ReadInvocationExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var expression = reader.ReadProperty<Expression>(nameof(InvocationExpression.Expression), options);
-            reader.TryReadArrayProperty<Expression>(nameof(InvocationExpression.Arguments), options, out var arguments);
-            return Expression.Invoke(expression!, arguments);
-        }
-
-        private void WriteInvocationExpression(Utf8JsonWriter writer, JsonSerializerOptions options, InvocationExpression value)
-        {
-            writer.WriteProperty(nameof(value.Expression), value.Expression, options);
-            if (value.Arguments.Any())
-                writer.WriteArrayProperty(nameof(value.Arguments), value.Arguments, options);
-        }
-
-        private TypeBinaryExpression ReadTypeBinaryExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var expression = reader.ReadProperty<Expression>(nameof(TypeBinaryExpression.Expression), options);
-            var typeOperand = reader.ReadProperty<Type>(nameof(TypeBinaryExpression.TypeOperand), options); 
-            return Expression.TypeIs(expression, typeOperand!);
-        }
-
-        private void WriteTypeBinaryExpression(Utf8JsonWriter writer, JsonSerializerOptions options, TypeBinaryExpression value)
-        {
-            writer.WriteProperty(nameof(value.Expression), value.Expression, options);
-            writer.WriteProperty(nameof(value.TypeOperand), value.TypeOperand, options);
-        }
-        
-        private NewExpression ReadNewExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var declaringType = reader.ReadProperty<Type>(nameof(NewExpression.Constructor.DeclaringType), options);
-            reader.TryReadArrayProperty<Expression>(nameof(NewExpression.Arguments), options, out var arguments);
-            
-            var ctor = declaringType.GetConstructor(arguments.Select(x => x.Type).ToArray())
-                ?? throw new ArgumentException($"Unable to find constructor. Type={declaringType}", nameof(declaringType));
-            return Expression.New(ctor, arguments);
-        }
-
-        private void WriteNewExpression(Utf8JsonWriter writer, JsonSerializerOptions options, NewExpression value)
-        {
-            writer.WriteProperty(nameof(value.Constructor.DeclaringType), value.Constructor.DeclaringType, options);
-            if (value.Arguments.Any())
-                writer.WriteArrayProperty(nameof(value.Arguments), value.Arguments, options);
-        }
-
-        private NewArrayExpression ReadNewArrayInitExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var elementType = reader.ReadProperty<Type>("ElementType", options);
-            reader.TryReadArrayProperty<Expression>(nameof(NewArrayExpression.Expressions), options, out var expressions);
-            return Expression.NewArrayInit(elementType, expressions);
-        }
-
-        private void WriteNewArrayInitExpression(Utf8JsonWriter writer, JsonSerializerOptions options, NewArrayExpression value)
-        {
-            writer.WriteProperty("ElementType", value.Type.GetElementType(), options);
-            if (value.Expressions.Any())
-                writer.WriteArrayProperty(nameof(value.Expressions), value.Expressions, options);
-        }
-
-        private MemberInitExpression ReadMemberInitExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var newExpression = ReadNewExpression(ref reader, options);
-            var bindings = reader.ReadObjectArrayProperty(nameof(MemberInitExpression.Bindings), options, ReadMemberBinding);
-            return Expression.MemberInit(newExpression, bindings);
-
-            MemberBinding ReadMemberBinding(ref Utf8JsonReader r, JsonSerializerOptions o)
-            {
-                return r.ReadMemberBinding(o, newExpression.Type);
-            }
-        }
-
-        private void WriteMemberInitExpression(Utf8JsonWriter writer, JsonSerializerOptions options, MemberInitExpression value)
-        {
-            WriteNewExpression(writer, options, value.NewExpression);
-            writer.WriteObjectArrayProperty(nameof(value.Bindings), value.Bindings, options, mb =>
-            {
-                writer.WriteMemberBinding(mb, options, value.NewExpression.Type);
+                WriteParameter(writer, options, pe);
             });
-        }
+        writer.WriteProperty(nameof(value.Body), value.Body, options);
+    }
 
-        private ListInitExpression ReadListInitExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var newExpression = ReadNewExpression(ref reader, options);
-            var initializers = reader.ReadObjectArrayProperty(nameof(ListInitExpression.Initializers), options, ReadElementInit);
-            return Expression.ListInit(newExpression!, initializers);
+    private ConstantExpression ReadConstant(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var type = reader.ReadProperty<Type>(nameof(ConstantExpression.Type), options);
+        var value = reader.ReadProperty(nameof(ConstantExpression.Value), type, options);
+        return Expression.Constant(value, type);
+    }
 
-            ElementInit ReadElementInit(ref Utf8JsonReader r, JsonSerializerOptions o)
-            {
-                var methodRecord = r.ReadMethodInfo(o);
-                var arguments = r.ReadArrayProperty<Expression>(nameof(ElementInit.Arguments), o);
-                var method = methodRecord.GetMethod(arguments.Select(x => x.Type).ToArray(), newExpression.Type);
-                return Expression.ElementInit(method, arguments);
-            }
-        }
+    private void WriteConstant(Utf8JsonWriter writer, JsonSerializerOptions options, ConstantExpression value)
+    {
+        writer.WriteProperty(nameof(value.Type), value.Type, options);
+        writer.WriteProperty(nameof(value.Value), value.Value, value.Type, options);
+    }
+
+    private ParameterExpression ReadParameter(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var name = reader.ReadStringProperty(nameof(ParameterExpression.Name), options);
+        var type = reader.ReadProperty<Type>(nameof(ParameterExpression.Type), options);
+        return Expression.Parameter(type, name);
+    }
+
+    private void WriteParameter(Utf8JsonWriter writer, JsonSerializerOptions options, ParameterExpression value)
+    {
+        writer.WriteStringProperty(nameof(value.Name), value.Name, options);
+        writer.WriteProperty(nameof(value.Type), value.Type, options);
+    }
+
+    private MemberExpression ReadMember(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var member = reader.ReadMemberInfo(options);
+        reader.TryReadProperty<Expression>(nameof(MemberExpression.Expression), options, out var expression);
+        return Expression.MakeMemberAccess(expression, member);
+    }
+
+    private void WriteMember(Utf8JsonWriter writer, JsonSerializerOptions options, MemberExpression value)
+    {
+        writer.WriteMemberInfo(options, value.Member);
+        if (value.Expression != null)
+            writer.WriteProperty(nameof(value.Expression), value.Expression, options);
+    }
+
+    private MethodCallExpression ReadMethodCall(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        reader.TryReadProperty<Expression>(nameof(MethodCallExpression.Object), options, out var @object);
+        var methodRecord = reader.ReadMethodInfo(options);
+        reader.TryReadArrayProperty<Expression>(nameof(MethodCallExpression.Arguments), options, out var arguments);
+        var method = methodRecord.GetMethod(arguments.Select(x => x.Type).ToArray(), @object?.Type);
+        return Expression.Call(@object, method, arguments);
+    }
+
+    private void WriteMethodCall(Utf8JsonWriter writer, JsonSerializerOptions options, MethodCallExpression value)
+    {
+        if (value.Object != null)
+            writer.WriteProperty(nameof(value.Object), value.Object, options);
+        writer.WriteMethodInfo(options, value.Method, value.Object?.Type);
+        if (value.Arguments.Any())
+            writer.WriteArrayProperty(nameof(value.Arguments), value.Arguments, options);
+    }
+
+    private BinaryExpression ReadBinaryExpression(ref Utf8JsonReader reader, JsonSerializerOptions options, ExpressionType expressionType)
+    {
+        var left = reader.ReadProperty<Expression>(nameof(BinaryExpression.Left), options);
+        var right = reader.ReadProperty<Expression>(nameof(BinaryExpression.Right), options);
+
+        MethodInfo method = default;
+        if (reader.TryReadMethodInfo(options, out var methodRecord))
+            method = methodRecord.GetMethod(new[] { left.Type, right.Type }, left.Type);
         
-        private void WriteListInitExpression(Utf8JsonWriter writer, JsonSerializerOptions options, ListInitExpression value)
+        switch (expressionType)
         {
-            WriteNewExpression(writer, options, value.NewExpression);
-
-            writer.WriteObjectArrayProperty(nameof(value.Initializers), value.Initializers, options, initializer =>
-            {
-                writer.WriteMethodInfo(options, initializer.AddMethod, value.Type);
-                writer.WriteArrayProperty(nameof(initializer.Arguments), initializer.Arguments, options);
-            });
+            case ExpressionType.Equal:
+                return Expression.Equal(left, right, false, method);
+            case ExpressionType.NotEqual:
+                return Expression.NotEqual(left, right, false, method);
+            case ExpressionType.LessThanOrEqual:
+                return Expression.LessThanOrEqual(left, right, false, method);
+            case ExpressionType.LessThan:
+                return Expression.LessThan(left, right, false, method);
+            case ExpressionType.GreaterThanOrEqual:
+                return Expression.GreaterThanOrEqual(left, right, false, method);
+            case ExpressionType.GreaterThan:
+                return Expression.GreaterThan(left, right, false, method);
+            case ExpressionType.AndAlso:
+                return Expression.AndAlso(left, right, method);
+            case ExpressionType.OrElse:
+                return Expression.OrElse(left, right, method);
+            case ExpressionType.And:
+                return Expression.And(left, right, method);
+            case ExpressionType.Or:
+                return Expression.Or(left, right, method);
+            case ExpressionType.ExclusiveOr:
+                return Expression.ExclusiveOr(left, right, method);
+            case ExpressionType.Add:
+                return Expression.Add(left, right, method);
+            case ExpressionType.AddChecked:
+                return Expression.AddChecked(left, right, method);
+            case ExpressionType.Divide:
+                return Expression.Divide(left, right, method);
+            case ExpressionType.Modulo:
+                return Expression.Modulo(left, right, method);
+            case ExpressionType.Multiply:
+                return Expression.Multiply(left, right, method);
+            case ExpressionType.MultiplyChecked:
+                return Expression.MultiplyChecked(left, right, method);
+            case ExpressionType.Power:
+                return Expression.Power(left, right, method);
+            case ExpressionType.Subtract:
+                return Expression.Subtract(left, right, method);
+            case ExpressionType.SubtractChecked:
+                return Expression.SubtractChecked(left, right, method);
+            case ExpressionType.Coalesce:
+                return Expression.Coalesce(left, right);
+            case ExpressionType.ArrayIndex:
+                return Expression.ArrayIndex(left, right);
+            case ExpressionType.LeftShift:
+                return Expression.LeftShift(left, right, method);
+            case ExpressionType.RightShift:
+                return Expression.RightShift(left, right, method);
+            default:
+                throw new NotSupportedException($"Unrecognized binary expression: {expressionType}");
         }
+    }
+
+    private void WriteBinaryExpression(Utf8JsonWriter writer, JsonSerializerOptions options, BinaryExpression value)
+    {
+        writer.WriteProperty(nameof(BinaryExpression.Left), value.Left, options);
+        writer.WriteProperty(nameof(BinaryExpression.Right), value.Right, options);
+
+        if (value.Method != null && !value.Method.IsSpecialName)
+            writer.WriteMethodInfo(options, value.Method, value.Left.Type);
+    }
+
+    private UnaryExpression ReadUnaryExpression(ref Utf8JsonReader reader, JsonSerializerOptions options, ExpressionType expressionType)
+    {
+        var operand = reader.ReadProperty<Expression>(nameof(UnaryExpression.Operand), options);
+        reader.TryReadProperty<Type>(nameof(UnaryExpression.Type), options, out var type);
+
+        MethodInfo method = default;
+        if (reader.TryReadMethodInfo(options, out var methodRecord))
+            method = methodRecord.GetMethod(new[] { operand.Type }, operand.Type);
+
+        switch (expressionType)
+        {
+            case ExpressionType.Not:
+                return Expression.Not(operand, method);
+            case ExpressionType.Negate:
+                return Expression.Negate(operand, method);
+            case ExpressionType.NegateChecked:
+                return Expression.NegateChecked(operand, method);
+            case ExpressionType.UnaryPlus:
+                return Expression.UnaryPlus(operand, method);
+            case ExpressionType.Convert:
+                return Expression.Convert(operand, type, method);
+            case ExpressionType.ConvertChecked:
+                return Expression.ConvertChecked(operand, type, method);
+            case ExpressionType.TypeAs:
+                return Expression.TypeAs(operand, type);
+            default:
+                throw new NotSupportedException($"Unrecognized unary expression: {expressionType}");
+        }
+    }
+
+    private void WriteUnaryExpression(Utf8JsonWriter writer, JsonSerializerOptions options, UnaryExpression value)
+    {
+        writer.WriteProperty(nameof(UnaryExpression.Operand), value.Operand, options);
+        if (value.Type != value.Operand.Type)
+            writer.WriteProperty(nameof(UnaryExpression.Type), value.Type, options);
+        if (value.Method != null && !value.Method.IsSpecialName)
+            writer.WriteMethodInfo(options, value.Method, value.Operand.Type);
+    }
+
+    private InvocationExpression ReadInvocationExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var expression = reader.ReadProperty<Expression>(nameof(InvocationExpression.Expression), options);
+        reader.TryReadArrayProperty<Expression>(nameof(InvocationExpression.Arguments), options, out var arguments);
+        return Expression.Invoke(expression!, arguments);
+    }
+
+    private void WriteInvocationExpression(Utf8JsonWriter writer, JsonSerializerOptions options, InvocationExpression value)
+    {
+        writer.WriteProperty(nameof(value.Expression), value.Expression, options);
+        if (value.Arguments.Any())
+            writer.WriteArrayProperty(nameof(value.Arguments), value.Arguments, options);
+    }
+
+    private TypeBinaryExpression ReadTypeBinaryExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var expression = reader.ReadProperty<Expression>(nameof(TypeBinaryExpression.Expression), options);
+        var typeOperand = reader.ReadProperty<Type>(nameof(TypeBinaryExpression.TypeOperand), options); 
+        return Expression.TypeIs(expression, typeOperand!);
+    }
+
+    private void WriteTypeBinaryExpression(Utf8JsonWriter writer, JsonSerializerOptions options, TypeBinaryExpression value)
+    {
+        writer.WriteProperty(nameof(value.Expression), value.Expression, options);
+        writer.WriteProperty(nameof(value.TypeOperand), value.TypeOperand, options);
+    }
+    
+    private NewExpression ReadNewExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var declaringType = reader.ReadProperty<Type>(nameof(NewExpression.Constructor.DeclaringType), options);
+        reader.TryReadArrayProperty<Expression>(nameof(NewExpression.Arguments), options, out var arguments);
         
-        private ConditionalExpression ReadConditionalExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var test = reader.ReadProperty<Expression>(nameof(ConditionalExpression.Test), options);
-            var ifTrue = reader.ReadProperty<Expression>(nameof(ConditionalExpression.IfTrue), options);
-            var ifFalse = reader.ReadProperty<Expression>(nameof(ConditionalExpression.IfFalse), options);
-            return Expression.Condition(test, ifTrue, ifFalse);
-        }
+        var ctor = declaringType.GetConstructor(arguments.Select(x => x.Type).ToArray())
+            ?? throw new ArgumentException($"Unable to find constructor. Type={declaringType}", nameof(declaringType));
+        return Expression.New(ctor, arguments);
+    }
 
-        private void WriteConditionalExpression(Utf8JsonWriter writer, JsonSerializerOptions options, ConditionalExpression value)
-        {
-            writer.WriteProperty(nameof(value.Test), value.Test, options);
-            writer.WriteProperty(nameof(value.IfTrue), value.IfTrue, options);
-            writer.WriteProperty(nameof(value.IfFalse), value.IfFalse, options);
-        }
+    private void WriteNewExpression(Utf8JsonWriter writer, JsonSerializerOptions options, NewExpression value)
+    {
+        writer.WriteProperty(nameof(value.Constructor.DeclaringType), value.Constructor.DeclaringType, options);
+        if (value.Arguments.Any())
+            writer.WriteArrayProperty(nameof(value.Arguments), value.Arguments, options);
+    }
 
-        private DefaultExpression ReadDefaultExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var type = reader.ReadProperty<Type>(nameof(DefaultExpression.Type), options);
-            return Expression.Default(type);
-        }
+    private NewArrayExpression ReadNewArrayInitExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var elementType = reader.ReadProperty<Type>("ElementType", options);
+        reader.TryReadArrayProperty<Expression>(nameof(NewArrayExpression.Expressions), options, out var expressions);
+        return Expression.NewArrayInit(elementType, expressions);
+    }
 
-        private void WriteDefaultExpression(Utf8JsonWriter writer, JsonSerializerOptions options, DefaultExpression value)
+    private void WriteNewArrayInitExpression(Utf8JsonWriter writer, JsonSerializerOptions options, NewArrayExpression value)
+    {
+        writer.WriteProperty("ElementType", value.Type.GetElementType(), options);
+        if (value.Expressions.Any())
+            writer.WriteArrayProperty(nameof(value.Expressions), value.Expressions, options);
+    }
+
+    private MemberInitExpression ReadMemberInitExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var newExpression = ReadNewExpression(ref reader, options);
+        var bindings = reader.ReadObjectArrayProperty(nameof(MemberInitExpression.Bindings), options, ReadMemberBinding);
+        return Expression.MemberInit(newExpression, bindings);
+
+        MemberBinding ReadMemberBinding(ref Utf8JsonReader r, JsonSerializerOptions o)
         {
-            writer.WriteProperty(nameof(value.Type), value.Type, options);
+            return r.ReadMemberBinding(o, newExpression.Type);
         }
+    }
+
+    private void WriteMemberInitExpression(Utf8JsonWriter writer, JsonSerializerOptions options, MemberInitExpression value)
+    {
+        WriteNewExpression(writer, options, value.NewExpression);
+        writer.WriteObjectArrayProperty(nameof(value.Bindings), value.Bindings, options, mb =>
+        {
+            writer.WriteMemberBinding(mb, options, value.NewExpression.Type);
+        });
+    }
+
+    private ListInitExpression ReadListInitExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var newExpression = ReadNewExpression(ref reader, options);
+        var initializers = reader.ReadObjectArrayProperty(nameof(ListInitExpression.Initializers), options, ReadElementInit);
+        return Expression.ListInit(newExpression!, initializers);
+
+        ElementInit ReadElementInit(ref Utf8JsonReader r, JsonSerializerOptions o)
+        {
+            var methodRecord = r.ReadMethodInfo(o);
+            var arguments = r.ReadArrayProperty<Expression>(nameof(ElementInit.Arguments), o);
+            var method = methodRecord.GetMethod(arguments.Select(x => x.Type).ToArray(), newExpression.Type);
+            return Expression.ElementInit(method, arguments);
+        }
+    }
+    
+    private void WriteListInitExpression(Utf8JsonWriter writer, JsonSerializerOptions options, ListInitExpression value)
+    {
+        WriteNewExpression(writer, options, value.NewExpression);
+
+        writer.WriteObjectArrayProperty(nameof(value.Initializers), value.Initializers, options, initializer =>
+        {
+            writer.WriteMethodInfo(options, initializer.AddMethod, value.Type);
+            writer.WriteArrayProperty(nameof(initializer.Arguments), initializer.Arguments, options);
+        });
+    }
+    
+    private ConditionalExpression ReadConditionalExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var test = reader.ReadProperty<Expression>(nameof(ConditionalExpression.Test), options);
+        var ifTrue = reader.ReadProperty<Expression>(nameof(ConditionalExpression.IfTrue), options);
+        var ifFalse = reader.ReadProperty<Expression>(nameof(ConditionalExpression.IfFalse), options);
+        return Expression.Condition(test, ifTrue, ifFalse);
+    }
+
+    private void WriteConditionalExpression(Utf8JsonWriter writer, JsonSerializerOptions options, ConditionalExpression value)
+    {
+        writer.WriteProperty(nameof(value.Test), value.Test, options);
+        writer.WriteProperty(nameof(value.IfTrue), value.IfTrue, options);
+        writer.WriteProperty(nameof(value.IfFalse), value.IfFalse, options);
+    }
+
+    private DefaultExpression ReadDefaultExpression(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var type = reader.ReadProperty<Type>(nameof(DefaultExpression.Type), options);
+        return Expression.Default(type);
+    }
+
+    private void WriteDefaultExpression(Utf8JsonWriter writer, JsonSerializerOptions options, DefaultExpression value)
+    {
+        writer.WriteProperty(nameof(value.Type), value.Type, options);
     }
 }

--- a/src/NRules/NRules.Json/Converters/ExpressionElementConverter.cs
+++ b/src/NRules/NRules.Json/Converters/ExpressionElementConverter.cs
@@ -6,45 +6,44 @@ using NRules.Json.Utilities;
 using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 
-namespace NRules.Json.Converters
+namespace NRules.Json.Converters;
+
+internal class NamedExpressionElementConverter : JsonConverter<NamedExpressionElement>
 {
-    internal class NamedExpressionElementConverter : JsonConverter<NamedExpressionElement>
+    public override NamedExpressionElement Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        public override NamedExpressionElement Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            reader.ReadStartObject();
-            var name = reader.ReadStringProperty(nameof(NamedExpressionElement.Name), options);
-            var expression = reader.ReadProperty<LambdaExpression>(nameof(NamedExpressionElement.Expression), options);
-            return Element.Expression(name, expression);
-        }
-
-        public override void Write(Utf8JsonWriter writer, NamedExpressionElement value, JsonSerializerOptions options)
-        {
-            writer.WriteStartObject();
-            writer.WriteStringProperty(nameof(NamedExpressionElement.Name), value.Name, options);
-            writer.WriteProperty(nameof(NamedExpressionElement.Expression), value.Expression, options);
-            writer.WriteEndObject();
-        }
+        reader.ReadStartObject();
+        var name = reader.ReadStringProperty(nameof(NamedExpressionElement.Name), options);
+        var expression = reader.ReadProperty<LambdaExpression>(nameof(NamedExpressionElement.Expression), options);
+        return Element.Expression(name, expression);
     }
-    
-    internal class ActionElementConverter : JsonConverter<ActionElement>
-    {
-        public override ActionElement Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            reader.ReadStartObject();
-            if (!reader.TryReadEnumProperty<ActionTrigger>(nameof(ActionElement.ActionTrigger), options, out var trigger))
-                trigger = ActionElement.DefaultTrigger;
-            var expression = reader.ReadProperty<LambdaExpression>(nameof(ActionElement.Expression), options);
-            return Element.Action(expression, trigger);
-        }
 
-        public override void Write(Utf8JsonWriter writer, ActionElement value, JsonSerializerOptions options)
-        {
-            writer.WriteStartObject();
-            if (value.ActionTrigger != ActionElement.DefaultTrigger)
-                writer.WriteEnumProperty(nameof(ActionElement.ActionTrigger), value.ActionTrigger, options); 
-            writer.WriteProperty(nameof(ActionElement.Expression), value.Expression, options);
-            writer.WriteEndObject();
-        }
+    public override void Write(Utf8JsonWriter writer, NamedExpressionElement value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteStringProperty(nameof(NamedExpressionElement.Name), value.Name, options);
+        writer.WriteProperty(nameof(NamedExpressionElement.Expression), value.Expression, options);
+        writer.WriteEndObject();
+    }
+}
+
+internal class ActionElementConverter : JsonConverter<ActionElement>
+{
+    public override ActionElement Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        reader.ReadStartObject();
+        if (!reader.TryReadEnumProperty<ActionTrigger>(nameof(ActionElement.ActionTrigger), options, out var trigger))
+            trigger = ActionElement.DefaultTrigger;
+        var expression = reader.ReadProperty<LambdaExpression>(nameof(ActionElement.Expression), options);
+        return Element.Action(expression, trigger);
+    }
+
+    public override void Write(Utf8JsonWriter writer, ActionElement value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        if (value.ActionTrigger != ActionElement.DefaultTrigger)
+            writer.WriteEnumProperty(nameof(ActionElement.ActionTrigger), value.ActionTrigger, options); 
+        writer.WriteProperty(nameof(ActionElement.Expression), value.Expression, options);
+        writer.WriteEndObject();
     }
 }

--- a/src/NRules/NRules.Json/Converters/MemberBindingExtensions.cs
+++ b/src/NRules/NRules.Json/Converters/MemberBindingExtensions.cs
@@ -3,48 +3,47 @@ using System.Linq.Expressions;
 using System.Text.Json;
 using NRules.Json.Utilities;
 
-namespace NRules.Json.Converters
+namespace NRules.Json.Converters;
+
+internal static class MemberBindingExtensions
 {
-    internal static class MemberBindingExtensions
+    public static MemberBinding ReadMemberBinding(this ref Utf8JsonReader reader, JsonSerializerOptions options, Type impiedType = null)
     {
-        public static MemberBinding ReadMemberBinding(this ref Utf8JsonReader reader, JsonSerializerOptions options, Type impiedType = null)
+        var bindingType = reader.ReadEnumProperty<MemberBindingType>(nameof(MemberBinding.BindingType), options);
+
+        switch (bindingType)
         {
-            var bindingType = reader.ReadEnumProperty<MemberBindingType>(nameof(MemberBinding.BindingType), options);
-
-            switch (bindingType)
-            {
-                case MemberBindingType.Assignment:
-                    return ReadMemberAssignment(ref reader, options, impiedType);
-                default:
-                    throw new NotSupportedException($"Unsupported member binding type. BindingType={bindingType}");
-            }
+            case MemberBindingType.Assignment:
+                return ReadMemberAssignment(ref reader, options, impiedType);
+            default:
+                throw new NotSupportedException($"Unsupported member binding type. BindingType={bindingType}");
         }
+    }
 
-        public static void WriteMemberBinding(this Utf8JsonWriter writer, MemberBinding value, JsonSerializerOptions options, Type impliedType = null)
+    public static void WriteMemberBinding(this Utf8JsonWriter writer, MemberBinding value, JsonSerializerOptions options, Type impliedType = null)
+    {
+        writer.WriteEnumProperty(nameof(value.BindingType), value.BindingType, options);
+
+        switch (value)
         {
-            writer.WriteEnumProperty(nameof(value.BindingType), value.BindingType, options);
-
-            switch (value)
-            {
-                case MemberAssignment ma:
-                    WriteMemberAssignment(writer, options, ma, impliedType);
-                    break;
-                default:
-                    throw new NotSupportedException($"Unsupported member binding type. BindingType={value.BindingType}");
-            }
+            case MemberAssignment ma:
+                WriteMemberAssignment(writer, options, ma, impliedType);
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported member binding type. BindingType={value.BindingType}");
         }
+    }
 
-        private static MemberAssignment ReadMemberAssignment(ref Utf8JsonReader reader, JsonSerializerOptions options, Type impliedType)
-        {
-            var member = reader.ReadMemberInfo(options, impliedType);
-            var expression = reader.ReadProperty<Expression>(nameof(MemberExpression.Expression), options);
-            return Expression.Bind(member, expression);
-        }
+    private static MemberAssignment ReadMemberAssignment(ref Utf8JsonReader reader, JsonSerializerOptions options, Type impliedType)
+    {
+        var member = reader.ReadMemberInfo(options, impliedType);
+        var expression = reader.ReadProperty<Expression>(nameof(MemberExpression.Expression), options);
+        return Expression.Bind(member, expression);
+    }
 
-        private static void WriteMemberAssignment(Utf8JsonWriter writer, JsonSerializerOptions options, MemberAssignment value, Type impliedType)
-        {
-            writer.WriteMemberInfo(options, value.Member, impliedType);
-            writer.WriteProperty(nameof(value.Expression), value.Expression, options);
-        }
+    private static void WriteMemberAssignment(Utf8JsonWriter writer, JsonSerializerOptions options, MemberAssignment value, Type impliedType)
+    {
+        writer.WriteMemberInfo(options, value.Member, impliedType);
+        writer.WriteProperty(nameof(value.Expression), value.Expression, options);
     }
 }

--- a/src/NRules/NRules.Json/Converters/MemberExtensions.cs
+++ b/src/NRules/NRules.Json/Converters/MemberExtensions.cs
@@ -3,88 +3,87 @@ using System.Reflection;
 using System.Text.Json;
 using NRules.Json.Utilities;
 
-namespace NRules.Json.Converters
-{
-    internal readonly struct MethodRecord
-    {
-        public readonly string Name;
-        public readonly Type DeclaringType;
+namespace NRules.Json.Converters;
 
-        public MethodRecord(string name, Type declaringType)
+internal readonly struct MethodRecord
+{
+    public readonly string Name;
+    public readonly Type DeclaringType;
+
+    public MethodRecord(string name, Type declaringType)
+    {
+        Name = name;
+        DeclaringType = declaringType;
+    }
+}
+
+internal static class MemberExtensions
+{
+    public static MemberInfo ReadMemberInfo(this ref Utf8JsonReader reader, JsonSerializerOptions options, Type impliedType = null)
+    {
+        var memberType = reader.ReadEnumProperty<MemberTypes>(nameof(MemberInfo.MemberType), options);
+        var name = reader.ReadStringProperty(nameof(MemberInfo.Name), options);
+        reader.TryReadProperty<Type>(nameof(MemberInfo.DeclaringType), options, out var declaringType);
+
+        var type = declaringType ?? impliedType;
+        if (type == null)
+            throw new ArgumentException($"Unable to determine declaring type for member. Name={name}");
+
+        switch (memberType)
         {
-            Name = name;
-            DeclaringType = declaringType;
+            case MemberTypes.Field:
+                return type.GetField(name) ??
+                    throw new ArgumentException($"Unknown field. DeclaringType={type}, Name={name}", nameof(name));
+            case MemberTypes.Property:
+                return type.GetProperty(name) ??
+                    throw new ArgumentException($"Unknown property. DeclaringType={type}, Name={name}", nameof(name));
+            default:
+                throw new NotSupportedException($"MemberType={memberType}");
         }
     }
 
-    internal static class MemberExtensions
+    public static void WriteMemberInfo(this Utf8JsonWriter writer, JsonSerializerOptions options, MemberInfo value, Type impliedType = null)
     {
-        public static MemberInfo ReadMemberInfo(this ref Utf8JsonReader reader, JsonSerializerOptions options, Type impliedType = null)
-        {
-            var memberType = reader.ReadEnumProperty<MemberTypes>(nameof(MemberInfo.MemberType), options);
-            var name = reader.ReadStringProperty(nameof(MemberInfo.Name), options);
-            reader.TryReadProperty<Type>(nameof(MemberInfo.DeclaringType), options, out var declaringType);
+        writer.WriteEnumProperty(nameof(value.MemberType), value.MemberType, options);
+        writer.WriteStringProperty(nameof(value.Name), value.Name, options);
+        if (impliedType != value.DeclaringType)
+            writer.WriteProperty(nameof(value.DeclaringType), value.DeclaringType, options);
+    }
 
-            var type = declaringType ?? impliedType;
-            if (type == null)
-                throw new ArgumentException($"Unable to determine declaring type for member. Name={name}");
+    public static MethodRecord ReadMethodInfo(this ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var name = reader.ReadStringProperty("MethodName", options);
+        reader.TryReadProperty<Type>(nameof(MethodInfo.DeclaringType), options, out var declaringType);
+        return new MethodRecord(name, declaringType);
+    }
 
-            switch (memberType)
-            {
-                case MemberTypes.Field:
-                    return type.GetField(name) ??
-                        throw new ArgumentException($"Unknown field. DeclaringType={type}, Name={name}", nameof(name));
-                case MemberTypes.Property:
-                    return type.GetProperty(name) ??
-                        throw new ArgumentException($"Unknown property. DeclaringType={type}, Name={name}", nameof(name));
-                default:
-                    throw new NotSupportedException($"MemberType={memberType}");
-            }
-        }
+    public static bool TryReadMethodInfo(this ref Utf8JsonReader reader, JsonSerializerOptions options, out MethodRecord method)
+    {
+        method = default;
 
-        public static void WriteMemberInfo(this Utf8JsonWriter writer, JsonSerializerOptions options, MemberInfo value, Type impliedType = null)
-        {
-            writer.WriteEnumProperty(nameof(value.MemberType), value.MemberType, options);
-            writer.WriteStringProperty(nameof(value.Name), value.Name, options);
-            if (impliedType != value.DeclaringType)
-                writer.WriteProperty(nameof(value.DeclaringType), value.DeclaringType, options);
-        }
+        if (!reader.TryReadStringProperty("MethodName", options, out var name))
+            return false;
 
-        public static MethodRecord ReadMethodInfo(this ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var name = reader.ReadStringProperty("MethodName", options);
-            reader.TryReadProperty<Type>(nameof(MethodInfo.DeclaringType), options, out var declaringType);
-            return new MethodRecord(name, declaringType);
-        }
+        reader.TryReadProperty<Type>(nameof(MethodInfo.DeclaringType), options, out var declaringType);
+        method = new MethodRecord(name, declaringType);
+        return true;
+    }
 
-        public static bool TryReadMethodInfo(this ref Utf8JsonReader reader, JsonSerializerOptions options, out MethodRecord method)
-        {
-            method = default;
+    public static void WriteMethodInfo(this Utf8JsonWriter writer, JsonSerializerOptions options, MethodInfo value, Type impliedType = null)
+    {
+        writer.WriteStringProperty("MethodName", value.Name, options);
+        if (impliedType != value.DeclaringType)
+            writer.WriteProperty(nameof(value.DeclaringType), value.DeclaringType, options);
+    }
 
-            if (!reader.TryReadStringProperty("MethodName", options, out var name))
-                return false;
+    public static MethodInfo GetMethod(this MethodRecord methodRecord, Type[] argumentTypes, Type impliedType = null)
+    {
+        var type = methodRecord.DeclaringType ?? impliedType;
+        if (type == null)
+            throw new ArgumentException($"Unable to determine declaring type for method. Name={methodRecord.Name}");
 
-            reader.TryReadProperty<Type>(nameof(MethodInfo.DeclaringType), options, out var declaringType);
-            method = new MethodRecord(name, declaringType);
-            return true;
-        }
-
-        public static void WriteMethodInfo(this Utf8JsonWriter writer, JsonSerializerOptions options, MethodInfo value, Type impliedType = null)
-        {
-            writer.WriteStringProperty("MethodName", value.Name, options);
-            if (impliedType != value.DeclaringType)
-                writer.WriteProperty(nameof(value.DeclaringType), value.DeclaringType, options);
-        }
-
-        public static MethodInfo GetMethod(this MethodRecord methodRecord, Type[] argumentTypes, Type impliedType = null)
-        {
-            var type = methodRecord.DeclaringType ?? impliedType;
-            if (type == null)
-                throw new ArgumentException($"Unable to determine declaring type for method. Name={methodRecord.Name}");
-
-            var method = type.GetMethod(methodRecord.Name, argumentTypes)
-                ?? throw new ArgumentException($"Unknown method. DeclaringType={type}, Name={methodRecord.Name}");
-            return method;
-        }
+        var method = type.GetMethod(methodRecord.Name, argumentTypes)
+            ?? throw new ArgumentException($"Unknown method. DeclaringType={type}, Name={methodRecord.Name}");
+        return method;
     }
 }

--- a/src/NRules/NRules.Json/Converters/RuleDefinitionConverter.cs
+++ b/src/NRules/NRules.Json/Converters/RuleDefinitionConverter.cs
@@ -6,61 +6,60 @@ using NRules.Json.Utilities;
 using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 
-namespace NRules.Json.Converters
+namespace NRules.Json.Converters;
+
+internal class RuleDefinitionConverter : JsonConverter<IRuleDefinition>
 {
-    internal class RuleDefinitionConverter : JsonConverter<IRuleDefinition>
+    public override IRuleDefinition Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        public override IRuleDefinition Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            reader.ReadStartObject();
+        reader.ReadStartObject();
 
-            var name = reader.ReadStringProperty(nameof(IRuleDefinition.Name), options);
-            if (!reader.TryReadStringProperty(nameof(IRuleDefinition.Description), options, out var description))
-                description = string.Empty;
-            if (!reader.TryReadInt32Property(nameof(IRuleDefinition.Priority), options, out var priority))
-                priority = 0;
-            if (!reader.TryReadEnumProperty<RuleRepeatability>(nameof(IRuleDefinition.Repeatability), options, out var repeatability))
-                repeatability = RuleRepeatability.Repeatable;
-            reader.TryReadArrayProperty(nameof(IRuleDefinition.Tags), options, out string[] tags);
-            reader.TryReadArrayProperty<RuleProperty>(nameof(IRuleDefinition.Properties), options, out var properties);
-            reader.TryReadArrayProperty<DependencyElement>(nameof(DependencyGroupElement.Dependencies), options, out var dependencies);
-            var lhs = reader.ReadProperty<GroupElement>(nameof(IRuleDefinition.LeftHandSide), options);
-            reader.TryReadArrayProperty<FilterElement>(nameof(FilterGroupElement.Filters), options, out var filters);
-            var actions = reader.ReadArrayProperty<ActionElement>(nameof(IRuleDefinition.RightHandSide), options);
-            
-            var ruleDefinition = Element.RuleDefinition(name, description, priority, 
-                repeatability, tags, properties, Element.DependencyGroup(dependencies),
-                lhs, Element.FilterGroup(filters), Element.ActionGroup(actions));
-            return ruleDefinition;
-        }
+        var name = reader.ReadStringProperty(nameof(IRuleDefinition.Name), options);
+        if (!reader.TryReadStringProperty(nameof(IRuleDefinition.Description), options, out var description))
+            description = string.Empty;
+        if (!reader.TryReadInt32Property(nameof(IRuleDefinition.Priority), options, out var priority))
+            priority = 0;
+        if (!reader.TryReadEnumProperty<RuleRepeatability>(nameof(IRuleDefinition.Repeatability), options, out var repeatability))
+            repeatability = RuleRepeatability.Repeatable;
+        reader.TryReadArrayProperty(nameof(IRuleDefinition.Tags), options, out string[] tags);
+        reader.TryReadArrayProperty<RuleProperty>(nameof(IRuleDefinition.Properties), options, out var properties);
+        reader.TryReadArrayProperty<DependencyElement>(nameof(DependencyGroupElement.Dependencies), options, out var dependencies);
+        var lhs = reader.ReadProperty<GroupElement>(nameof(IRuleDefinition.LeftHandSide), options);
+        reader.TryReadArrayProperty<FilterElement>(nameof(FilterGroupElement.Filters), options, out var filters);
+        var actions = reader.ReadArrayProperty<ActionElement>(nameof(IRuleDefinition.RightHandSide), options);
+        
+        var ruleDefinition = Element.RuleDefinition(name, description, priority, 
+            repeatability, tags, properties, Element.DependencyGroup(dependencies),
+            lhs, Element.FilterGroup(filters), Element.ActionGroup(actions));
+        return ruleDefinition;
+    }
 
-        public override void Write(Utf8JsonWriter writer, IRuleDefinition value, JsonSerializerOptions options)
-        {
-            writer.WriteStartObject();
-            writer.WriteStringProperty(nameof(IRuleDefinition.Name), value.Name, options);
-            if (!string.IsNullOrEmpty(value.Description))
-                writer.WriteStringProperty(nameof(IRuleDefinition.Description), value.Description, options);
-            if (value.Priority != 0)
-                writer.WriteNumberProperty(nameof(IRuleDefinition.Priority), value.Priority, options);
-            if (value.Repeatability != RuleRepeatability.Repeatable)
-                writer.WriteEnumProperty(nameof(IRuleDefinition.Repeatability), value.Repeatability, options);
+    public override void Write(Utf8JsonWriter writer, IRuleDefinition value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteStringProperty(nameof(IRuleDefinition.Name), value.Name, options);
+        if (!string.IsNullOrEmpty(value.Description))
+            writer.WriteStringProperty(nameof(IRuleDefinition.Description), value.Description, options);
+        if (value.Priority != 0)
+            writer.WriteNumberProperty(nameof(IRuleDefinition.Priority), value.Priority, options);
+        if (value.Repeatability != RuleRepeatability.Repeatable)
+            writer.WriteEnumProperty(nameof(IRuleDefinition.Repeatability), value.Repeatability, options);
 
-            if (value.Tags.Any())
-                writer.WriteArrayProperty(nameof(IRuleDefinition.Tags), value.Tags, options);
+        if (value.Tags.Any())
+            writer.WriteArrayProperty(nameof(IRuleDefinition.Tags), value.Tags, options);
 
-            if (value.Properties.Any())
-                writer.WriteArrayProperty(nameof(IRuleDefinition.Properties), value.Properties, options);
+        if (value.Properties.Any())
+            writer.WriteArrayProperty(nameof(IRuleDefinition.Properties), value.Properties, options);
 
-            if (value.DependencyGroup.Dependencies.Any())
-                writer.WriteArrayProperty(nameof(DependencyGroupElement.Dependencies), value.DependencyGroup.Dependencies, options);
+        if (value.DependencyGroup.Dependencies.Any())
+            writer.WriteArrayProperty(nameof(DependencyGroupElement.Dependencies), value.DependencyGroup.Dependencies, options);
 
-            writer.WriteProperty(nameof(IRuleDefinition.LeftHandSide), value.LeftHandSide, options);
-            
-            if (value.FilterGroup.Filters.Any())
-                writer.WriteArrayProperty(nameof(FilterGroupElement.Filters), value.FilterGroup.Filters, options);
-            
-            writer.WriteArrayProperty(nameof(IRuleDefinition.RightHandSide), value.RightHandSide.Actions, options);
-            writer.WriteEndObject();
-        }
+        writer.WriteProperty(nameof(IRuleDefinition.LeftHandSide), value.LeftHandSide, options);
+        
+        if (value.FilterGroup.Filters.Any())
+            writer.WriteArrayProperty(nameof(FilterGroupElement.Filters), value.FilterGroup.Filters, options);
+        
+        writer.WriteArrayProperty(nameof(IRuleDefinition.RightHandSide), value.RightHandSide.Actions, options);
+        writer.WriteEndObject();
     }
 }

--- a/src/NRules/NRules.Json/Converters/RuleElementConverter.cs
+++ b/src/NRules/NRules.Json/Converters/RuleElementConverter.cs
@@ -7,219 +7,218 @@ using NRules.Json.Utilities;
 using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 
-namespace NRules.Json.Converters
+namespace NRules.Json.Converters;
+
+internal class RuleElementConverter : JsonConverter<RuleElement>
 {
-    internal class RuleElementConverter : JsonConverter<RuleElement>
+    public override bool CanConvert(Type typeToConvert) =>
+        typeof(RuleElement).IsAssignableFrom(typeToConvert);
+
+    public override RuleElement Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        public override bool CanConvert(Type typeToConvert) =>
-            typeof(RuleElement).IsAssignableFrom(typeToConvert);
+        reader.ReadStartObject();
+        var elementType = reader.ReadEnumProperty<ElementType>(nameof(RuleElement.ElementType), options);
 
-        public override RuleElement Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        switch (elementType)
         {
-            reader.ReadStartObject();
-            var elementType = reader.ReadEnumProperty<ElementType>(nameof(RuleElement.ElementType), options);
-
-            switch (elementType)
-            {
-                case ElementType.And:
-                    return ReadGroup(ref reader, options, GroupType.And);
-                case ElementType.Or:
-                    return ReadGroup(ref reader, options, GroupType.Or);
-                case ElementType.Exists:
-                    return ReadExists(ref reader, options);
-                case ElementType.Not:
-                    return ReadNot(ref reader, options);
-                case ElementType.Aggregate:
-                    return ReadAggregate(ref reader, options);
-                case ElementType.Binding:
-                    return ReadBinding(ref reader, options);
-                case ElementType.Pattern:
-                    return ReadPattern(ref reader, options);
-                case ElementType.Dependency:
-                    return ReadDependency(ref reader, options);
-                case ElementType.Filter:
-                    return ReadFilter(ref reader, options);
-                case ElementType.ForAll:
-                    return ReadForAll(ref reader, options);
-                default:
-                    throw new NotSupportedException($"Unsupported element type. ElementType={elementType}");
-            }
+            case ElementType.And:
+                return ReadGroup(ref reader, options, GroupType.And);
+            case ElementType.Or:
+                return ReadGroup(ref reader, options, GroupType.Or);
+            case ElementType.Exists:
+                return ReadExists(ref reader, options);
+            case ElementType.Not:
+                return ReadNot(ref reader, options);
+            case ElementType.Aggregate:
+                return ReadAggregate(ref reader, options);
+            case ElementType.Binding:
+                return ReadBinding(ref reader, options);
+            case ElementType.Pattern:
+                return ReadPattern(ref reader, options);
+            case ElementType.Dependency:
+                return ReadDependency(ref reader, options);
+            case ElementType.Filter:
+                return ReadFilter(ref reader, options);
+            case ElementType.ForAll:
+                return ReadForAll(ref reader, options);
+            default:
+                throw new NotSupportedException($"Unsupported element type. ElementType={elementType}");
         }
-        
-        public override void Write(Utf8JsonWriter writer, RuleElement value, JsonSerializerOptions options)
-        {
-            writer.WriteStartObject();
-            writer.WriteEnumProperty(nameof(RuleElement.ElementType), value.ElementType, options);
+    }
+    
+    public override void Write(Utf8JsonWriter writer, RuleElement value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteEnumProperty(nameof(RuleElement.ElementType), value.ElementType, options);
 
-            switch (value)
-            {
-                case GroupElement ge:
-                    WriteGroup(writer, options, ge);
-                    break;
-                case ExistsElement ee:
-                    WriteExists(writer, options, ee);
-                    break;
-                case NotElement ne:
-                    WriteNot(writer, options, ne);
-                    break;
-                case AggregateElement ae:
-                    WriteAggregate(writer, options, ae);
-                    break;
-                case BindingElement be:
-                    WriteBinding(writer, options, be);
-                    break;
-                case PatternElement pe:
-                    WritePattern(writer, options, pe);
-                    break;
-                case DependencyElement de:
-                    WriteDependency(writer, options, de);
-                    break;
-                case FilterElement fe:
-                    WriteFilter(writer, options, fe);
-                    break;
-                case ForAllElement fa:
-                    WriteForAll(writer, options, fa);
-                    break;
-                default:
-                    throw new NotSupportedException($"Unsupported element type. ElementType={value.ElementType}");
-            }
-
-            writer.WriteEndObject();
-        }
-        
-        private GroupElement ReadGroup(ref Utf8JsonReader reader, JsonSerializerOptions options, GroupType groupType)
+        switch (value)
         {
-            var children = reader.ReadArrayProperty<RuleElement>(nameof(GroupElement.ChildElements), options);
-            return Element.Group(groupType, children);
+            case GroupElement ge:
+                WriteGroup(writer, options, ge);
+                break;
+            case ExistsElement ee:
+                WriteExists(writer, options, ee);
+                break;
+            case NotElement ne:
+                WriteNot(writer, options, ne);
+                break;
+            case AggregateElement ae:
+                WriteAggregate(writer, options, ae);
+                break;
+            case BindingElement be:
+                WriteBinding(writer, options, be);
+                break;
+            case PatternElement pe:
+                WritePattern(writer, options, pe);
+                break;
+            case DependencyElement de:
+                WriteDependency(writer, options, de);
+                break;
+            case FilterElement fe:
+                WriteFilter(writer, options, fe);
+                break;
+            case ForAllElement fa:
+                WriteForAll(writer, options, fa);
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported element type. ElementType={value.ElementType}");
         }
 
-        private static void WriteGroup(Utf8JsonWriter writer, JsonSerializerOptions options, GroupElement value)
-        {
-            writer.WriteArrayProperty(nameof(GroupElement.ChildElements), value.ChildElements, options);
-        }
+        writer.WriteEndObject();
+    }
+    
+    private GroupElement ReadGroup(ref Utf8JsonReader reader, JsonSerializerOptions options, GroupType groupType)
+    {
+        var children = reader.ReadArrayProperty<RuleElement>(nameof(GroupElement.ChildElements), options);
+        return Element.Group(groupType, children);
+    }
 
-        private ExistsElement ReadExists(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var source = reader.ReadProperty<RuleElement>(nameof(ExistsElement.Source), options);
-            return Element.Exists(source);
-        }
+    private static void WriteGroup(Utf8JsonWriter writer, JsonSerializerOptions options, GroupElement value)
+    {
+        writer.WriteArrayProperty(nameof(GroupElement.ChildElements), value.ChildElements, options);
+    }
 
-        private static void WriteExists(Utf8JsonWriter writer, JsonSerializerOptions options, ExistsElement value)
-        {
-            writer.WriteProperty(nameof(ExistsElement.Source), value.Source, options);
-        }
+    private ExistsElement ReadExists(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var source = reader.ReadProperty<RuleElement>(nameof(ExistsElement.Source), options);
+        return Element.Exists(source);
+    }
 
-        private NotElement ReadNot(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var source = reader.ReadProperty<RuleElement>(nameof(NotElement.Source), options);
-            return Element.Not(source);
-        }
+    private static void WriteExists(Utf8JsonWriter writer, JsonSerializerOptions options, ExistsElement value)
+    {
+        writer.WriteProperty(nameof(ExistsElement.Source), value.Source, options);
+    }
 
-        private static void WriteNot(Utf8JsonWriter writer, JsonSerializerOptions options, NotElement value)
-        {
-            writer.WriteProperty(nameof(NotElement.Source), value.Source, options);
-        }
-        
-        private AggregateElement ReadAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var name = reader.ReadStringProperty(nameof(AggregateElement.Name), options);
-            var resultType = reader.ReadProperty<Type>(nameof(AggregateElement.ResultType), options);
-            reader.TryReadArrayProperty<NamedExpressionElement>(nameof(AggregateElement.Expressions), options, out var expressions);
-            reader.TryReadProperty<Type>(nameof(AggregateElement.CustomFactoryType), options, out var customFactoryType);
-            var source = reader.ReadProperty<PatternElement>(nameof(AggregateElement.Source), options);
-            return Element.Aggregate(resultType, name, expressions, source, customFactoryType);
-        }
+    private NotElement ReadNot(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var source = reader.ReadProperty<RuleElement>(nameof(NotElement.Source), options);
+        return Element.Not(source);
+    }
 
-        private static void WriteAggregate(Utf8JsonWriter writer, JsonSerializerOptions options, AggregateElement value)
-        {
-            writer.WriteStringProperty(nameof(AggregateElement.Name), value.Name, options);
-            writer.WriteProperty(nameof(AggregateElement.ResultType), value.ResultType, options);
+    private static void WriteNot(Utf8JsonWriter writer, JsonSerializerOptions options, NotElement value)
+    {
+        writer.WriteProperty(nameof(NotElement.Source), value.Source, options);
+    }
+    
+    private AggregateElement ReadAggregate(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var name = reader.ReadStringProperty(nameof(AggregateElement.Name), options);
+        var resultType = reader.ReadProperty<Type>(nameof(AggregateElement.ResultType), options);
+        reader.TryReadArrayProperty<NamedExpressionElement>(nameof(AggregateElement.Expressions), options, out var expressions);
+        reader.TryReadProperty<Type>(nameof(AggregateElement.CustomFactoryType), options, out var customFactoryType);
+        var source = reader.ReadProperty<PatternElement>(nameof(AggregateElement.Source), options);
+        return Element.Aggregate(resultType, name, expressions, source, customFactoryType);
+    }
 
-            if (value.Expressions.Any())
-                writer.WriteArrayProperty(nameof(AggregateElement.Expressions), value.Expressions, options);
+    private static void WriteAggregate(Utf8JsonWriter writer, JsonSerializerOptions options, AggregateElement value)
+    {
+        writer.WriteStringProperty(nameof(AggregateElement.Name), value.Name, options);
+        writer.WriteProperty(nameof(AggregateElement.ResultType), value.ResultType, options);
 
-            if (value.CustomFactoryType != null)
-                writer.WriteProperty(nameof(AggregateElement.CustomFactoryType), value.CustomFactoryType, options);
+        if (value.Expressions.Any())
+            writer.WriteArrayProperty(nameof(AggregateElement.Expressions), value.Expressions, options);
 
-            writer.WriteProperty(nameof(AggregateElement.Source), value.Source, options);
-        }
+        if (value.CustomFactoryType != null)
+            writer.WriteProperty(nameof(AggregateElement.CustomFactoryType), value.CustomFactoryType, options);
 
-        private BindingElement ReadBinding(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var resultType = reader.ReadProperty<Type>(nameof(BindingElement.ResultType), options);
-            var expression = reader.ReadProperty<LambdaExpression>(nameof(BindingElement.Expression), options);
-            return Element.Binding(resultType, expression);
-        }
+        writer.WriteProperty(nameof(AggregateElement.Source), value.Source, options);
+    }
 
-        private static void WriteBinding(Utf8JsonWriter writer, JsonSerializerOptions options, BindingElement value)
-        {
-            writer.WriteProperty(nameof(BindingElement.ResultType), value.ResultType, options);
-            writer.WriteProperty(nameof(BindingElement.Expression), value.Expression, options);
-        }
+    private BindingElement ReadBinding(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var resultType = reader.ReadProperty<Type>(nameof(BindingElement.ResultType), options);
+        var expression = reader.ReadProperty<LambdaExpression>(nameof(BindingElement.Expression), options);
+        return Element.Binding(resultType, expression);
+    }
 
-        private PatternElement ReadPattern(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var name = reader.ReadStringProperty(nameof(Declaration.Name), options);
-            var type = reader.ReadProperty<Type>(nameof(Declaration.Type), options);
-            reader.TryReadArrayProperty<NamedExpressionElement>(nameof(PatternElement.Expressions), options, out var expressions);
-            reader.TryReadProperty<RuleElement>(nameof(PatternElement.Source), options, out var source);
-            return Element.Pattern(type, name, expressions, source);
-        }
+    private static void WriteBinding(Utf8JsonWriter writer, JsonSerializerOptions options, BindingElement value)
+    {
+        writer.WriteProperty(nameof(BindingElement.ResultType), value.ResultType, options);
+        writer.WriteProperty(nameof(BindingElement.Expression), value.Expression, options);
+    }
 
-        private static void WritePattern(Utf8JsonWriter writer, JsonSerializerOptions options, PatternElement value)
-        {
-            writer.WriteStringProperty(nameof(Declaration.Name), value.Declaration.Name, options);
-            writer.WriteProperty(nameof(Declaration.Type), value.Declaration.Type, options);
+    private PatternElement ReadPattern(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var name = reader.ReadStringProperty(nameof(Declaration.Name), options);
+        var type = reader.ReadProperty<Type>(nameof(Declaration.Type), options);
+        reader.TryReadArrayProperty<NamedExpressionElement>(nameof(PatternElement.Expressions), options, out var expressions);
+        reader.TryReadProperty<RuleElement>(nameof(PatternElement.Source), options, out var source);
+        return Element.Pattern(type, name, expressions, source);
+    }
 
-            if (value.Expressions.Any())
-                writer.WriteArrayProperty(nameof(PatternElement.Expressions), value.Expressions, options);
+    private static void WritePattern(Utf8JsonWriter writer, JsonSerializerOptions options, PatternElement value)
+    {
+        writer.WriteStringProperty(nameof(Declaration.Name), value.Declaration.Name, options);
+        writer.WriteProperty(nameof(Declaration.Type), value.Declaration.Type, options);
 
-            if (value.Source != null)
-                writer.WriteProperty(nameof(PatternElement.Source), value.Source, options);
-        }
+        if (value.Expressions.Any())
+            writer.WriteArrayProperty(nameof(PatternElement.Expressions), value.Expressions, options);
 
-        private static DependencyElement ReadDependency(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var name = reader.ReadStringProperty(nameof(DependencyElement.Declaration.Name), options);
-            var type = reader.ReadProperty<Type>(nameof(DependencyElement.Declaration.Type), options);
-            reader.TryReadProperty<Type>(nameof(DependencyElement.ServiceType), options, out var serviceType);
-            var declaration = Element.Declaration(type, name);
-            return Element.Dependency(declaration, serviceType ?? type);
-        }
-        
-        private void WriteDependency(Utf8JsonWriter writer, JsonSerializerOptions options, DependencyElement value)
-        {
-            writer.WriteStringProperty(nameof(Declaration.Name), value.Declaration.Name, options);
-            writer.WriteProperty(nameof(Declaration.Type), value.Declaration.Type, options);
+        if (value.Source != null)
+            writer.WriteProperty(nameof(PatternElement.Source), value.Source, options);
+    }
 
-            if (value.ServiceType != value.Declaration.Type)
-                writer.WriteProperty(nameof(value.ServiceType), value.ServiceType, options);
-        }
-        
-        private static FilterElement ReadFilter(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var filterType = reader.ReadEnumProperty<FilterType>(nameof(FilterElement.FilterType), options);
-            var expression = reader.ReadProperty<LambdaExpression>(nameof(FilterElement.Expression), options);
-            return Element.Filter(filterType, expression);
-        }
-        
-        private void WriteFilter(Utf8JsonWriter writer, JsonSerializerOptions options, FilterElement value)
-        {
-            writer.WriteEnumProperty(nameof(value.FilterType), value.FilterType, options);
-            writer.WriteProperty(nameof(value.Expression), value.Expression, options);
-        }
+    private static DependencyElement ReadDependency(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var name = reader.ReadStringProperty(nameof(DependencyElement.Declaration.Name), options);
+        var type = reader.ReadProperty<Type>(nameof(DependencyElement.Declaration.Type), options);
+        reader.TryReadProperty<Type>(nameof(DependencyElement.ServiceType), options, out var serviceType);
+        var declaration = Element.Declaration(type, name);
+        return Element.Dependency(declaration, serviceType ?? type);
+    }
+    
+    private void WriteDependency(Utf8JsonWriter writer, JsonSerializerOptions options, DependencyElement value)
+    {
+        writer.WriteStringProperty(nameof(Declaration.Name), value.Declaration.Name, options);
+        writer.WriteProperty(nameof(Declaration.Type), value.Declaration.Type, options);
 
-        private ForAllElement ReadForAll(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            var basePattern = reader.ReadProperty<PatternElement>(nameof(ForAllElement.BasePattern), options);
-            var patterns = reader.ReadArrayProperty<PatternElement>(nameof(ForAllElement.Patterns), options);
-            return Element.ForAll(basePattern, patterns);
-        }
+        if (value.ServiceType != value.Declaration.Type)
+            writer.WriteProperty(nameof(value.ServiceType), value.ServiceType, options);
+    }
+    
+    private static FilterElement ReadFilter(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var filterType = reader.ReadEnumProperty<FilterType>(nameof(FilterElement.FilterType), options);
+        var expression = reader.ReadProperty<LambdaExpression>(nameof(FilterElement.Expression), options);
+        return Element.Filter(filterType, expression);
+    }
+    
+    private void WriteFilter(Utf8JsonWriter writer, JsonSerializerOptions options, FilterElement value)
+    {
+        writer.WriteEnumProperty(nameof(value.FilterType), value.FilterType, options);
+        writer.WriteProperty(nameof(value.Expression), value.Expression, options);
+    }
 
-        private static void WriteForAll(Utf8JsonWriter writer, JsonSerializerOptions options, ForAllElement value)
-        {
-            writer.WriteProperty(nameof(ForAllElement.BasePattern), value.BasePattern, options);
-            writer.WriteArrayProperty(nameof(ForAllElement.Patterns), value.Patterns, options);
-        }
+    private ForAllElement ReadForAll(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var basePattern = reader.ReadProperty<PatternElement>(nameof(ForAllElement.BasePattern), options);
+        var patterns = reader.ReadArrayProperty<PatternElement>(nameof(ForAllElement.Patterns), options);
+        return Element.ForAll(basePattern, patterns);
+    }
+
+    private static void WriteForAll(Utf8JsonWriter writer, JsonSerializerOptions options, ForAllElement value)
+    {
+        writer.WriteProperty(nameof(ForAllElement.BasePattern), value.BasePattern, options);
+        writer.WriteArrayProperty(nameof(ForAllElement.Patterns), value.Patterns, options);
     }
 }

--- a/src/NRules/NRules.Json/Converters/RulePropertyConverter.cs
+++ b/src/NRules/NRules.Json/Converters/RulePropertyConverter.cs
@@ -4,29 +4,28 @@ using System.Text.Json.Serialization;
 using NRules.Json.Utilities;
 using NRules.RuleModel;
 
-namespace NRules.Json.Converters
+namespace NRules.Json.Converters;
+
+internal class RulePropertyConverter : JsonConverter<RuleProperty>
 {
-    internal class RulePropertyConverter : JsonConverter<RuleProperty>
+    public override RuleProperty Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        public override RuleProperty Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            reader.ReadStartObject();
-            var name = reader.ReadStringProperty(nameof(RuleProperty.Name), options);
-            var type = reader.ReadProperty<Type>("Type", options);
-            var value = reader.ReadProperty(nameof(RuleProperty.Value), type, options);
-            return new RuleProperty(name, value);
-        }
+        reader.ReadStartObject();
+        var name = reader.ReadStringProperty(nameof(RuleProperty.Name), options);
+        var type = reader.ReadProperty<Type>("Type", options);
+        var value = reader.ReadProperty(nameof(RuleProperty.Value), type, options);
+        return new RuleProperty(name, value);
+    }
 
-        public override void Write(Utf8JsonWriter writer, RuleProperty value, JsonSerializerOptions options)
-        {
-            writer.WriteStartObject();
-            writer.WriteStringProperty(nameof(RuleProperty.Name), value.Name, options);
+    public override void Write(Utf8JsonWriter writer, RuleProperty value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteStringProperty(nameof(RuleProperty.Name), value.Name, options);
 
-            var type = value.Value is Type ? typeof(Type) : value.Value.GetType();
-            writer.WriteProperty("Type", type, options);
+        var type = value.Value is Type ? typeof(Type) : value.Value.GetType();
+        writer.WriteProperty("Type", type, options);
 
-            writer.WriteProperty(nameof(RuleProperty.Value), value.Value, type, options);
-            writer.WriteEndObject();
-        }
+        writer.WriteProperty(nameof(RuleProperty.Value), value.Value, type, options);
+        writer.WriteEndObject();
     }
 }

--- a/src/NRules/NRules.Json/Converters/TypeConverter.cs
+++ b/src/NRules/NRules.Json/Converters/TypeConverter.cs
@@ -2,28 +2,27 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace NRules.Json.Converters
+namespace NRules.Json.Converters;
+
+internal class TypeConverter : JsonConverter<Type>
 {
-    internal class TypeConverter : JsonConverter<Type>
+    private readonly ITypeResolver _typeResolver;
+
+    public TypeConverter(ITypeResolver typeResolver)
     {
-        private readonly ITypeResolver _typeResolver;
+        _typeResolver = typeResolver;
+    }
 
-        public TypeConverter(ITypeResolver typeResolver)
-        {
-            _typeResolver = typeResolver;
-        }
+    public override Type Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var typeName = reader.GetString();
+        var type = _typeResolver.GetTypeFromName(typeName);
+        return type;
+    }
 
-        public override Type Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            var typeName = reader.GetString();
-            var type = _typeResolver.GetTypeFromName(typeName);
-            return type;
-        }
-
-        public override void Write(Utf8JsonWriter writer, Type value, JsonSerializerOptions options)
-        {
-            var typeName = _typeResolver.GetTypeName(value);
-            writer.WriteStringValue(typeName);
-        }
+    public override void Write(Utf8JsonWriter writer, Type value, JsonSerializerOptions options)
+    {
+        var typeName = _typeResolver.GetTypeName(value);
+        writer.WriteStringValue(typeName);
     }
 }

--- a/src/NRules/NRules.Json/NRules.Json.csproj
+++ b/src/NRules/NRules.Json/NRules.Json.csproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/NRules/NRules.Json/RuleSerializer.cs
+++ b/src/NRules/NRules.Json/RuleSerializer.cs
@@ -4,77 +4,76 @@ using System.Text.Json.Serialization;
 using NRules.Json.Converters;
 using NRules.RuleModel;
 
-namespace NRules.Json
+namespace NRules.Json;
+
+/// <summary>
+/// Provides functionality to serialize rules to JSON and deserialize JSON into rules.
+/// </summary>
+public static class RuleSerializer
 {
     /// <summary>
-    /// Provides functionality to serialize rules to JSON and deserialize JSON into rules.
+    /// Configures <see cref="JsonSerializerOptions"/>, so that it can be used with the
+    /// <see cref="JsonSerializer"/> to serialize <see cref="IRuleDefinition"/> objects to JSON
+    /// and deserialize JSON into <see cref="IRuleDefinition"/> objects.
     /// </summary>
-    public static class RuleSerializer
+    /// <param name="options"><see cref="JsonSerializerOptions"/> to configure for rules serialization.</param>
+    public static void Setup(JsonSerializerOptions options)
     {
-        /// <summary>
-        /// Configures <see cref="JsonSerializerOptions"/>, so that it can be used with the
-        /// <see cref="JsonSerializer"/> to serialize <see cref="IRuleDefinition"/> objects to JSON
-        /// and deserialize JSON into <see cref="IRuleDefinition"/> objects.
-        /// </summary>
-        /// <param name="options"><see cref="JsonSerializerOptions"/> to configure for rules serialization.</param>
-        public static void Setup(JsonSerializerOptions options)
-        {
-            Setup(options, GetDefaultTypeResolver());
-        }
+        Setup(options, GetDefaultTypeResolver());
+    }
 
-        /// <summary>
-        /// Configures <see cref="JsonSerializerOptions"/>, so that it can be used with the
-        /// <see cref="JsonSerializer"/> to serialize <see cref="IRuleDefinition"/> objects to JSON
-        /// and deserialize JSON into <see cref="IRuleDefinition"/> objects.
-        /// </summary>
-        /// <param name="options"><see cref="JsonSerializerOptions"/> to configure for rules serialization.</param>
-        /// <param name="typeResolver">Type resolver that converts CLR types to type names and type names to CLR types.</param>
-        public static void Setup(JsonSerializerOptions options, ITypeResolver typeResolver)
+    /// <summary>
+    /// Configures <see cref="JsonSerializerOptions"/>, so that it can be used with the
+    /// <see cref="JsonSerializer"/> to serialize <see cref="IRuleDefinition"/> objects to JSON
+    /// and deserialize JSON into <see cref="IRuleDefinition"/> objects.
+    /// </summary>
+    /// <param name="options"><see cref="JsonSerializerOptions"/> to configure for rules serialization.</param>
+    /// <param name="typeResolver">Type resolver that converts CLR types to type names and type names to CLR types.</param>
+    public static void Setup(JsonSerializerOptions options, ITypeResolver typeResolver)
+    {
+        foreach (var converter in GetConverters(typeResolver))
         {
-            foreach (var converter in GetConverters(typeResolver))
-            {
-                options.Converters.Add(converter);
-            }
+            options.Converters.Add(converter);
         }
+    }
 
-        /// <summary>
-        /// Creates custom JSON converters that can be used with <see cref="JsonSerializerOptions"/> and
-        /// <see cref="JsonSerializer"/> to serialize <see cref="IRuleDefinition"/> objects to JSON
-        /// and deserialize JSON into <see cref="IRuleDefinition"/> objects.
-        /// </summary>
-        /// <returns>Collection of JSON converters necessary for rules serialization.</returns>
-        public static IReadOnlyCollection<JsonConverter> GetConverters()
-        {
-            return GetConverters(GetDefaultTypeResolver());
-        }
+    /// <summary>
+    /// Creates custom JSON converters that can be used with <see cref="JsonSerializerOptions"/> and
+    /// <see cref="JsonSerializer"/> to serialize <see cref="IRuleDefinition"/> objects to JSON
+    /// and deserialize JSON into <see cref="IRuleDefinition"/> objects.
+    /// </summary>
+    /// <returns>Collection of JSON converters necessary for rules serialization.</returns>
+    public static IReadOnlyCollection<JsonConverter> GetConverters()
+    {
+        return GetConverters(GetDefaultTypeResolver());
+    }
 
-        /// <summary>
-        /// Creates custom JSON converters that can be used with <see cref="JsonSerializerOptions"/> and
-        /// <see cref="JsonSerializer"/> to serialize <see cref="IRuleDefinition"/> objects to JSON
-        /// and deserialize JSON into <see cref="IRuleDefinition"/> objects.
-        /// </summary>
-        /// <param name="typeResolver">Type resolver that converts CLR types to type names and type names to CLR types.</param>
-        /// <returns>Collection of JSON converters necessary for rules serialization.</returns>
-        public static IReadOnlyCollection<JsonConverter> GetConverters(ITypeResolver typeResolver)
+    /// <summary>
+    /// Creates custom JSON converters that can be used with <see cref="JsonSerializerOptions"/> and
+    /// <see cref="JsonSerializer"/> to serialize <see cref="IRuleDefinition"/> objects to JSON
+    /// and deserialize JSON into <see cref="IRuleDefinition"/> objects.
+    /// </summary>
+    /// <param name="typeResolver">Type resolver that converts CLR types to type names and type names to CLR types.</param>
+    /// <returns>Collection of JSON converters necessary for rules serialization.</returns>
+    public static IReadOnlyCollection<JsonConverter> GetConverters(ITypeResolver typeResolver)
+    {
+        var converters = new List<JsonConverter>()
         {
-            var converters = new List<JsonConverter>()
-            {
-                new TypeConverter(typeResolver),
-                new ExpressionConverter(),
-                new RuleDefinitionConverter(),
-                new RulePropertyConverter(),
-                new NamedExpressionElementConverter(),
-                new ActionElementConverter(),
-                new RuleElementConverter(),
-            };
-            return converters;
-        }
+            new TypeConverter(typeResolver),
+            new ExpressionConverter(),
+            new RuleDefinitionConverter(),
+            new RulePropertyConverter(),
+            new NamedExpressionElementConverter(),
+            new ActionElementConverter(),
+            new RuleElementConverter(),
+        };
+        return converters;
+    }
 
-        private static TypeResolver GetDefaultTypeResolver()
-        {
-            var typeResolver = new TypeResolver();
-            typeResolver.RegisterDefaultAliases();
-            return typeResolver;
-        }
+    private static TypeResolver GetDefaultTypeResolver()
+    {
+        var typeResolver = new TypeResolver();
+        typeResolver.RegisterDefaultAliases();
+        return typeResolver;
     }
 }

--- a/src/NRules/NRules.Json/TypeAliasResolver.cs
+++ b/src/NRules/NRules.Json/TypeAliasResolver.cs
@@ -1,46 +1,45 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace NRules.Json
+namespace NRules.Json;
+
+internal class TypeAliasResolver
 {
-    internal class TypeAliasResolver
+    private readonly Dictionary<string, Type> _aliasToTypeMap = new();
+    private readonly Dictionary<Type, string> _typeToAliasMap = new();
+
+    public bool TryGetAliasForType(Type type, out string alias)
     {
-        private readonly Dictionary<string, Type> _aliasToTypeMap = new();
-        private readonly Dictionary<Type, string> _typeToAliasMap = new();
+        return _typeToAliasMap.TryGetValue(type, out alias);
+    }
 
-        public bool TryGetAliasForType(Type type, out string alias)
-        {
-            return _typeToAliasMap.TryGetValue(type, out alias);
-        }
+    public bool TryGetTypeByAlias(string alias, out Type type)
+    {
+        return _aliasToTypeMap.TryGetValue(alias, out type);
+    }
 
-        public bool TryGetTypeByAlias(string alias, out Type type)
-        {
-            return _aliasToTypeMap.TryGetValue(alias, out type);
-        }
+    public void RegisterAlias(string alias, Type type)
+    {
+        _aliasToTypeMap[alias] = type;
+        _typeToAliasMap[type] = alias;
+    }
 
-        public void RegisterAlias(string alias, Type type)
-        {
-            _aliasToTypeMap[alias] = type;
-            _typeToAliasMap[type] = alias;
-        }
-
-        public void RegisterDefaultAliases()
-        {
-            RegisterAlias("bool", typeof(Boolean));
-            RegisterAlias("byte", typeof(Byte));
-            RegisterAlias("sbyte", typeof(SByte));
-            RegisterAlias("char", typeof(Char));
-            RegisterAlias("decimal", typeof(Decimal));
-            RegisterAlias("double", typeof(Double));
-            RegisterAlias("float", typeof(Single));
-            RegisterAlias("int", typeof(Int32));
-            RegisterAlias("uint", typeof(UInt32));
-            RegisterAlias("long", typeof(Int64));
-            RegisterAlias("ulong", typeof(UInt64));
-            RegisterAlias("short", typeof(Int16));
-            RegisterAlias("ushort", typeof(UInt16));
-            RegisterAlias("object", typeof(Object));
-            RegisterAlias("string", typeof(String));
-        }
+    public void RegisterDefaultAliases()
+    {
+        RegisterAlias("bool", typeof(Boolean));
+        RegisterAlias("byte", typeof(Byte));
+        RegisterAlias("sbyte", typeof(SByte));
+        RegisterAlias("char", typeof(Char));
+        RegisterAlias("decimal", typeof(Decimal));
+        RegisterAlias("double", typeof(Double));
+        RegisterAlias("float", typeof(Single));
+        RegisterAlias("int", typeof(Int32));
+        RegisterAlias("uint", typeof(UInt32));
+        RegisterAlias("long", typeof(Int64));
+        RegisterAlias("ulong", typeof(UInt64));
+        RegisterAlias("short", typeof(Int16));
+        RegisterAlias("ushort", typeof(UInt16));
+        RegisterAlias("object", typeof(Object));
+        RegisterAlias("string", typeof(String));
     }
 }

--- a/src/NRules/NRules.Json/TypeCache.cs
+++ b/src/NRules/NRules.Json/TypeCache.cs
@@ -1,21 +1,20 @@
 ﻿using System;
 using System.Collections.Concurrent;
 
-namespace NRules.Json
+namespace NRules.Json;
+
+internal class TypeCache
 {
-    internal class TypeCache
+    private readonly ConcurrentDictionary<string, Type> _nameToTypeCache = new();
+    private readonly ConcurrentDictionary<Type, string> _typeToNameCache = new();
+
+    public string GetTypeName(Type type, Func<Type, string> fallback)
     {
-        private readonly ConcurrentDictionary<string, Type> _nameToTypeCache = new();
-        private readonly ConcurrentDictionary<Type, string> _typeToNameCache = new();
+        return _typeToNameCache.GetOrAdd(type, fallback);
+    }
 
-        public string GetTypeName(Type type, Func<Type, string> fallback)
-        {
-            return _typeToNameCache.GetOrAdd(type, fallback);
-        }
-
-        public Type GetTypeFromName(string typeName, Func<string, Type> fallback)
-        {
-            return _nameToTypeCache.GetOrAdd(typeName, fallback);
-        }
+    public Type GetTypeFromName(string typeName, Func<string, Type> fallback)
+    {
+        return _nameToTypeCache.GetOrAdd(typeName, fallback);
     }
 }

--- a/src/NRules/NRules.Json/TypeResolver.cs
+++ b/src/NRules/NRules.Json/TypeResolver.cs
@@ -2,120 +2,119 @@
 using System.Reflection;
 using NRules.Json.Utilities;
 
-namespace NRules.Json
+namespace NRules.Json;
+
+/// <summary>
+/// Defines the methods that enable conversion of CLR types to type names
+/// and type names to CLR types for the purpose of JSON serialization.
+/// </summary>
+public interface ITypeResolver
 {
     /// <summary>
-    /// Defines the methods that enable conversion of CLR types to type names
-    /// and type names to CLR types for the purpose of JSON serialization.
+    /// Gets the name of the type from the CLR type, for the purpose of JSON serialization.
     /// </summary>
-    public interface ITypeResolver
-    {
-        /// <summary>
-        /// Gets the name of the type from the CLR type, for the purpose of JSON serialization.
-        /// </summary>
-        /// <param name="type">CLR type.</param>
-        /// <returns>String representation of the CLR type.</returns>
-        string GetTypeName(Type type);
+    /// <param name="type">CLR type.</param>
+    /// <returns>String representation of the CLR type.</returns>
+    string GetTypeName(Type type);
 
-        /// <summary>
-        /// Gets the CLR type that corresponds to the type name, retrieved from the JSON document.
-        /// </summary>
-        /// <param name="typeName">String representation of the CLR type.</param>
-        /// <returns>CLR type that corresponds to the string representation.</returns>
-        Type GetTypeFromName(string typeName);
+    /// <summary>
+    /// Gets the CLR type that corresponds to the type name, retrieved from the JSON document.
+    /// </summary>
+    /// <param name="typeName">String representation of the CLR type.</param>
+    /// <returns>CLR type that corresponds to the string representation.</returns>
+    Type GetTypeFromName(string typeName);
+}
+
+/// <summary>
+/// Default <see cref="ITypeResolver"/> that uses assembly-qualified type names
+/// and supports type aliases.
+/// </summary>
+public class TypeResolver : ITypeResolver
+{
+    private readonly TypeAliasResolver _aliasResolver = new();
+    private readonly TypeCache _cache = new();
+
+    /// <summary><inheritdoc/></summary>
+    public string GetTypeName(Type type)
+    {
+        return _cache.GetTypeName(type, GetAssemblyQualifiedTypeName);
+    }
+
+    private string GetAssemblyQualifiedTypeName(Type type)
+    {
+        var typeName = InternalGetTypeName(type);
+        return TypeNameFormatter.ConstructAssemblyQualifiedTypeName(typeName);
+    }
+
+    private TypeName InternalGetTypeName(Type type)
+    {
+        if (_aliasResolver.TryGetAliasForType(type, out var alias))
+            return new TypeName(alias);
+        
+        if (type.IsArray)
+        {
+            var elementType = type.GetElementType();
+            var elementTypeName = InternalGetTypeName(elementType);
+            return TypeNameFormatter.ConstructArrayTypeName(elementTypeName, type.GetArrayRank());
+        }
+
+        if (type.IsConstructedGenericType)
+        {
+            var definitionType = type.GetGenericTypeDefinition();
+            var definitionTypeName = InternalGetTypeName(definitionType);
+
+            var typeArguments = type.GenericTypeArguments;
+            var typeArgumentNames = new TypeName[typeArguments.Length];
+            for (int i = 0; i < typeArguments.Length; i++)
+            {
+                typeArgumentNames[i] = InternalGetTypeName(typeArguments[i]);
+            }
+
+            return TypeNameFormatter.ConstructGenericTypeName(definitionTypeName, typeArgumentNames);
+        }
+
+        return new TypeName(type);
+    }
+
+    /// <summary><inheritdoc/></summary>
+    public Type GetTypeFromName(string typeName)
+    {
+        return _cache.GetTypeFromName(typeName, GetType);
+    }
+
+    private Type GetType(string typeName)
+    {
+        var type = Type.GetType(typeName, null, ResolveType, throwOnError: false, ignoreCase: false);
+        if (type == null)
+            throw new ArgumentException($"Unrecognized type name. Type={typeName}");
+        return type;
+    }
+
+    private Type ResolveType(Assembly assembly, string typeName, bool ignoreCase)
+    {
+        if (_aliasResolver.TryGetTypeByAlias(typeName, out var type))
+            return type;
+
+        if (assembly != null)
+            return assembly.GetType(typeName, throwOnError: false, ignoreCase);
+        return Type.GetType(typeName, throwOnError: false, ignoreCase);
     }
 
     /// <summary>
-    /// Default <see cref="ITypeResolver"/> that uses assembly-qualified type names
-    /// and supports type aliases.
+    /// Registers an alias for a CLR type for the purpose of JSON serialization.
     /// </summary>
-    public class TypeResolver : ITypeResolver
+    /// <param name="alias">String representation of the CLR type.</param>
+    /// <param name="type">CLR type.</param>
+    public void RegisterAlias(string alias, Type type)
     {
-        private readonly TypeAliasResolver _aliasResolver = new();
-        private readonly TypeCache _cache = new();
+        _aliasResolver.RegisterAlias(alias, type);
+    }
 
-        /// <summary><inheritdoc/></summary>
-        public string GetTypeName(Type type)
-        {
-            return _cache.GetTypeName(type, GetAssemblyQualifiedTypeName);
-        }
-
-        private string GetAssemblyQualifiedTypeName(Type type)
-        {
-            var typeName = InternalGetTypeName(type);
-            return TypeNameFormatter.ConstructAssemblyQualifiedTypeName(typeName);
-        }
-
-        private TypeName InternalGetTypeName(Type type)
-        {
-            if (_aliasResolver.TryGetAliasForType(type, out var alias))
-                return new TypeName(alias);
-            
-            if (type.IsArray)
-            {
-                var elementType = type.GetElementType();
-                var elementTypeName = InternalGetTypeName(elementType);
-                return TypeNameFormatter.ConstructArrayTypeName(elementTypeName, type.GetArrayRank());
-            }
-
-            if (type.IsConstructedGenericType)
-            {
-                var definitionType = type.GetGenericTypeDefinition();
-                var definitionTypeName = InternalGetTypeName(definitionType);
-
-                var typeArguments = type.GenericTypeArguments;
-                var typeArgumentNames = new TypeName[typeArguments.Length];
-                for (int i = 0; i < typeArguments.Length; i++)
-                {
-                    typeArgumentNames[i] = InternalGetTypeName(typeArguments[i]);
-                }
-
-                return TypeNameFormatter.ConstructGenericTypeName(definitionTypeName, typeArgumentNames);
-            }
-
-            return new TypeName(type);
-        }
-
-        /// <summary><inheritdoc/></summary>
-        public Type GetTypeFromName(string typeName)
-        {
-            return _cache.GetTypeFromName(typeName, GetType);
-        }
-
-        private Type GetType(string typeName)
-        {
-            var type = Type.GetType(typeName, null, ResolveType, throwOnError: false, ignoreCase: false);
-            if (type == null)
-                throw new ArgumentException($"Unrecognized type name. Type={typeName}");
-            return type;
-        }
-
-        private Type ResolveType(Assembly assembly, string typeName, bool ignoreCase)
-        {
-            if (_aliasResolver.TryGetTypeByAlias(typeName, out var type))
-                return type;
-
-            if (assembly != null)
-                return assembly.GetType(typeName, throwOnError: false, ignoreCase);
-            return Type.GetType(typeName, throwOnError: false, ignoreCase);
-        }
-
-        /// <summary>
-        /// Registers an alias for a CLR type for the purpose of JSON serialization.
-        /// </summary>
-        /// <param name="alias">String representation of the CLR type.</param>
-        /// <param name="type">CLR type.</param>
-        public void RegisterAlias(string alias, Type type)
-        {
-            _aliasResolver.RegisterAlias(alias, type);
-        }
-
-        /// <summary>
-        /// Registers built-in C# types as aliases for rule serialization.
-        /// </summary>
-        public void RegisterDefaultAliases()
-        {
-            _aliasResolver.RegisterDefaultAliases();
-        }
+    /// <summary>
+    /// Registers built-in C# types as aliases for rule serialization.
+    /// </summary>
+    public void RegisterDefaultAliases()
+    {
+        _aliasResolver.RegisterDefaultAliases();
     }
 }

--- a/src/NRules/NRules.Json/Utilities/ExpressionExtensions.cs
+++ b/src/NRules/NRules.Json/Utilities/ExpressionExtensions.cs
@@ -1,23 +1,22 @@
 ﻿using System;
 using System.Linq.Expressions;
 
-namespace NRules.Json.Utilities
-{
-    internal static class ExpressionExtensions
-    {
-        public static Type GetImpliedDelegateType(this LambdaExpression value)
-        {
-            var parameterTypes = new Type[value.Parameters.Count + 1];
-            for (int i = 0; i < value.Parameters.Count; i++)
-            {
-                var parameter = value.Parameters[i];
-                var parameterType = parameter.IsByRef ? parameter.Type.MakeByRefType() : parameter.Type;
-                parameterTypes[i] = parameterType;
-            }
+namespace NRules.Json.Utilities;
 
-            parameterTypes[value.Parameters.Count] = value.Body.Type;
-            var impliedDelegateType = Expression.GetDelegateType(parameterTypes);
-            return impliedDelegateType;
+internal static class ExpressionExtensions
+{
+    public static Type GetImpliedDelegateType(this LambdaExpression value)
+    {
+        var parameterTypes = new Type[value.Parameters.Count + 1];
+        for (int i = 0; i < value.Parameters.Count; i++)
+        {
+            var parameter = value.Parameters[i];
+            var parameterType = parameter.IsByRef ? parameter.Type.MakeByRefType() : parameter.Type;
+            parameterTypes[i] = parameterType;
         }
+
+        parameterTypes[value.Parameters.Count] = value.Body.Type;
+        var impliedDelegateType = Expression.GetDelegateType(parameterTypes);
+        return impliedDelegateType;
     }
 }

--- a/src/NRules/NRules.Json/Utilities/ExpressionParameterCompactor.cs
+++ b/src/NRules/NRules.Json/Utilities/ExpressionParameterCompactor.cs
@@ -2,25 +2,24 @@
 using System.Linq;
 using System.Linq.Expressions;
 
-namespace NRules.Json.Utilities
+namespace NRules.Json.Utilities;
+
+internal class ExpressionParameterCompactor : ExpressionVisitor
 {
-    internal class ExpressionParameterCompactor : ExpressionVisitor
+    private Dictionary<string, ParameterExpression> _parameterMap;
+
+    public LambdaExpression Compact(LambdaExpression lambdaExpression)
     {
-        private Dictionary<string, ParameterExpression> _parameterMap;
+        _parameterMap = lambdaExpression.Parameters.ToDictionary(p => p.Name);
+        var result = Visit(lambdaExpression);
+        return (LambdaExpression) result;
+    }
 
-        public LambdaExpression Compact(LambdaExpression lambdaExpression)
-        {
-            _parameterMap = lambdaExpression.Parameters.ToDictionary(p => p.Name);
-            var result = Visit(lambdaExpression);
-            return (LambdaExpression) result;
-        }
+    protected override Expression VisitParameter(ParameterExpression node)
+    {
+        if (_parameterMap.TryGetValue(node.Name, out var lambdaParameter))
+            return lambdaParameter;
 
-        protected override Expression VisitParameter(ParameterExpression node)
-        {
-            if (_parameterMap.TryGetValue(node.Name, out var lambdaParameter))
-                return lambdaParameter;
-
-            return base.VisitParameter(node);
-        }
+        return base.VisitParameter(node);
     }
 }

--- a/src/NRules/NRules.Json/Utilities/JsonExtensions.cs
+++ b/src/NRules/NRules.Json/Utilities/JsonExtensions.cs
@@ -2,324 +2,323 @@
 using System.Collections.Generic;
 using System.Text.Json;
 
-namespace NRules.Json.Utilities
+namespace NRules.Json.Utilities;
+
+internal static class JsonExtensions
 {
-    internal static class JsonExtensions
+    public static void ReadStartObject(this ref Utf8JsonReader reader)
     {
-        public static void ReadStartObject(this ref Utf8JsonReader reader)
-        {
-            if (reader.TokenType != JsonTokenType.StartObject)
-                throw new JsonException($"Expected start of object. Actual={reader.TokenType}");
-            reader.Read();
-        }
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException($"Expected start of object. Actual={reader.TokenType}");
+        reader.Read();
+    }
 
-        public static void ReadEndObject(this ref Utf8JsonReader reader)
-        {
-            if (reader.TokenType != JsonTokenType.EndObject)
-                throw new JsonException($"Expected end of object. Actual={reader.TokenType}");
-            reader.Read();
-        }
+    public static void ReadEndObject(this ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType != JsonTokenType.EndObject)
+            throw new JsonException($"Expected end of object. Actual={reader.TokenType}");
+        reader.Read();
+    }
 
-        public static void ReadStartArray(this ref Utf8JsonReader reader)
-        {
-            if (reader.TokenType != JsonTokenType.StartArray)
-                throw new JsonException($"Expected start of array. Actual={reader.TokenType}");
-            reader.Read();
-        }
+    public static void ReadStartArray(this ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType != JsonTokenType.StartArray)
+            throw new JsonException($"Expected start of array. Actual={reader.TokenType}");
+        reader.Read();
+    }
 
-        public static void ReadPropertyName(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options)
-        {
-            if (!reader.TryReadPropertyName(name, options))
-                throw new JsonException($"Expected property. Name={name}");
-        }
+    public static void ReadPropertyName(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options)
+    {
+        if (!reader.TryReadPropertyName(name, options))
+            throw new JsonException($"Expected property. Name={name}");
+    }
 
-        public static bool TryReadPropertyName(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options)
-        {
-            if (reader.TokenType == JsonTokenType.EndObject ||
-                reader.TokenType == JsonTokenType.EndArray)
-                return false;
+    public static bool TryReadPropertyName(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.EndObject ||
+            reader.TokenType == JsonTokenType.EndArray)
+            return false;
 
-            if (reader.TokenType != JsonTokenType.PropertyName)
-                throw new JsonException($"Expected property. Name={name}, Actual={reader.TokenType}");
+        if (reader.TokenType != JsonTokenType.PropertyName)
+            throw new JsonException($"Expected property. Name={name}, Actual={reader.TokenType}");
 
-            var propertyName = reader.GetString();
-            if (!name.NameEquals(propertyName, options))
-                return false;
+        var propertyName = reader.GetString();
+        if (!name.NameEquals(propertyName, options))
+            return false;
 
-            reader.Read();
-            
-            return true;
-        }
-
-        public static string ReadStringProperty(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options)
-        {
-            reader.ReadPropertyName(name, options);
-            
-            string value = reader.GetString();
-            reader.Read();
-            
-            return value;
-        }
-
-        public static bool TryReadStringProperty(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, out string value)
-        {
-            value = default;
-            if (!reader.TryReadPropertyName(name, options))
-                return false;
-            
-            value = reader.GetString();
-            reader.Read();
-            
-            return true;
-        }
-
-        public static int ReadInt32Property(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options)
-        {
-            reader.ReadPropertyName(name, options);
-            
-            int value = reader.GetInt32();
-            reader.Read();
-            
-            return value;
-        }
-
-        public static bool TryReadInt32Property(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, out int value)
-        {
-            value = default;
-            if (!reader.TryReadPropertyName(name, options))
-                return false;
-            
-            value = reader.GetInt32();
-            reader.Read();
-            
-            return true;
-        }
-
-        public static TEnum ReadEnumProperty<TEnum>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options) where TEnum : struct
-        {
-            reader.ReadPropertyName(name, options);
-            
-            return reader.ReadEnum<TEnum>(options);
-        }
-
-        public static bool TryReadEnumProperty<TEnum>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, out TEnum value) where TEnum : struct
-        {
-            value = default;
-            if (!reader.TryReadPropertyName(name, options))
-                return false;
-            
-            value = reader.ReadEnum<TEnum>(options);
-            
-            return true;
-        }
-
-        public static TEnum ReadEnum<TEnum>(this ref Utf8JsonReader reader, JsonSerializerOptions options) where TEnum : struct
-        {
-            var rawValue = reader.GetString();
-            if (!Enum.TryParse(rawValue, ignoreCase: false, out TEnum value) &&
-                !Enum.TryParse(rawValue, ignoreCase: true, out value))
-                throw new JsonException($"Unable to convert Enum value. Value={rawValue}, EnumType={typeof(TEnum)}");
-            reader.Read();
-            
-            return value;
-        }
-
-        public delegate TElement YieldElement<out TElement>(ref Utf8JsonReader reader, JsonSerializerOptions options);
-
-        public static IReadOnlyCollection<TElement> ReadObjectArrayProperty<TElement>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, YieldElement<TElement> elementReader)
-        {
-            reader.ReadPropertyName(name, options);
-            
-            return reader.ReadObjectArray(options, elementReader);
-        }
-
-        public static bool TryReadObjectArrayProperty<TElement>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, YieldElement<TElement> elementReader, out IReadOnlyCollection<TElement> value)
-        {
-            value = Array.Empty<TElement>();
-            if (!reader.TryReadPropertyName(name, options))
-                return false;
-            
-            value = reader.ReadObjectArray(options, elementReader);
-            
-            return true;
-        }
-
-        private static IReadOnlyCollection<TElement> ReadObjectArray<TElement>(this ref Utf8JsonReader reader, JsonSerializerOptions options, YieldElement<TElement> elementReader)
-        {
-            reader.ReadStartArray();
-            
-            var elements = new List<TElement>();
-            while (reader.TokenType != JsonTokenType.EndArray)
-            {
-                reader.ReadStartObject();
-
-                var element = elementReader(ref reader, options);
-                elements.Add(element);
-
-                reader.ReadEndObject();
-            }
-            reader.Read();
-            
-            return elements;
-        }
-
-        public static IReadOnlyCollection<TElement> ReadArrayProperty<TElement>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options)
-        {
-            reader.ReadPropertyName(name, options);
-            
-            return reader.ReadArray<TElement>(options);
-        }
-
-        public static bool TryReadArrayProperty<TElement>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, out IReadOnlyCollection<TElement> value)
-        {
-            value = Array.Empty<TElement>();
-            if (!reader.TryReadPropertyName(name, options))
-                return false;
-            
-            value = reader.ReadArray<TElement>(options);
-            
-            return true;
-        }
-
-        public static bool TryReadArrayProperty(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, out string[] value)
-        {
-            value = Array.Empty<string>();
-            if (!reader.TryReadPropertyName(name, options))
-                return false;
-
-            reader.ReadStartArray();
-            
-            var elements = new List<string>();
-            while (reader.TokenType != JsonTokenType.EndArray)
-            {
-                var element = reader.GetString();
-                elements.Add(element);
-                reader.Read();
-            }
-            reader.Read();
-            
-            value = elements.ToArray();
-            return true;
-        }
-
-        public static IReadOnlyCollection<TElement> ReadArray<TElement>(this ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            reader.ReadStartArray();
-            
-            var elements = new List<TElement>();
-            while (reader.TokenType != JsonTokenType.EndArray)
-            {
-                var element = JsonSerializer.Deserialize<TElement>(ref reader, options);
-                elements.Add(element);
-                reader.Read();
-            }
-            reader.Read();
-            
-            return elements;
-        }
-
-        public static TElement ReadProperty<TElement>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options)
-        {
-            reader.ReadPropertyName(name, options);
-
-            var value = JsonSerializer.Deserialize<TElement>(ref reader, options);
-            reader.Read();
-
-            return value;
-        }
-
-        public static object ReadProperty(this ref Utf8JsonReader reader, string name, Type type, JsonSerializerOptions options)
-        {
-            reader.ReadPropertyName(name, options);
-
-            var value = JsonSerializer.Deserialize(ref reader, type, options);
-            reader.Read();
-
-            return value;
-        }
-
-        public static bool TryReadProperty<TElement>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, out TElement value)
-        {
-            value = default;
-            if (!reader.TryReadPropertyName(name, options))
-                return false;
-
-            value = JsonSerializer.Deserialize<TElement>(ref reader, options);
-            reader.Read();
-
-            return true;
-        }
-
-        public static void WriteStringProperty(this Utf8JsonWriter writer, string name, string value, JsonSerializerOptions options)
-        {
-            writer.WriteString(name.ToName(options), value);
-        }
-
-        public static void WriteNumberProperty(this Utf8JsonWriter writer, string name, int value, JsonSerializerOptions options)
-        {
-            writer.WriteNumber(name.ToName(options), value);
-        }
-
-        public static void WriteEnumProperty<TEnum>(this Utf8JsonWriter writer, string name, TEnum value, JsonSerializerOptions options) where TEnum: struct
-        {
-            writer.WriteString(name.ToName(options), value.ToString());
-        }
-
-        public static void WriteArrayProperty<TElement>(this Utf8JsonWriter writer, string name, IEnumerable<TElement> elements, JsonSerializerOptions options)
-        {
-            writer.WriteStartArray(name.ToName(options));
-            foreach (var element in elements)
-            {
-                JsonSerializer.Serialize(writer, element, options);
-            }
-            writer.WriteEndArray();
-        }
-
-        public static void WriteArrayProperty(this Utf8JsonWriter writer, string name, IEnumerable<string> elements, JsonSerializerOptions options)
-        {
-            writer.WriteStartArray(name.ToName(options));
-            foreach (var element in elements)
-            {
-                writer.WriteStringValue(element);
-            }
-            writer.WriteEndArray();
-        }
+        reader.Read();
         
-        public static void WriteObjectArrayProperty<TElement>(this Utf8JsonWriter writer, string name, IEnumerable<TElement> elements, JsonSerializerOptions options, Action<TElement> elementAction)
-        {
-            writer.WriteStartArray(name.ToName(options));
-            foreach (var element in elements)
-            {
-                writer.WriteStartObject();
-                elementAction(element);
-                writer.WriteEndObject();
-            }
-            writer.WriteEndArray();
-        }
+        return true;
+    }
 
-        public static void WriteProperty<TValue>(this Utf8JsonWriter writer, string name, TValue value, JsonSerializerOptions options)
-        {
-            writer.WritePropertyName(name.ToName(options));
-            JsonSerializer.Serialize(writer, value, options);
-        }
+    public static string ReadStringProperty(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options)
+    {
+        reader.ReadPropertyName(name, options);
+        
+        string value = reader.GetString();
+        reader.Read();
+        
+        return value;
+    }
 
-        public static void WriteProperty(this Utf8JsonWriter writer, string name, object value, Type valueType, JsonSerializerOptions options)
-        {
-            writer.WritePropertyName(name.ToName(options));
-            JsonSerializer.Serialize(writer, value, valueType, options);
-        }
+    public static bool TryReadStringProperty(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, out string value)
+    {
+        value = default;
+        if (!reader.TryReadPropertyName(name, options))
+            return false;
+        
+        value = reader.GetString();
+        reader.Read();
+        
+        return true;
+    }
 
-        private static string ToName(this string name, JsonSerializerOptions options)
-        {
-            return options?.PropertyNamingPolicy?.ConvertName(name) ?? name;
-        }
+    public static int ReadInt32Property(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options)
+    {
+        reader.ReadPropertyName(name, options);
+        
+        int value = reader.GetInt32();
+        reader.Read();
+        
+        return value;
+    }
 
-        private static bool NameEquals(this string rawExpectedName, string rawActualName, JsonSerializerOptions options)
+    public static bool TryReadInt32Property(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, out int value)
+    {
+        value = default;
+        if (!reader.TryReadPropertyName(name, options))
+            return false;
+        
+        value = reader.GetInt32();
+        reader.Read();
+        
+        return true;
+    }
+
+    public static TEnum ReadEnumProperty<TEnum>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options) where TEnum : struct
+    {
+        reader.ReadPropertyName(name, options);
+        
+        return reader.ReadEnum<TEnum>(options);
+    }
+
+    public static bool TryReadEnumProperty<TEnum>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, out TEnum value) where TEnum : struct
+    {
+        value = default;
+        if (!reader.TryReadPropertyName(name, options))
+            return false;
+        
+        value = reader.ReadEnum<TEnum>(options);
+        
+        return true;
+    }
+
+    public static TEnum ReadEnum<TEnum>(this ref Utf8JsonReader reader, JsonSerializerOptions options) where TEnum : struct
+    {
+        var rawValue = reader.GetString();
+        if (!Enum.TryParse(rawValue, ignoreCase: false, out TEnum value) &&
+            !Enum.TryParse(rawValue, ignoreCase: true, out value))
+            throw new JsonException($"Unable to convert Enum value. Value={rawValue}, EnumType={typeof(TEnum)}");
+        reader.Read();
+        
+        return value;
+    }
+
+    public delegate TElement YieldElement<out TElement>(ref Utf8JsonReader reader, JsonSerializerOptions options);
+
+    public static IReadOnlyCollection<TElement> ReadObjectArrayProperty<TElement>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, YieldElement<TElement> elementReader)
+    {
+        reader.ReadPropertyName(name, options);
+        
+        return reader.ReadObjectArray(options, elementReader);
+    }
+
+    public static bool TryReadObjectArrayProperty<TElement>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, YieldElement<TElement> elementReader, out IReadOnlyCollection<TElement> value)
+    {
+        value = Array.Empty<TElement>();
+        if (!reader.TryReadPropertyName(name, options))
+            return false;
+        
+        value = reader.ReadObjectArray(options, elementReader);
+        
+        return true;
+    }
+
+    private static IReadOnlyCollection<TElement> ReadObjectArray<TElement>(this ref Utf8JsonReader reader, JsonSerializerOptions options, YieldElement<TElement> elementReader)
+    {
+        reader.ReadStartArray();
+        
+        var elements = new List<TElement>();
+        while (reader.TokenType != JsonTokenType.EndArray)
         {
-            var comparisonType = options?.PropertyNameCaseInsensitive ?? false
-                ? StringComparison.CurrentCultureIgnoreCase
-                : StringComparison.CurrentCulture;
-            return string.Equals(rawExpectedName.ToName(options), rawActualName.ToName(options), comparisonType);
+            reader.ReadStartObject();
+
+            var element = elementReader(ref reader, options);
+            elements.Add(element);
+
+            reader.ReadEndObject();
         }
+        reader.Read();
+        
+        return elements;
+    }
+
+    public static IReadOnlyCollection<TElement> ReadArrayProperty<TElement>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options)
+    {
+        reader.ReadPropertyName(name, options);
+        
+        return reader.ReadArray<TElement>(options);
+    }
+
+    public static bool TryReadArrayProperty<TElement>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, out IReadOnlyCollection<TElement> value)
+    {
+        value = Array.Empty<TElement>();
+        if (!reader.TryReadPropertyName(name, options))
+            return false;
+        
+        value = reader.ReadArray<TElement>(options);
+        
+        return true;
+    }
+
+    public static bool TryReadArrayProperty(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, out string[] value)
+    {
+        value = Array.Empty<string>();
+        if (!reader.TryReadPropertyName(name, options))
+            return false;
+
+        reader.ReadStartArray();
+        
+        var elements = new List<string>();
+        while (reader.TokenType != JsonTokenType.EndArray)
+        {
+            var element = reader.GetString();
+            elements.Add(element);
+            reader.Read();
+        }
+        reader.Read();
+        
+        value = elements.ToArray();
+        return true;
+    }
+
+    public static IReadOnlyCollection<TElement> ReadArray<TElement>(this ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        reader.ReadStartArray();
+        
+        var elements = new List<TElement>();
+        while (reader.TokenType != JsonTokenType.EndArray)
+        {
+            var element = JsonSerializer.Deserialize<TElement>(ref reader, options);
+            elements.Add(element);
+            reader.Read();
+        }
+        reader.Read();
+        
+        return elements;
+    }
+
+    public static TElement ReadProperty<TElement>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options)
+    {
+        reader.ReadPropertyName(name, options);
+
+        var value = JsonSerializer.Deserialize<TElement>(ref reader, options);
+        reader.Read();
+
+        return value;
+    }
+
+    public static object ReadProperty(this ref Utf8JsonReader reader, string name, Type type, JsonSerializerOptions options)
+    {
+        reader.ReadPropertyName(name, options);
+
+        var value = JsonSerializer.Deserialize(ref reader, type, options);
+        reader.Read();
+
+        return value;
+    }
+
+    public static bool TryReadProperty<TElement>(this ref Utf8JsonReader reader, string name, JsonSerializerOptions options, out TElement value)
+    {
+        value = default;
+        if (!reader.TryReadPropertyName(name, options))
+            return false;
+
+        value = JsonSerializer.Deserialize<TElement>(ref reader, options);
+        reader.Read();
+
+        return true;
+    }
+
+    public static void WriteStringProperty(this Utf8JsonWriter writer, string name, string value, JsonSerializerOptions options)
+    {
+        writer.WriteString(name.ToName(options), value);
+    }
+
+    public static void WriteNumberProperty(this Utf8JsonWriter writer, string name, int value, JsonSerializerOptions options)
+    {
+        writer.WriteNumber(name.ToName(options), value);
+    }
+
+    public static void WriteEnumProperty<TEnum>(this Utf8JsonWriter writer, string name, TEnum value, JsonSerializerOptions options) where TEnum: struct
+    {
+        writer.WriteString(name.ToName(options), value.ToString());
+    }
+
+    public static void WriteArrayProperty<TElement>(this Utf8JsonWriter writer, string name, IEnumerable<TElement> elements, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray(name.ToName(options));
+        foreach (var element in elements)
+        {
+            JsonSerializer.Serialize(writer, element, options);
+        }
+        writer.WriteEndArray();
+    }
+
+    public static void WriteArrayProperty(this Utf8JsonWriter writer, string name, IEnumerable<string> elements, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray(name.ToName(options));
+        foreach (var element in elements)
+        {
+            writer.WriteStringValue(element);
+        }
+        writer.WriteEndArray();
+    }
+    
+    public static void WriteObjectArrayProperty<TElement>(this Utf8JsonWriter writer, string name, IEnumerable<TElement> elements, JsonSerializerOptions options, Action<TElement> elementAction)
+    {
+        writer.WriteStartArray(name.ToName(options));
+        foreach (var element in elements)
+        {
+            writer.WriteStartObject();
+            elementAction(element);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
+    }
+
+    public static void WriteProperty<TValue>(this Utf8JsonWriter writer, string name, TValue value, JsonSerializerOptions options)
+    {
+        writer.WritePropertyName(name.ToName(options));
+        JsonSerializer.Serialize(writer, value, options);
+    }
+
+    public static void WriteProperty(this Utf8JsonWriter writer, string name, object value, Type valueType, JsonSerializerOptions options)
+    {
+        writer.WritePropertyName(name.ToName(options));
+        JsonSerializer.Serialize(writer, value, valueType, options);
+    }
+
+    private static string ToName(this string name, JsonSerializerOptions options)
+    {
+        return options?.PropertyNamingPolicy?.ConvertName(name) ?? name;
+    }
+
+    private static bool NameEquals(this string rawExpectedName, string rawActualName, JsonSerializerOptions options)
+    {
+        var comparisonType = options?.PropertyNameCaseInsensitive ?? false
+            ? StringComparison.CurrentCultureIgnoreCase
+            : StringComparison.CurrentCulture;
+        return string.Equals(rawExpectedName.ToName(options), rawActualName.ToName(options), comparisonType);
     }
 }

--- a/src/NRules/NRules.Json/Utilities/TypeName.cs
+++ b/src/NRules/NRules.Json/Utilities/TypeName.cs
@@ -1,28 +1,27 @@
 ﻿using System;
 using System.Reflection;
 
-namespace NRules.Json.Utilities
+namespace NRules.Json.Utilities;
+
+internal class TypeName
 {
-    internal class TypeName
+    public TypeName(Type type)
     {
-        public TypeName(Type type)
-        {
-            FullName = type.FullName;
-            AssemblyName = type.Assembly.GetName();
-        }
-
-        public TypeName(string typeFullName)
-            : this(typeFullName, null)
-        {
-        }
-
-        public TypeName(string typeFullName, AssemblyName assemblyName)
-        {
-            FullName = typeFullName;
-            AssemblyName = assemblyName;
-        }
-
-        public string FullName { get; }
-        public AssemblyName AssemblyName { get; }
+        FullName = type.FullName;
+        AssemblyName = type.Assembly.GetName();
     }
+
+    public TypeName(string typeFullName)
+        : this(typeFullName, null)
+    {
+    }
+
+    public TypeName(string typeFullName, AssemblyName assemblyName)
+    {
+        FullName = typeFullName;
+        AssemblyName = assemblyName;
+    }
+
+    public string FullName { get; }
+    public AssemblyName AssemblyName { get; }
 }

--- a/src/NRules/NRules.Json/Utilities/TypeNameFormatter.cs
+++ b/src/NRules/NRules.Json/Utilities/TypeNameFormatter.cs
@@ -2,45 +2,44 @@
 using System.Reflection;
 using System.Text;
 
-namespace NRules.Json.Utilities
+namespace NRules.Json.Utilities;
+
+internal static class TypeNameFormatter
 {
-    internal static class TypeNameFormatter
+    private static readonly HashSet<string> SystemAssemblyNames = new() { "mscorlib", "System.Core", "System.Private.CoreLib" };
+
+    public static string ConstructAssemblyQualifiedTypeName(TypeName typeName)
     {
-        private static readonly HashSet<string> SystemAssemblyNames = new() { "mscorlib", "System.Core", "System.Private.CoreLib" };
-
-        public static string ConstructAssemblyQualifiedTypeName(TypeName typeName)
+        if (typeName.FullName == null ||
+            typeName.AssemblyName == null ||
+            SystemAssemblyNames.Contains(typeName.AssemblyName.Name)) return typeName.FullName;
+        return Assembly.CreateQualifiedName(typeName.AssemblyName.FullName, typeName.FullName);
+    }
+    
+    public static TypeName ConstructGenericTypeName(TypeName definitionTypeName, TypeName[] typeArgumentNames)
+    {
+        var sb = new StringBuilder(definitionTypeName.FullName);
+        sb.Append('[');
+        for (var i = 0; i < typeArgumentNames.Length; i++)
         {
-            if (typeName.FullName == null ||
-                typeName.AssemblyName == null ||
-                SystemAssemblyNames.Contains(typeName.AssemblyName.Name)) return typeName.FullName;
-            return Assembly.CreateQualifiedName(typeName.AssemblyName.FullName, typeName.FullName);
-        }
-        
-        public static TypeName ConstructGenericTypeName(TypeName definitionTypeName, TypeName[] typeArgumentNames)
-        {
-            var sb = new StringBuilder(definitionTypeName.FullName);
+            if (i > 0) sb.Append(',');
             sb.Append('[');
-            for (var i = 0; i < typeArgumentNames.Length; i++)
-            {
-                if (i > 0) sb.Append(',');
-                sb.Append('[');
-                sb.Append(ConstructAssemblyQualifiedTypeName(typeArgumentNames[i]));
-                sb.Append(']');
-            }
+            sb.Append(ConstructAssemblyQualifiedTypeName(typeArgumentNames[i]));
             sb.Append(']');
-            return new TypeName(sb.ToString(), definitionTypeName.AssemblyName);
         }
+        sb.Append(']');
+        return new TypeName(sb.ToString(), definitionTypeName.AssemblyName);
+    }
 
-        public static TypeName ConstructArrayTypeName(TypeName elementTypeName, int arrayRank)
+    public static TypeName ConstructArrayTypeName(TypeName elementTypeName, int arrayRank)
+    {
+        var sb = new StringBuilder(elementTypeName.FullName);
+        sb.Append('[');
+        for (int i = 1; i < arrayRank; i++)
         {
-            var sb = new StringBuilder(elementTypeName.FullName);
-            sb.Append('[');
-            for (int i = 1; i < arrayRank; i++)
-            {
-                sb.Append(',');
-            }
-            sb.Append(']');
-            return new TypeName(sb.ToString(), elementTypeName.AssemblyName);
+            sb.Append(',');
         }
+        sb.Append(']');
+        return new TypeName(sb.ToString(), elementTypeName.AssemblyName);
     }
 }

--- a/src/NRules/NRules.RuleModel/ActionElement.cs
+++ b/src/NRules/NRules.RuleModel/ActionElement.cs
@@ -3,63 +3,62 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Activation events that trigger the actions.
+/// </summary>
+[Flags]
+public enum ActionTrigger
 {
     /// <summary>
-    /// Activation events that trigger the actions.
+    /// Action is not triggered.
     /// </summary>
-    [Flags]
-    public enum ActionTrigger
+    None = 0x0,
+
+    /// <summary>
+    /// Action is triggered when activation is created.
+    /// </summary>
+    Activated = 0x1,
+
+    /// <summary>
+    /// Action is triggered when activation is updated.
+    /// </summary>
+    Reactivated = 0x2,
+
+    /// <summary>
+    /// Action is triggered when activation is removed.
+    /// </summary>
+    Deactivated = 0x4,
+}
+
+/// <summary>
+/// Action executed by the engine when the rule fires.
+/// </summary>
+[DebuggerDisplay("{Expression.ToString()}")]
+public class ActionElement : ExpressionElement
+{
+    /// <summary>
+    /// Default value for action trigger.
+    /// </summary>
+    public const ActionTrigger DefaultTrigger = ActionTrigger.Activated | ActionTrigger.Reactivated;
+    
+    internal ActionElement(LambdaExpression expression, ActionTrigger actionTrigger)
+        : base(expression, expression.Parameters.Skip(1))
     {
-        /// <summary>
-        /// Action is not triggered.
-        /// </summary>
-        None = 0x0,
-
-        /// <summary>
-        /// Action is triggered when activation is created.
-        /// </summary>
-        Activated = 0x1,
-
-        /// <summary>
-        /// Action is triggered when activation is updated.
-        /// </summary>
-        Reactivated = 0x2,
-
-        /// <summary>
-        /// Action is triggered when activation is removed.
-        /// </summary>
-        Deactivated = 0x4,
+        ActionTrigger = actionTrigger;
     }
 
     /// <summary>
-    /// Action executed by the engine when the rule fires.
+    /// Activation events that trigger this action.
     /// </summary>
-    [DebuggerDisplay("{Expression.ToString()}")]
-    public class ActionElement : ExpressionElement
+    public ActionTrigger ActionTrigger { get; }
+
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.Action;
+
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
     {
-        /// <summary>
-        /// Default value for action trigger.
-        /// </summary>
-        public const ActionTrigger DefaultTrigger = ActionTrigger.Activated | ActionTrigger.Reactivated;
-        
-        internal ActionElement(LambdaExpression expression, ActionTrigger actionTrigger)
-            : base(expression, expression.Parameters.Skip(1))
-        {
-            ActionTrigger = actionTrigger;
-        }
-
-        /// <summary>
-        /// Activation events that trigger this action.
-        /// </summary>
-        public ActionTrigger ActionTrigger { get; }
-
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.Action;
-
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitAction(context, this);
-        }
+        visitor.VisitAction(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/ActionGroupElement.cs
+++ b/src/NRules/NRules.RuleModel/ActionGroupElement.cs
@@ -1,32 +1,31 @@
 using System.Collections.Generic;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Rule element that groups actions that run when the rule fires.
+/// </summary>
+public class ActionGroupElement : RuleElement
 {
-    /// <summary>
-    /// Rule element that groups actions that run when the rule fires.
-    /// </summary>
-    public class ActionGroupElement : RuleElement
+    private readonly List<ActionElement> _actions;
+
+    internal ActionGroupElement(IEnumerable<ActionElement> actions)
     {
-        private readonly List<ActionElement> _actions;
+        _actions = new List<ActionElement>(actions);
 
-        internal ActionGroupElement(IEnumerable<ActionElement> actions)
-        {
-            _actions = new List<ActionElement>(actions);
+        AddImports(_actions);
+    }
 
-            AddImports(_actions);
-        }
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.ActionGroup;
 
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.ActionGroup;
+    /// <summary>
+    /// List of actions the group element contains.
+    /// </summary>
+    public IEnumerable<ActionElement> Actions => _actions;
 
-        /// <summary>
-        /// List of actions the group element contains.
-        /// </summary>
-        public IEnumerable<ActionElement> Actions => _actions;
-
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitActionGroup(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitActionGroup(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/AggregateElement.cs
+++ b/src/NRules/NRules.RuleModel/AggregateElement.cs
@@ -1,67 +1,66 @@
 using System;
 using System.Linq;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Rule element that creates new facts (aggregates) based on matching facts it receives as input.
+/// </summary>
+public class AggregateElement : RuleElement
 {
+    public const string CollectName = "Collect";
+    public const string GroupByName = "GroupBy";
+    public const string ProjectName = "Project";
+    public const string FlattenName = "Flatten";
+
+    public const string SelectorName = "Selector";
+    public const string ElementSelectorName = "ElementSelector";
+    public const string KeySelectorName = "KeySelector";
+    public const string KeySelectorAscendingName = "KeySelectorAscending";
+    public const string KeySelectorDescendingName = "KeySelectorDescending";
+
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.Aggregate;
+
     /// <summary>
-    /// Rule element that creates new facts (aggregates) based on matching facts it receives as input.
+    /// Type of the result that this rule element yields.
     /// </summary>
-    public class AggregateElement : RuleElement
+    public Type ResultType { get; }
+
+    /// <summary>
+    /// Fact source of the aggregate.
+    /// </summary>
+    public PatternElement Source { get; }
+
+    /// <summary>
+    /// Aggregate name.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// The type of custom aggregator factory.
+    /// </summary>
+    public Type CustomFactoryType { get; }
+
+    /// <summary>
+    /// Expressions used by the aggregate.
+    /// </summary>
+    public ExpressionCollection Expressions { get; }
+
+    internal AggregateElement(Type resultType, string name, ExpressionCollection expressions, PatternElement source, Type customFactoryType)
     {
-        public const string CollectName = "Collect";
-        public const string GroupByName = "GroupBy";
-        public const string ProjectName = "Project";
-        public const string FlattenName = "Flatten";
+        ResultType = resultType;
+        Name = name;
+        Expressions = expressions;
+        Source = source;
+        CustomFactoryType = customFactoryType;
 
-        public const string SelectorName = "Selector";
-        public const string ElementSelectorName = "ElementSelector";
-        public const string KeySelectorName = "KeySelector";
-        public const string KeySelectorAscendingName = "KeySelectorAscending";
-        public const string KeySelectorDescendingName = "KeySelectorDescending";
+        AddImports(source);
+        AddImports(expressions.SelectMany(x => x.Imports.Except(source.Exports)));
+    }
 
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.Aggregate;
-
-        /// <summary>
-        /// Type of the result that this rule element yields.
-        /// </summary>
-        public Type ResultType { get; }
-
-        /// <summary>
-        /// Fact source of the aggregate.
-        /// </summary>
-        public PatternElement Source { get; }
-
-        /// <summary>
-        /// Aggregate name.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// The type of custom aggregator factory.
-        /// </summary>
-        public Type CustomFactoryType { get; }
-
-        /// <summary>
-        /// Expressions used by the aggregate.
-        /// </summary>
-        public ExpressionCollection Expressions { get; }
-
-        internal AggregateElement(Type resultType, string name, ExpressionCollection expressions, PatternElement source, Type customFactoryType)
-        {
-            ResultType = resultType;
-            Name = name;
-            Expressions = expressions;
-            Source = source;
-            CustomFactoryType = customFactoryType;
-
-            AddImports(source);
-            AddImports(expressions.SelectMany(x => x.Imports.Except(source.Exports)));
-        }
-
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitAggregate(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitAggregate(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/AndElement.cs
+++ b/src/NRules/NRules.RuleModel/AndElement.cs
@@ -1,23 +1,22 @@
 using System.Collections.Generic;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Grouping element based on the logical AND condition.
+/// </summary>
+public class AndElement : GroupElement
 {
-    /// <summary>
-    /// Grouping element based on the logical AND condition.
-    /// </summary>
-    public class AndElement : GroupElement
+    internal AndElement(IEnumerable<RuleElement> childElements)
+        : base(childElements)
     {
-        internal AndElement(IEnumerable<RuleElement> childElements)
-            : base(childElements)
-        {
-        }
+    }
 
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.And;
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.And;
 
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitAnd(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitAnd(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/BindingElement.cs
+++ b/src/NRules/NRules.RuleModel/BindingElement.cs
@@ -1,30 +1,29 @@
 ﻿using System;
 using System.Linq.Expressions;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Rule element that represents results of an expression.
+/// </summary>
+public class BindingElement : ExpressionElement
 {
-    /// <summary>
-    /// Rule element that represents results of an expression.
-    /// </summary>
-    public class BindingElement : ExpressionElement
+    internal BindingElement(Type resultType, LambdaExpression expression) 
+        : base(expression)
     {
-        internal BindingElement(Type resultType, LambdaExpression expression) 
-            : base(expression)
-        {
-            ResultType = resultType;
-        }
+        ResultType = resultType;
+    }
 
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.Binding;
-        
-        /// <summary>
-        /// Type of the result that this rule element yields.
-        /// </summary>
-        public Type ResultType { get; }
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.Binding;
+    
+    /// <summary>
+    /// Type of the result that this rule element yields.
+    /// </summary>
+    public Type ResultType { get; }
 
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitBinding(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitBinding(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/ActionGroupBuilder.cs
+++ b/src/NRules/NRules.RuleModel/Builders/ActionGroupBuilder.cs
@@ -1,51 +1,50 @@
 ﻿using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+/// <summary>
+/// Builder to compose a group of rule actions.
+/// </summary>
+public class ActionGroupBuilder : RuleElementBuilder, IBuilder<ActionGroupElement>
 {
+    private readonly List<ActionElement> _actions = new();
+
     /// <summary>
-    /// Builder to compose a group of rule actions.
+    /// Initializes a new instance of the <see cref="ActionGroupBuilder"/>.
     /// </summary>
-    public class ActionGroupBuilder : RuleElementBuilder, IBuilder<ActionGroupElement>
+    public ActionGroupBuilder()
     {
-        private readonly List<ActionElement> _actions = new();
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ActionGroupBuilder"/>.
-        /// </summary>
-        public ActionGroupBuilder()
-        {
-        }
+    /// <summary>
+    /// Adds a rule action to the group element.
+    /// The action will be executed on new and updated rule activations.
+    /// </summary>
+    /// <param name="expression">Rule action expression.
+    /// The first parameter of the action expression must be <see cref="IContext"/>.
+    /// Names and types of the rest of the expression parameters must match the names and types defined in the pattern declarations.</param>
+    public void Action(LambdaExpression expression)
+    {
+        Action(expression, ActionElement.DefaultTrigger);
+    }
 
-        /// <summary>
-        /// Adds a rule action to the group element.
-        /// The action will be executed on new and updated rule activations.
-        /// </summary>
-        /// <param name="expression">Rule action expression.
-        /// The first parameter of the action expression must be <see cref="IContext"/>.
-        /// Names and types of the rest of the expression parameters must match the names and types defined in the pattern declarations.</param>
-        public void Action(LambdaExpression expression)
-        {
-            Action(expression, ActionElement.DefaultTrigger);
-        }
+    /// <summary>
+    /// Adds a rule action to the group element.
+    /// </summary>
+    /// <param name="expression">Rule action expression.
+    /// The first parameter of the action expression must be <see cref="IContext"/>.
+    /// Names and types of the rest of the expression parameters must match the names and types defined in the pattern declarations.</param>
+    /// <param name="actionTrigger">Activation events that trigger the action.</param>
+    public void Action(LambdaExpression expression, ActionTrigger actionTrigger)
+    {
+        var actionElement = Element.Action(expression, actionTrigger);
+        _actions.Add(actionElement);
+    }
 
-        /// <summary>
-        /// Adds a rule action to the group element.
-        /// </summary>
-        /// <param name="expression">Rule action expression.
-        /// The first parameter of the action expression must be <see cref="IContext"/>.
-        /// Names and types of the rest of the expression parameters must match the names and types defined in the pattern declarations.</param>
-        /// <param name="actionTrigger">Activation events that trigger the action.</param>
-        public void Action(LambdaExpression expression, ActionTrigger actionTrigger)
-        {
-            var actionElement = Element.Action(expression, actionTrigger);
-            _actions.Add(actionElement);
-        }
-
-        ActionGroupElement IBuilder<ActionGroupElement>.Build()
-        {
-            var actionGroup = Element.ActionGroup(_actions);
-            return actionGroup;
-        }
+    ActionGroupElement IBuilder<ActionGroupElement>.Build()
+    {
+        var actionGroup = Element.ActionGroup(_actions);
+        return actionGroup;
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/AggregateBuilder.cs
+++ b/src/NRules/NRules.RuleModel/Builders/AggregateBuilder.cs
@@ -2,182 +2,181 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+/// <summary>
+/// Builder to compose an aggregate element.
+/// </summary>
+public class AggregateBuilder : RuleElementBuilder, IBuilder<AggregateElement>
 {
+    private string _name;
+    private Type _resultType;
+    private readonly List<KeyValuePair<string, LambdaExpression>> _expressions = new();
+    private Type _customFactoryType;
+    private IBuilder<PatternElement> _sourceBuilder;
+
     /// <summary>
-    /// Builder to compose an aggregate element.
+    /// Initializes a new instance of the <see cref="AggregateBuilder"/>.
     /// </summary>
-    public class AggregateBuilder : RuleElementBuilder, IBuilder<AggregateElement>
+    public AggregateBuilder()
     {
-        private string _name;
-        private Type _resultType;
-        private readonly List<KeyValuePair<string, LambdaExpression>> _expressions = new();
-        private Type _customFactoryType;
-        private IBuilder<PatternElement> _sourceBuilder;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AggregateBuilder"/>.
-        /// </summary>
-        public AggregateBuilder()
+    /// <summary>
+    /// Sets type of the result produced by the aggregation.
+    /// </summary>
+    /// <param name="resultType">Type of the result.</param>
+    public void ResultType(Type resultType)
+    {
+        _resultType = resultType;
+    }
+
+    /// <summary>
+    /// Configure a custom aggregator.
+    /// </summary>
+    /// <param name="name">Name of the aggregator.</param>
+    /// <param name="expressions">Named expressions used by the aggregator.</param>
+    /// <param name="customFactoryType">The type of the custom aggregate factory</param>
+    public void Aggregator(string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, Type customFactoryType = null)
+    {
+        _name = name;
+        _expressions.AddRange(expressions);
+        _customFactoryType = customFactoryType;
+    }
+
+    /// <summary>
+    /// Configure a collection aggregator.
+    /// </summary>
+    public void Collect()
+    {
+        _name = AggregateElement.CollectName;
+    }
+
+    /// <summary>
+    /// Configure <see cref="Collect"/> aggregator to order facts by key.
+    /// </summary>
+    /// <param name="keySelector">Key selection expression.</param>
+    /// <param name="sortDirection">Order to sort the aggregation in.</param>
+    public void OrderBy(LambdaExpression keySelector, SortDirection sortDirection)
+    {
+        if (_name != AggregateElement.CollectName)
+            throw new InvalidOperationException(
+                $"{nameof(OrderBy)} can only be applied to {AggregateElement.CollectName} aggregate");
+
+        var expressionName = sortDirection == SortDirection.Ascending ? AggregateElement.KeySelectorAscendingName : AggregateElement.KeySelectorDescendingName;
+        AddExpression(expressionName, keySelector);
+    }
+
+    /// <summary>
+    /// Configure <see cref="Collect"/> aggregator to arrange facts into a lookup, grouped by key.
+    /// </summary>
+    /// <param name="keySelector">Grouping key selection expressions.</param>
+    /// <param name="elementSelector">Element selection expression.</param>
+    public void ToLookup(LambdaExpression keySelector, LambdaExpression elementSelector)
+    {
+        if (_name != AggregateElement.CollectName)
+            throw new InvalidOperationException(
+                $"{nameof(ToLookup)} can only be applied to {AggregateElement.CollectName} aggregate");
+
+        AddExpression(AggregateElement.KeySelectorName, keySelector);
+        AddExpression(AggregateElement.ElementSelectorName, elementSelector);
+    }
+
+    /// <summary>
+    /// Configure group by aggregator.
+    /// </summary>
+    /// <param name="keySelector">Grouping key selection expressions.</param>
+    /// <param name="elementSelector">Element selection expression.</param>
+    public void GroupBy(LambdaExpression keySelector, LambdaExpression elementSelector)
+    {
+        _name = AggregateElement.GroupByName;
+        AddExpression(AggregateElement.KeySelectorName, keySelector);
+        AddExpression(AggregateElement.ElementSelectorName, elementSelector);
+    }
+
+    /// <summary>
+    /// Configure projection aggregator.
+    /// </summary>
+    /// <param name="selector">Projection expression.</param>
+    public void Project(LambdaExpression selector)
+    {
+        _name = AggregateElement.ProjectName;
+        AddExpression(AggregateElement.SelectorName, selector);
+    }
+
+    /// <summary>
+    /// Configure flattening aggregator.
+    /// </summary>
+    /// <param name="selector">Projection expression.</param>
+    public void Flatten(LambdaExpression selector)
+    {
+        _name = AggregateElement.FlattenName;
+        AddExpression(AggregateElement.SelectorName, selector);
+    }
+
+    /// <summary>
+    /// Creates a pattern builder that builds the source of the aggregate.
+    /// Sets a pattern element as the source of the aggregate element.
+    /// </summary>
+    /// <param name="element">Element to set as the source.</param>
+    public void Pattern(PatternElement element)
+    {
+        AssertSingleSource();
+        _sourceBuilder = BuilderAdapter.Create(element);
+    }
+
+    /// <summary>
+    /// Sets a pattern builder as the source of the aggregate element.
+    /// </summary>
+    /// <param name="builder">Element builder to set as the source.</param>
+    public void Pattern(PatternBuilder builder)
+    {
+        AssertSingleSource();
+        _sourceBuilder = builder;
+    }
+
+    /// <summary>
+    /// Creates a pattern builder that builds the source of the aggregate element.
+    /// </summary>
+    /// <param name="type">Type of the element the pattern matches.</param>
+    /// <param name="name">Pattern name (optional).</param>
+    /// <returns>Pattern builder.</returns>
+    public PatternBuilder Pattern(Type type, string name = null)
+    {
+        var declaration = Element.Declaration(type, DeclarationName(name));
+        return Pattern(declaration);
+    }
+
+    /// <summary>
+    /// Creates a pattern builder that builds the source of the aggregate element.
+    /// </summary>
+    /// <param name="declaration">Pattern declaration.</param>
+    /// <returns>Pattern builder.</returns>
+    public PatternBuilder Pattern(Declaration declaration)
+    {
+        AssertSingleSource();
+        var sourceBuilder = new PatternBuilder(declaration);
+        _sourceBuilder = sourceBuilder;
+        return sourceBuilder;
+    }
+
+    AggregateElement IBuilder<AggregateElement>.Build()
+    {
+        PatternElement sourceElement = _sourceBuilder?.Build();
+        AggregateElement aggregateElement = Element.Aggregate(_resultType, _name, _expressions, sourceElement, _customFactoryType);
+        return aggregateElement;
+    }
+
+    private void AddExpression(string name, LambdaExpression expression)
+    {
+        _expressions.Add(new KeyValuePair<string, LambdaExpression>(name, expression));
+    }
+
+    private void AssertSingleSource()
+    {
+        if (_sourceBuilder != null)
         {
-        }
-
-        /// <summary>
-        /// Sets type of the result produced by the aggregation.
-        /// </summary>
-        /// <param name="resultType">Type of the result.</param>
-        public void ResultType(Type resultType)
-        {
-            _resultType = resultType;
-        }
-
-        /// <summary>
-        /// Configure a custom aggregator.
-        /// </summary>
-        /// <param name="name">Name of the aggregator.</param>
-        /// <param name="expressions">Named expressions used by the aggregator.</param>
-        /// <param name="customFactoryType">The type of the custom aggregate factory</param>
-        public void Aggregator(string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, Type customFactoryType = null)
-        {
-            _name = name;
-            _expressions.AddRange(expressions);
-            _customFactoryType = customFactoryType;
-        }
-
-        /// <summary>
-        /// Configure a collection aggregator.
-        /// </summary>
-        public void Collect()
-        {
-            _name = AggregateElement.CollectName;
-        }
-
-        /// <summary>
-        /// Configure <see cref="Collect"/> aggregator to order facts by key.
-        /// </summary>
-        /// <param name="keySelector">Key selection expression.</param>
-        /// <param name="sortDirection">Order to sort the aggregation in.</param>
-        public void OrderBy(LambdaExpression keySelector, SortDirection sortDirection)
-        {
-            if (_name != AggregateElement.CollectName)
-                throw new InvalidOperationException(
-                    $"{nameof(OrderBy)} can only be applied to {AggregateElement.CollectName} aggregate");
-
-            var expressionName = sortDirection == SortDirection.Ascending ? AggregateElement.KeySelectorAscendingName : AggregateElement.KeySelectorDescendingName;
-            AddExpression(expressionName, keySelector);
-        }
-
-        /// <summary>
-        /// Configure <see cref="Collect"/> aggregator to arrange facts into a lookup, grouped by key.
-        /// </summary>
-        /// <param name="keySelector">Grouping key selection expressions.</param>
-        /// <param name="elementSelector">Element selection expression.</param>
-        public void ToLookup(LambdaExpression keySelector, LambdaExpression elementSelector)
-        {
-            if (_name != AggregateElement.CollectName)
-                throw new InvalidOperationException(
-                    $"{nameof(ToLookup)} can only be applied to {AggregateElement.CollectName} aggregate");
-
-            AddExpression(AggregateElement.KeySelectorName, keySelector);
-            AddExpression(AggregateElement.ElementSelectorName, elementSelector);
-        }
-
-        /// <summary>
-        /// Configure group by aggregator.
-        /// </summary>
-        /// <param name="keySelector">Grouping key selection expressions.</param>
-        /// <param name="elementSelector">Element selection expression.</param>
-        public void GroupBy(LambdaExpression keySelector, LambdaExpression elementSelector)
-        {
-            _name = AggregateElement.GroupByName;
-            AddExpression(AggregateElement.KeySelectorName, keySelector);
-            AddExpression(AggregateElement.ElementSelectorName, elementSelector);
-        }
-
-        /// <summary>
-        /// Configure projection aggregator.
-        /// </summary>
-        /// <param name="selector">Projection expression.</param>
-        public void Project(LambdaExpression selector)
-        {
-            _name = AggregateElement.ProjectName;
-            AddExpression(AggregateElement.SelectorName, selector);
-        }
-
-        /// <summary>
-        /// Configure flattening aggregator.
-        /// </summary>
-        /// <param name="selector">Projection expression.</param>
-        public void Flatten(LambdaExpression selector)
-        {
-            _name = AggregateElement.FlattenName;
-            AddExpression(AggregateElement.SelectorName, selector);
-        }
-
-        /// <summary>
-        /// Creates a pattern builder that builds the source of the aggregate.
-        /// Sets a pattern element as the source of the aggregate element.
-        /// </summary>
-        /// <param name="element">Element to set as the source.</param>
-        public void Pattern(PatternElement element)
-        {
-            AssertSingleSource();
-            _sourceBuilder = BuilderAdapter.Create(element);
-        }
-
-        /// <summary>
-        /// Sets a pattern builder as the source of the aggregate element.
-        /// </summary>
-        /// <param name="builder">Element builder to set as the source.</param>
-        public void Pattern(PatternBuilder builder)
-        {
-            AssertSingleSource();
-            _sourceBuilder = builder;
-        }
-
-        /// <summary>
-        /// Creates a pattern builder that builds the source of the aggregate element.
-        /// </summary>
-        /// <param name="type">Type of the element the pattern matches.</param>
-        /// <param name="name">Pattern name (optional).</param>
-        /// <returns>Pattern builder.</returns>
-        public PatternBuilder Pattern(Type type, string name = null)
-        {
-            var declaration = Element.Declaration(type, DeclarationName(name));
-            return Pattern(declaration);
-        }
-
-        /// <summary>
-        /// Creates a pattern builder that builds the source of the aggregate element.
-        /// </summary>
-        /// <param name="declaration">Pattern declaration.</param>
-        /// <returns>Pattern builder.</returns>
-        public PatternBuilder Pattern(Declaration declaration)
-        {
-            AssertSingleSource();
-            var sourceBuilder = new PatternBuilder(declaration);
-            _sourceBuilder = sourceBuilder;
-            return sourceBuilder;
-        }
-
-        AggregateElement IBuilder<AggregateElement>.Build()
-        {
-            PatternElement sourceElement = _sourceBuilder?.Build();
-            AggregateElement aggregateElement = Element.Aggregate(_resultType, _name, _expressions, sourceElement, _customFactoryType);
-            return aggregateElement;
-        }
-
-        private void AddExpression(string name, LambdaExpression expression)
-        {
-            _expressions.Add(new KeyValuePair<string, LambdaExpression>(name, expression));
-        }
-
-        private void AssertSingleSource()
-        {
-            if (_sourceBuilder != null)
-            {
-                throw new InvalidOperationException("Aggregate element can only have a single source");
-            }
+            throw new InvalidOperationException("Aggregate element can only have a single source");
         }
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/BindingBuilder.cs
+++ b/src/NRules/NRules.RuleModel/Builders/BindingBuilder.cs
@@ -1,47 +1,46 @@
 ﻿using System;
 using System.Linq.Expressions;
 
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+/// <summary>
+/// Builder to compose a binding expression element.
+/// </summary>
+public class BindingBuilder : RuleElementBuilder, IBuilder<BindingElement>
 {
+    private Type _resultType;
+    private LambdaExpression _expression;
+
     /// <summary>
-    /// Builder to compose a binding expression element.
+    /// Initializes a new instance of the <see cref="BindingBuilder"/>.
     /// </summary>
-    public class BindingBuilder : RuleElementBuilder, IBuilder<BindingElement>
+    public BindingBuilder()
     {
-        private Type _resultType;
-        private LambdaExpression _expression;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BindingBuilder"/>.
-        /// </summary>
-        public BindingBuilder()
-        {
-        }
+    /// <summary>
+    /// Sets type of the result produced by the binding expression.
+    /// If not provided, this is set to the return type of the binding expression.
+    /// </summary>
+    /// <param name="resultType">Type of the result.</param>
+    public void ResultType(Type resultType)
+    {
+        _resultType = resultType;
+    }
 
-        /// <summary>
-        /// Sets type of the result produced by the binding expression.
-        /// If not provided, this is set to the return type of the binding expression.
-        /// </summary>
-        /// <param name="resultType">Type of the result.</param>
-        public void ResultType(Type resultType)
-        {
-            _resultType = resultType;
-        }
+    /// <summary>
+    /// Sets a calculated expression on the binding element.
+    /// </summary>
+    /// <param name="expression">Expression to bind.</param>
+    public void BindingExpression(LambdaExpression expression)
+    {
+        _expression = expression;
+    }
 
-        /// <summary>
-        /// Sets a calculated expression on the binding element.
-        /// </summary>
-        /// <param name="expression">Expression to bind.</param>
-        public void BindingExpression(LambdaExpression expression)
-        {
-            _expression = expression;
-        }
-
-        BindingElement IBuilder<BindingElement>.Build()
-        {
-            var resultType = _resultType ?? _expression?.ReturnType;
-            var element = Element.Binding(resultType, _expression);
-            return element;
-        }
+    BindingElement IBuilder<BindingElement>.Build()
+    {
+        var resultType = _resultType ?? _expression?.ReturnType;
+        var element = Element.Binding(resultType, _expression);
+        return element;
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/BuilderAdapter.cs
+++ b/src/NRules/NRules.RuleModel/Builders/BuilderAdapter.cs
@@ -1,27 +1,26 @@
-﻿namespace NRules.RuleModel.Builders
+﻿namespace NRules.RuleModel.Builders;
+
+internal static class BuilderAdapter
 {
-    internal static class BuilderAdapter
-    {
-        public static BuilderAdapter<T> Create<T>(T element)
-            where T : RuleElement
-        {
-            return new BuilderAdapter<T>(element);
-        }
-    }
-    
-    internal class BuilderAdapter<T> : RuleElementBuilder, IBuilder<T>
+    public static BuilderAdapter<T> Create<T>(T element)
         where T : RuleElement
     {
-        private readonly T _element;
+        return new BuilderAdapter<T>(element);
+    }
+}
 
-        public BuilderAdapter(T element)
-        {
-            _element = element;
-        }
+internal class BuilderAdapter<T> : RuleElementBuilder, IBuilder<T>
+    where T : RuleElement
+{
+    private readonly T _element;
 
-        public T Build()
-        {
-            return _element;
-        }
+    public BuilderAdapter(T element)
+    {
+        _element = element;
+    }
+
+    public T Build()
+    {
+        return _element;
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/DependencyGroupBuilder.cs
+++ b/src/NRules/NRules.RuleModel/Builders/DependencyGroupBuilder.cs
@@ -1,48 +1,47 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+/// <summary>
+/// Builder to compose a group of rule dependencies.
+/// </summary>
+public class DependencyGroupBuilder : RuleElementBuilder, IBuilder<DependencyGroupElement>
 {
+    private readonly List<DependencyElement> _dependencies = new();
+
     /// <summary>
-    /// Builder to compose a group of rule dependencies.
+    /// Initializes a new instance of the <see cref="DependencyGroupBuilder"/>.
     /// </summary>
-    public class DependencyGroupBuilder : RuleElementBuilder, IBuilder<DependencyGroupElement>
+    public DependencyGroupBuilder()
     {
-        private readonly List<DependencyElement> _dependencies = new();
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DependencyGroupBuilder"/>.
-        /// </summary>
-        public DependencyGroupBuilder()
-        {
-        }
+    /// <summary>
+    /// Adds a dependency element to the group element.
+    /// </summary>
+    /// <param name="element">Element to add.</param>
+    public void Dependency(DependencyElement element)
+    {
+        _dependencies.Add(element);
+    }
 
-        /// <summary>
-        /// Adds a dependency element to the group element.
-        /// </summary>
-        /// <param name="element">Element to add.</param>
-        public void Dependency(DependencyElement element)
-        {
-            _dependencies.Add(element);
-        }
+    /// <summary>
+    /// Adds a dependency to the group element.
+    /// </summary>
+    /// <param name="type">Dependency CLR type.</param>
+    /// <param name="name">Dependency name.</param>
+    /// <returns>Dependency declaration.</returns>
+    public Declaration Dependency(Type type, string name)
+    {
+        var dependency = Element.Dependency(type, DeclarationName(name));
+        _dependencies.Add(dependency);
+        return dependency.Declaration;
+    }
 
-        /// <summary>
-        /// Adds a dependency to the group element.
-        /// </summary>
-        /// <param name="type">Dependency CLR type.</param>
-        /// <param name="name">Dependency name.</param>
-        /// <returns>Dependency declaration.</returns>
-        public Declaration Dependency(Type type, string name)
-        {
-            var dependency = Element.Dependency(type, DeclarationName(name));
-            _dependencies.Add(dependency);
-            return dependency.Declaration;
-        }
-
-        DependencyGroupElement IBuilder<DependencyGroupElement>.Build()
-        {
-            var dependencyGroup = Element.DependencyGroup(_dependencies);
-            return dependencyGroup;
-        }
+    DependencyGroupElement IBuilder<DependencyGroupElement>.Build()
+    {
+        var dependencyGroup = Element.DependencyGroup(_dependencies);
+        return dependencyGroup;
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/Element.cs
+++ b/src/NRules/NRules.RuleModel/Builders/Element.cs
@@ -3,746 +3,745 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+/// <summary>
+/// Factory class for rule elements.
+/// </summary>
+public static class Element
 {
     /// <summary>
-    /// Factory class for rule elements.
+    /// Creates a rule definition.
     /// </summary>
-    public static class Element
+    /// <param name="name">Rule's name.</param>
+    /// <param name="description">Rule's description.</param>
+    /// <param name="priority">Rule's priority.</param>
+    /// <param name="leftHandSide">Rule's left-hand side top group element.</param>
+    /// <param name="rightHandSide">Rule's right-hand side group element.</param>
+    /// <returns>Created rule definition.</returns>
+    public static IRuleDefinition RuleDefinition(string name, string description, int priority,
+        GroupElement leftHandSide, ActionGroupElement rightHandSide)
     {
-        /// <summary>
-        /// Creates a rule definition.
-        /// </summary>
-        /// <param name="name">Rule's name.</param>
-        /// <param name="description">Rule's description.</param>
-        /// <param name="priority">Rule's priority.</param>
-        /// <param name="leftHandSide">Rule's left-hand side top group element.</param>
-        /// <param name="rightHandSide">Rule's right-hand side group element.</param>
-        /// <returns>Created rule definition.</returns>
-        public static IRuleDefinition RuleDefinition(string name, string description, int priority,
-            GroupElement leftHandSide, ActionGroupElement rightHandSide)
+        var tags = Array.Empty<string>();
+        var ruleDefinition = RuleDefinition(name, description, priority, tags, leftHandSide, rightHandSide);
+        return ruleDefinition;
+    }
+
+    /// <summary>
+    /// Creates a rule definition.
+    /// </summary>
+    /// <param name="name">Rule's name.</param>
+    /// <param name="description">Rule's description.</param>
+    /// <param name="priority">Rule's priority.</param>
+    /// <param name="tags">Tags associated with the rule.</param>
+    /// <param name="leftHandSide">Rule's left-hand side top group element.</param>
+    /// <param name="rightHandSide">Rule's right-hand side group element.</param>
+    /// <returns>Created rule definition.</returns>
+    public static IRuleDefinition RuleDefinition(string name, string description, int priority,
+        IEnumerable<string> tags, GroupElement leftHandSide, ActionGroupElement rightHandSide)
+    {
+        var ruleProperties = Array.Empty<RuleProperty>();
+        var dependencyGroupElement = DependencyGroup();
+        var filterGroupElement = FilterGroup();
+        var ruleDefinition = RuleDefinition(name, description, priority, RuleRepeatability.Repeatable,
+            tags, ruleProperties, dependencyGroupElement, leftHandSide, filterGroupElement, rightHandSide);
+        return ruleDefinition;
+    }
+
+    /// <summary>
+    /// Creates a rule definition.
+    /// </summary>
+    /// <param name="name">Rule's name.</param>
+    /// <param name="description">Rule's description.</param>
+    /// <param name="priority">Rule's priority.</param>
+    /// <param name="repeatability">Rule's repeatability.</param>
+    /// <param name="tags">Tags associated with the rule.</param>
+    /// <param name="properties">Properties associated with the rule.</param>
+    /// <param name="dependencies">Rule's dependency group element.</param>
+    /// <param name="leftHandSide">Rule's left-hand side top group element.</param>
+    /// <param name="filters">Rule's filter group element.</param>
+    /// <param name="rightHandSide">Rule's right-hand side group element.</param>
+    /// <returns>Created rule definition.</returns>
+    public static IRuleDefinition RuleDefinition(string name, string description, int priority,
+        RuleRepeatability repeatability, IEnumerable<string> tags, IEnumerable<RuleProperty> properties,
+        DependencyGroupElement dependencies, GroupElement leftHandSide, FilterGroupElement filters, ActionGroupElement rightHandSide)
+    {
+        if (string.IsNullOrEmpty(name))
+            throw new ArgumentException("Rule name not provided", nameof(name));
+        if (tags == null)
+            throw new ArgumentNullException(nameof(tags), "Rule tags not provided");
+        if (properties == null)
+            throw new ArgumentNullException(nameof(properties), "Rule properties not provided");
+        if (dependencies == null)
+            throw new ArgumentNullException(nameof(dependencies), "Rule dependencies not provided");
+        if (leftHandSide == null)
+            throw new ArgumentNullException(nameof(leftHandSide), "Rule left-hand side not provided");
+        if (filters == null)
+            throw new ArgumentNullException(nameof(filters), "Rule filters not provided");
+        if (rightHandSide == null)
+            throw new ArgumentNullException(nameof(rightHandSide), "Rule right-hand side not provided");
+
+        var ruleDefinition = new RuleDefinition(name, description, priority, repeatability, tags, properties, dependencies, leftHandSide, filters, rightHandSide);
+
+        ElementValidator.ValidateUniqueDeclarations(ruleDefinition.LeftHandSide, ruleDefinition.DependencyGroup);
+        ElementValidator.ValidateRuleDefinition(ruleDefinition);
+
+        return ruleDefinition;
+    }
+
+    /// <summary>
+    /// Creates a dependency group element.
+    /// </summary>
+    /// <param name="dependencies">Dependency elements in the group.</param>
+    /// <returns>Created element.</returns>
+    /// <seealso cref="DependencyElement"/>
+    public static DependencyGroupElement DependencyGroup(params DependencyElement[] dependencies)
+    {
+        var element = DependencyGroup(dependencies.AsEnumerable());
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a dependency group element.
+    /// </summary>
+    /// <param name="dependencies">Dependency elements in the group.</param>
+    /// <returns>Created element.</returns>
+    /// <seealso cref="DependencyElement"/>
+    public static DependencyGroupElement DependencyGroup(IEnumerable<DependencyElement> dependencies)
+    {
+        if (dependencies == null)
+            throw new ArgumentNullException(nameof(dependencies), "Dependencies not provided");
+
+        var element = new DependencyGroupElement(dependencies);
+        ElementValidator.ValidateUniqueDeclarations(element.Dependencies);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a dependency element.
+    /// </summary>
+    /// <param name="type">Dependency type.</param>
+    /// <param name="name">Dependency name.</param>
+    /// <returns>Created element.</returns>
+    public static DependencyElement Dependency(Type type, string name)
+    {
+        var declaration = Declaration(type, name);
+        var element = Dependency(declaration, type);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a dependency element.
+    /// </summary>
+    /// <param name="declaration">Declaration that references the dependency.</param>
+    /// <param name="serviceType">Type of the service that the dependency represents.</param>
+    /// <returns>Created element.</returns>
+    public static DependencyElement Dependency(Declaration declaration, Type serviceType)
+    {
+        if (declaration == null)
+            throw new ArgumentNullException(nameof(declaration), "Dependency declaration not provided");
+        if (serviceType == null)
+            throw new ArgumentNullException(nameof(serviceType), "Dependency type not provided");
+
+        var element = new DependencyElement(declaration, serviceType);
+        declaration.Target = element;
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a left-hand side group element, that contains pattern elements and nested group elements.
+    /// </summary>
+    /// <param name="groupType">Type of the group element.</param>
+    /// <param name="childElements">Child elements contained in the group.</param>
+    /// <returns>Created element.</returns>
+    public static GroupElement Group(GroupType groupType, IEnumerable<RuleElement> childElements)
+    {
+        GroupElement element = groupType switch
         {
-            var tags = Array.Empty<string>();
-            var ruleDefinition = RuleDefinition(name, description, priority, tags, leftHandSide, rightHandSide);
-            return ruleDefinition;
+            GroupType.And => AndGroup(childElements),
+            GroupType.Or => OrGroup(childElements),
+            _ => throw new ArgumentException($"Unrecognized group type. GroupType={groupType}", nameof(groupType))
+        };
+
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a left-hand side group element that combines contained elements using an AND operator.
+    /// </summary>
+    /// <param name="childElements">Child elements contained in the group.</param>
+    /// <returns>Created element.</returns>
+    /// <see cref="RuleElement"/>
+    public static AndElement AndGroup(params RuleElement[] childElements)
+    {
+        var element = AndGroup(childElements.AsEnumerable());
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a left-hand side group element that combines contained elements using an AND operator.
+    /// </summary>
+    /// <param name="childElements">Child elements contained in the group.</param>
+    /// <returns>Created element.</returns>
+    /// <see cref="RuleElement"/>
+    public static AndElement AndGroup(IEnumerable<RuleElement> childElements)
+    {
+        if (childElements == null)
+            throw new ArgumentNullException(nameof(childElements), "Child elements not provided");
+
+        var element = new AndElement(childElements);
+        ElementValidator.ValidateGroup(element);
+        ElementValidator.ValidateUniqueDeclarations(element.ChildElements);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a left-hand side group element that combines contained elements using an OR operator.
+    /// </summary>
+    /// <param name="childElements">Child elements contained in the group.</param>
+    /// <returns>Created element.</returns>
+    /// <see cref="RuleElement"/>
+    public static OrElement OrGroup(params RuleElement[] childElements)
+    {
+        var element = OrGroup(childElements.AsEnumerable());
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a left-hand side group element that combines contained elements using an OR operator.
+    /// </summary>
+    /// <param name="childElements">Child elements contained in the group.</param>
+    /// <returns>Created element.</returns>
+    /// <see cref="RuleElement"/>
+    public static OrElement OrGroup(IEnumerable<RuleElement> childElements)
+    {
+        if (childElements == null)
+            throw new ArgumentNullException(nameof(childElements), "Child elements not provided");
+
+        var element = new OrElement(childElements);
+        ElementValidator.ValidateGroup(element);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates an element that represents an existential quantifier.
+    /// </summary>
+    /// <param name="source">Source element to apply the existential quantifier to.</param>
+    /// <returns>Created element.</returns>
+    /// <see cref="RuleElement"/>
+    public static ExistsElement Exists(RuleElement source)
+    {
+        if (source == null)
+            throw new ArgumentNullException(nameof(source), "Source element not provided");
+
+        var element = new ExistsElement(source);
+        ElementValidator.ValidateExists(element);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates an element that represents a negative existential quantifier.
+    /// </summary>
+    /// <param name="source">Source element to apply the negative existential quantifier to.</param>
+    /// <returns>Created element.</returns>
+    public static NotElement Not(RuleElement source)
+    {
+        if (source == null)
+            throw new ArgumentNullException(nameof(source), "Source element not provided");
+
+        var element = new NotElement(source);
+        ElementValidator.ValidateNot(element);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates an element that represents a universal quantifier.
+    /// Facts that match the <c>basePattern</c> must also match all other <c>patterns</c>.
+    /// </summary>
+    /// <param name="basePattern">Base patterns of the universal quantifier that defines the universe of facts to consider.</param>
+    /// <param name="patterns">Additional patterns of the universal quantifier that the fact matched by the base pattern must also satisfy.</param>
+    /// <returns>Created element.</returns>
+    public static ForAllElement ForAll(PatternElement basePattern, IEnumerable<PatternElement> patterns)
+    {
+        if (basePattern == null)
+            throw new ArgumentNullException(nameof(basePattern), "Base pattern not provided");
+        if (patterns == null)
+            throw new ArgumentNullException(nameof(patterns), "Patterns not provided");
+
+        var element = new ForAllElement(basePattern, patterns);
+        ElementValidator.ValidateForAll(element);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a pattern element that represents a match of facts in rules engine's working memory.
+    /// </summary>
+    /// <param name="type">Type of facts matched by the pattern.</param>
+    /// <param name="name">Pattern name.</param>
+    /// <param name="expressions">Expressions used by the pattern to match elements.</param>
+    /// <returns>Created element.</returns>
+    public static PatternElement Pattern(Type type, string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions)
+    {
+        var element = Pattern(type, name, expressions, null);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a pattern element that represents a match of facts in rules engine's working memory.
+    /// </summary>
+    /// <param name="declaration">Declaration that references the pattern.</param>
+    /// <param name="expressions">Expressions used by the pattern to match elements.</param>
+    /// <returns>Created element.</returns>
+    public static PatternElement Pattern(Declaration declaration, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions)
+    {
+        var element = Pattern(declaration, expressions, null);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a pattern element that represents a match over results of the source element.
+    /// </summary>
+    /// <param name="type">Type of elements matched by the pattern.</param>
+    /// <param name="name">Pattern name.</param>
+    /// <param name="expressions">Expressions used by the pattern to match elements.</param>
+    /// <param name="source">Source of the elements matched by the pattern. If it's <c>null</c>, the pattern matches facts in rules engine's working memory.</param>
+    /// <returns>Created element.</returns>
+    public static PatternElement Pattern(Type type, string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, RuleElement source)
+    {
+        var declaration = Declaration(type, name);
+        var element = Pattern(declaration, expressions, source);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a pattern element that represents a match over results of the source element.
+    /// </summary>
+    /// <param name="declaration">Declaration that references the pattern.</param>
+    /// <param name="expressions">Expressions used by the pattern to match elements.</param>
+    /// <param name="source">Source of the elements matched by the pattern. If it's <c>null</c>, the pattern matches facts in rules engine's working memory.</param>
+    /// <returns>Created element.</returns>
+    public static PatternElement Pattern(Declaration declaration, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, RuleElement source)
+    {
+        if (expressions == null)
+            throw new ArgumentNullException(nameof(expressions), "Pattern expressions not provided");
+
+        var expressionElements = expressions.Select(x => new NamedExpressionElement(x.Key, x.Value));
+        var element = Pattern(declaration, expressionElements, source);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a pattern element that represents a match over results of the source element.
+    /// </summary>
+    /// <param name="type">Type of elements matched by the pattern.</param>
+    /// <param name="name">Pattern name.</param>
+    /// <param name="expressions">Expressions used by the pattern to match elements.</param>
+    /// <param name="source">Source of the elements matched by the pattern. If it's <c>null</c>, the pattern matches facts in rules engine's working memory.</param>
+    /// <returns>Created element.</returns>
+    public static PatternElement Pattern(Type type, string name, IEnumerable<NamedExpressionElement> expressions, RuleElement source)
+    {
+        var declaration = Declaration(type, name);
+        var element = Pattern(declaration, expressions, source);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a pattern element that represents a match over results of the source element.
+    /// </summary>
+    /// <param name="declaration">Declaration that references the pattern.</param>
+    /// <param name="expressions">Expressions used by the pattern to match elements.</param>
+    /// <param name="source">Source of the elements matched by the pattern. If it's <c>null</c>, the pattern matches facts in rules engine's working memory.</param>
+    /// <returns>Created element.</returns>
+    public static PatternElement Pattern(Declaration declaration, IEnumerable<NamedExpressionElement> expressions, RuleElement source)
+    {
+        if (declaration == null)
+            throw new ArgumentNullException(nameof(declaration), "Pattern declaration not provided");
+        if (expressions == null)
+            throw new ArgumentNullException(nameof(expressions), "Pattern expressions not provided");
+
+        var expressionCollection = new ExpressionCollection(expressions);
+        var element = new PatternElement(declaration, expressionCollection, source);
+        declaration.Target = element;
+        ElementValidator.ValidatePattern(element);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a condition element that represents a condition applied to elements matched by a pattern.
+    /// </summary>
+    /// <param name="expression">Condition expression. It must have <c>Boolean</c> as its return type.</param>
+    /// <returns>Created element.</returns>
+    public static NamedExpressionElement Condition(LambdaExpression expression)
+    {
+        if (expression == null)
+            throw new ArgumentNullException(nameof(expression), "Condition expression not provided");
+        if (expression.ReturnType != typeof(bool))
+            throw new ArgumentException($"Pattern condition must return a Boolean result. Condition={expression}");
+
+        var element = new NamedExpressionElement(PatternElement.ConditionName, expression);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a named expression element that can be used by other rule elements.
+    /// </summary>
+    /// <param name="name">Name of the expression.</param>
+    /// <param name="expression">The actual expression that this element represents.</param>
+    /// <returns>Created element.</returns>
+    public static NamedExpressionElement Expression(string name, LambdaExpression expression)
+    {
+        if (name == null)
+            throw new ArgumentNullException(nameof(name), "Expression name not provided");
+        if (expression == null)
+            throw new ArgumentNullException(nameof(expression), "Expression not provided");
+
+        var element = new NamedExpressionElement(name, expression);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates a declaration with a given name and type to be used in other rule elements.
+    /// </summary>
+    /// <param name="type">Declaration type.</param>
+    /// <param name="name">Declaration name.</param>
+    /// <returns>Created declaration.</returns>
+    public static Declaration Declaration(Type type, string name)
+    {
+        if (type == null)
+            throw new ArgumentNullException(nameof(type), "Declaration type not provided");
+        if (string.IsNullOrEmpty(name))
+            throw new ArgumentNullException(nameof(name), "Declaration name not provided");
+
+        var declaration = new Declaration(type, name);
+        return declaration;
+    }
+
+    /// <summary>
+    /// Creates an element that represents results of an expression evaluation.
+    /// </summary>
+    /// <param name="resultType">Type of the expression result.</param>
+    /// <param name="expression">Binding expression.</param>
+    /// <returns>Created element.</returns>
+    public static BindingElement Binding(Type resultType, LambdaExpression expression)
+    {
+        if (expression == null)
+            throw new ArgumentNullException(nameof(expression), "Binding expression not provided");
+        if (resultType == null)
+            throw new ArgumentNullException(nameof(resultType), "Binding result type not provided");
+
+        var element = new BindingElement(resultType, expression);
+        ElementValidator.ValidateBinding(element);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates an element that represents results of an expression evaluation.
+    /// </summary>
+    /// <param name="expression">Binding expression.</param>
+    /// <returns>Created element.</returns>
+    public static BindingElement Binding(LambdaExpression expression)
+    {
+        var element = Binding(expression.ReturnType, expression);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates an element that represents an aggregation of facts.
+    /// </summary>
+    /// <param name="resultType">Type of the aggregate result.</param>
+    /// <param name="name">Aggregate name.</param>
+    /// <param name="expressions">Expressions used to construct aggregates from individual facts.</param>
+    /// <param name="source">Pattern that matches facts for aggregation.</param>
+    /// <returns>Created element.</returns>
+    public static AggregateElement Aggregate(Type resultType, string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, PatternElement source)
+    {
+        return Aggregate(resultType, name, expressions, source, null);
+    }
+
+    /// <summary>
+    /// Creates an element that represents an aggregation of facts.
+    /// </summary>
+    /// <param name="resultType">Type of the aggregate result.</param>
+    /// <param name="name">Aggregate name.</param>
+    /// <param name="expressions">Expressions used to construct aggregates from individual facts.</param>
+    /// <param name="source">Pattern that matches facts for aggregation.</param>
+    /// <param name="customFactoryType">Factory type used construct aggregators for this aggregation.</param>
+    /// <returns>Created element.</returns>
+    public static AggregateElement Aggregate(Type resultType, string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, PatternElement source, Type customFactoryType)
+    {
+        if (expressions == null)
+            throw new ArgumentNullException(nameof(expressions), "Aggregate expressions not provided");
+
+        var expressionElements = expressions.Select(x => new NamedExpressionElement(x.Key, x.Value));
+        var element = Aggregate(resultType, name, expressionElements, source, customFactoryType);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates an element that represents an aggregation of facts.
+    /// </summary>
+    /// <param name="resultType">Type of the aggregate result.</param>
+    /// <param name="name">Aggregate name.</param>
+    /// <param name="expressions">Expressions used to construct aggregates from individual facts.</param>
+    /// <param name="source">Pattern that matches facts for aggregation.</param>
+    /// <returns>Created element.</returns>
+    public static AggregateElement Aggregate(Type resultType, string name, IEnumerable<NamedExpressionElement> expressions, PatternElement source)
+    {
+        return Aggregate(resultType, name, expressions, source, null);
+    }
+
+    /// <summary>
+    /// Creates an element that represents an aggregation of facts.
+    /// </summary>
+    /// <param name="resultType">Type of the aggregate result.</param>
+    /// <param name="name">Aggregate name.</param>
+    /// <param name="expressions">Expressions used to construct aggregates from individual facts.</param>
+    /// <param name="source">Pattern that matches facts for aggregation.</param>
+    /// <param name="customFactoryType">Factory type used construct aggregators for this aggregation.</param>
+    /// <returns>Created element.</returns>
+    public static AggregateElement Aggregate(Type resultType, string name, IEnumerable<NamedExpressionElement> expressions, PatternElement source, Type customFactoryType)
+    {
+        if (resultType == null)
+            throw new ArgumentNullException(nameof(resultType), "Aggregate result type not provided");
+        if (string.IsNullOrEmpty(name))
+            throw new ArgumentNullException(nameof(name), "Aggregate name not provided");
+        if (expressions == null)
+            throw new ArgumentNullException(nameof(expressions), "Aggregate expressions not provided");
+        if (source == null)
+            throw new ArgumentNullException(nameof(source), "Aggregate source pattern not provided");
+
+        var expressionCollection = new ExpressionCollection(expressions);
+        var element = new AggregateElement(resultType, name, expressionCollection, source, customFactoryType);
+        ElementValidator.ValidateAggregate(element);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates an element that aggregates matching facts into a collection.
+    /// </summary>
+    /// <param name="source">Pattern that matches facts for aggregation.</param>
+    /// <returns>Created element.</returns>
+    public static AggregateElement Collect(PatternElement source)
+    {
+        var element = Collect(null, source);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates an element that aggregates matching facts into a collection.
+    /// </summary>
+    /// <param name="resultType">Type of the aggregate result.</param>
+    /// <param name="source">Pattern that matches facts for aggregation.</param>
+    /// <returns>Created element.</returns>
+    public static AggregateElement Collect(Type resultType, PatternElement source)
+    {
+        if (resultType == null)
+        {
+            var enumerableType = typeof(IEnumerable<>);
+            resultType = enumerableType.MakeGenericType(source.ValueType);
         }
 
-        /// <summary>
-        /// Creates a rule definition.
-        /// </summary>
-        /// <param name="name">Rule's name.</param>
-        /// <param name="description">Rule's description.</param>
-        /// <param name="priority">Rule's priority.</param>
-        /// <param name="tags">Tags associated with the rule.</param>
-        /// <param name="leftHandSide">Rule's left-hand side top group element.</param>
-        /// <param name="rightHandSide">Rule's right-hand side group element.</param>
-        /// <returns>Created rule definition.</returns>
-        public static IRuleDefinition RuleDefinition(string name, string description, int priority,
-            IEnumerable<string> tags, GroupElement leftHandSide, ActionGroupElement rightHandSide)
+        var expressions = Array.Empty<KeyValuePair<string, LambdaExpression>>();
+        var element = Aggregate(resultType, AggregateElement.CollectName, expressions, source);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates an element that aggregates matching facts into groups.
+    /// </summary>
+    /// <param name="keySelector">Expression that extracts grouping keys from source element.</param>
+    /// <param name="elementSelector">Expression that extracts elements to put into resulting groups.</param>
+    /// <param name="source">Pattern that matches facts for aggregation.</param>
+    /// <returns>Created element.</returns>
+    public static AggregateElement GroupBy(LambdaExpression keySelector, LambdaExpression elementSelector, PatternElement source)
+    {
+        var element = GroupBy(null, keySelector, elementSelector, source);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates an element that aggregates matching facts into groups.
+    /// </summary>
+    /// <param name="resultType">Type of the aggregate result.</param>
+    /// <param name="keySelector">Expression that extracts grouping keys from source element.</param>
+    /// <param name="elementSelector">Expression that extracts elements to put into resulting groups.</param>
+    /// <param name="source">Pattern that matches facts for aggregation.</param>
+    /// <returns>Created element.</returns>
+    public static AggregateElement GroupBy(Type resultType, LambdaExpression keySelector, LambdaExpression elementSelector, PatternElement source)
+    {
+        if (keySelector == null)
+            throw new ArgumentNullException(nameof(keySelector), "GroupBy key selector not provided");
+        if (elementSelector == null)
+            throw new ArgumentNullException(nameof(elementSelector), "GroupBy element selector not provided");
+
+        if (resultType == null)
         {
-            var ruleProperties = Array.Empty<RuleProperty>();
-            var dependencyGroupElement = DependencyGroup();
-            var filterGroupElement = FilterGroup();
-            var ruleDefinition = RuleDefinition(name, description, priority, RuleRepeatability.Repeatable,
-                tags, ruleProperties, dependencyGroupElement, leftHandSide, filterGroupElement, rightHandSide);
-            return ruleDefinition;
+            var groupingType = typeof(IGrouping<,>);
+            resultType = groupingType.MakeGenericType(keySelector.ReturnType, elementSelector.ReturnType);
         }
 
-        /// <summary>
-        /// Creates a rule definition.
-        /// </summary>
-        /// <param name="name">Rule's name.</param>
-        /// <param name="description">Rule's description.</param>
-        /// <param name="priority">Rule's priority.</param>
-        /// <param name="repeatability">Rule's repeatability.</param>
-        /// <param name="tags">Tags associated with the rule.</param>
-        /// <param name="properties">Properties associated with the rule.</param>
-        /// <param name="dependencies">Rule's dependency group element.</param>
-        /// <param name="leftHandSide">Rule's left-hand side top group element.</param>
-        /// <param name="filters">Rule's filter group element.</param>
-        /// <param name="rightHandSide">Rule's right-hand side group element.</param>
-        /// <returns>Created rule definition.</returns>
-        public static IRuleDefinition RuleDefinition(string name, string description, int priority,
-            RuleRepeatability repeatability, IEnumerable<string> tags, IEnumerable<RuleProperty> properties,
-            DependencyGroupElement dependencies, GroupElement leftHandSide, FilterGroupElement filters, ActionGroupElement rightHandSide)
+        var expressions = new List<KeyValuePair<string, LambdaExpression>>
         {
-            if (string.IsNullOrEmpty(name))
-                throw new ArgumentException("Rule name not provided", nameof(name));
-            if (tags == null)
-                throw new ArgumentNullException(nameof(tags), "Rule tags not provided");
-            if (properties == null)
-                throw new ArgumentNullException(nameof(properties), "Rule properties not provided");
-            if (dependencies == null)
-                throw new ArgumentNullException(nameof(dependencies), "Rule dependencies not provided");
-            if (leftHandSide == null)
-                throw new ArgumentNullException(nameof(leftHandSide), "Rule left-hand side not provided");
-            if (filters == null)
-                throw new ArgumentNullException(nameof(filters), "Rule filters not provided");
-            if (rightHandSide == null)
-                throw new ArgumentNullException(nameof(rightHandSide), "Rule right-hand side not provided");
+            new(AggregateElement.KeySelectorName, keySelector),
+            new(AggregateElement.ElementSelectorName, elementSelector)
+        };
+        var element = Aggregate(resultType, AggregateElement.GroupByName, expressions, source);
+        return element;
+    }
 
-            var ruleDefinition = new RuleDefinition(name, description, priority, repeatability, tags, properties, dependencies, leftHandSide, filters, rightHandSide);
+    /// <summary>
+    /// Creates an element that projects matching facts into different elements.
+    /// </summary>
+    /// <param name="selector">Expression that translates a matching element into a different element.</param>
+    /// <param name="source">Pattern that matches facts for aggregation.</param>
+    /// <returns>Created element.</returns>
+    public static AggregateElement Project(LambdaExpression selector, PatternElement source)
+    {
+        var element = Project(null, selector, source);
+        return element;
+    }
 
-            ElementValidator.ValidateUniqueDeclarations(ruleDefinition.LeftHandSide, ruleDefinition.DependencyGroup);
-            ElementValidator.ValidateRuleDefinition(ruleDefinition);
+    /// <summary>
+    /// Creates an element that projects matching facts into different elements.
+    /// </summary>
+    /// <param name="resultType">Type of the aggregate result.</param>
+    /// <param name="selector">Expression that translates a matching element into a different element.</param>
+    /// <param name="source">Pattern that matches facts for aggregation.</param>
+    /// <returns>Created element.</returns>
+    public static AggregateElement Project(Type resultType, LambdaExpression selector, PatternElement source)
+    {
+        if (selector == null)
+            throw new ArgumentNullException(nameof(selector), "Projection selector not provided");
 
-            return ruleDefinition;
+        if (resultType == null)
+        {
+            resultType = selector.ReturnType;
         }
 
-        /// <summary>
-        /// Creates a dependency group element.
-        /// </summary>
-        /// <param name="dependencies">Dependency elements in the group.</param>
-        /// <returns>Created element.</returns>
-        /// <seealso cref="DependencyElement"/>
-        public static DependencyGroupElement DependencyGroup(params DependencyElement[] dependencies)
+        var expressions = new List<KeyValuePair<string, LambdaExpression>>
         {
-            var element = DependencyGroup(dependencies.AsEnumerable());
-            return element;
-        }
+            new(AggregateElement.SelectorName, selector)
+        };
+        var element = Aggregate(resultType, AggregateElement.ProjectName, expressions, source);
+        return element;
+    }
 
-        /// <summary>
-        /// Creates a dependency group element.
-        /// </summary>
-        /// <param name="dependencies">Dependency elements in the group.</param>
-        /// <returns>Created element.</returns>
-        /// <seealso cref="DependencyElement"/>
-        public static DependencyGroupElement DependencyGroup(IEnumerable<DependencyElement> dependencies)
+    /// <summary>
+    /// Creates an element that flattens collections of elements from matching facts into a single set of facts.
+    /// </summary>
+    /// <param name="resultType">Type of the aggregate result.</param>
+    /// <param name="selector">Expression that selects a collection of elements from a matching fact.</param>
+    /// <param name="source">Pattern that matches facts for aggregation.</param>
+    /// <returns>Created element.</returns>
+    public static AggregateElement Flatten(Type resultType, LambdaExpression selector, PatternElement source)
+    {
+        if (selector == null)
+            throw new ArgumentNullException(nameof(selector), "Flattening selector not provided");
+
+        var expressions = new List<KeyValuePair<string, LambdaExpression>>
         {
-            if (dependencies == null)
-                throw new ArgumentNullException(nameof(dependencies), "Dependencies not provided");
+            new(AggregateElement.SelectorName, selector)
+        };
+        var element = Aggregate(resultType, AggregateElement.FlattenName, expressions, source);
+        return element;
+    }
 
-            var element = new DependencyGroupElement(dependencies);
-            ElementValidator.ValidateUniqueDeclarations(element.Dependencies);
-            return element;
-        }
+    /// <summary>
+    /// Creates an agenda filter group element.
+    /// </summary>
+    /// <param name="filters">Agenda filter elements in the group.</param>
+    /// <returns>Created element.</returns>
+    /// <seealso cref="FilterElement"/>
+    public static FilterGroupElement FilterGroup(params FilterElement[] filters)
+    {
+        var element = FilterGroup(filters.AsEnumerable());
+        return element;
+    }
 
-        /// <summary>
-        /// Creates a dependency element.
-        /// </summary>
-        /// <param name="type">Dependency type.</param>
-        /// <param name="name">Dependency name.</param>
-        /// <returns>Created element.</returns>
-        public static DependencyElement Dependency(Type type, string name)
+    /// <summary>
+    /// Creates an agenda filter group element.
+    /// </summary>
+    /// <param name="filters">Agenda filter elements in the group.</param>
+    /// <returns>Created element.</returns>
+    /// <seealso cref="FilterElement"/>
+    public static FilterGroupElement FilterGroup(IEnumerable<FilterElement> filters)
+    {
+        var element = new FilterGroupElement(filters);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates an agenda filter element.
+    /// </summary>
+    /// <param name="filterType">Type of agenda filter.</param>
+    /// <param name="expression">Filter expression.</param>
+    /// <returns>Created element.</returns>
+    public static FilterElement Filter(FilterType filterType, LambdaExpression expression)
+    {
+        var element = new FilterElement(filterType, expression);
+        return element;
+    }
+
+    /// <summary>
+    /// Creates an action group element.
+    /// </summary>
+    /// <param name="actions">Action elements in the group.</param>
+    /// <returns>Created element.</returns>
+    /// <seealso cref="ActionElement"/>
+    public static ActionGroupElement ActionGroup(params ActionElement[] actions)
+    {
+        var element = ActionGroup(actions.AsEnumerable());
+        return element;
+    }
+
+    /// <summary>
+    /// Creates an action group element.
+    /// </summary>
+    /// <param name="actions">Action elements in the group.</param>
+    /// <returns>Created element.</returns>
+    /// <seealso cref="ActionElement"/>
+    public static ActionGroupElement ActionGroup(IEnumerable<ActionElement> actions)
+    {
+        var element = new ActionGroupElement(actions);
+        var insertActions = element.Actions.Where(x => x.ActionTrigger.HasFlag(ActionTrigger.Activated)).ToList();
+        if (insertActions.Count == 0)
         {
-            var declaration = Declaration(type, name);
-            var element = Dependency(declaration, type);
-            return element;
+            throw new ArgumentException("Rule must have at least one match action");
         }
+        return element;
+    }
 
-        /// <summary>
-        /// Creates a dependency element.
-        /// </summary>
-        /// <param name="declaration">Declaration that references the dependency.</param>
-        /// <param name="serviceType">Type of the service that the dependency represents.</param>
-        /// <returns>Created element.</returns>
-        public static DependencyElement Dependency(Declaration declaration, Type serviceType)
-        {
-            if (declaration == null)
-                throw new ArgumentNullException(nameof(declaration), "Dependency declaration not provided");
-            if (serviceType == null)
-                throw new ArgumentNullException(nameof(serviceType), "Dependency type not provided");
+    /// <summary>
+    /// Creates an action element that represents an action taken by the engine when the rule fires.
+    /// </summary>
+    /// <param name="expression">Action expression. It must have <see cref="IContext"/> as it's first parameter.</param>
+    /// <param name="actionTrigger">Action trigger that indicates when the action should execute.</param>
+    /// <returns>Created element.</returns>
+    public static ActionElement Action(LambdaExpression expression, ActionTrigger actionTrigger)
+    {
+        if (expression == null)
+            throw new ArgumentNullException(nameof(expression), "Action expression not provided");
+        if (actionTrigger == ActionTrigger.None)
+            throw new ArgumentException("Action trigger not provided");
+        if (expression.Parameters.Count == 0 ||
+            expression.Parameters.First().Type != typeof(IContext))
+            throw new ArgumentException($"Action expression must have {typeof(IContext)} as its first parameter. Action={expression}");
 
-            var element = new DependencyElement(declaration, serviceType);
-            declaration.Target = element;
-            return element;
-        }
+        var element = new ActionElement(expression, actionTrigger);
+        return element;
+    }
 
-        /// <summary>
-        /// Creates a left-hand side group element, that contains pattern elements and nested group elements.
-        /// </summary>
-        /// <param name="groupType">Type of the group element.</param>
-        /// <param name="childElements">Child elements contained in the group.</param>
-        /// <returns>Created element.</returns>
-        public static GroupElement Group(GroupType groupType, IEnumerable<RuleElement> childElements)
-        {
-            GroupElement element = groupType switch
-            {
-                GroupType.And => AndGroup(childElements),
-                GroupType.Or => OrGroup(childElements),
-                _ => throw new ArgumentException($"Unrecognized group type. GroupType={groupType}", nameof(groupType))
-            };
-
-            return element;
-        }
-
-        /// <summary>
-        /// Creates a left-hand side group element that combines contained elements using an AND operator.
-        /// </summary>
-        /// <param name="childElements">Child elements contained in the group.</param>
-        /// <returns>Created element.</returns>
-        /// <see cref="RuleElement"/>
-        public static AndElement AndGroup(params RuleElement[] childElements)
-        {
-            var element = AndGroup(childElements.AsEnumerable());
-            return element;
-        }
-
-        /// <summary>
-        /// Creates a left-hand side group element that combines contained elements using an AND operator.
-        /// </summary>
-        /// <param name="childElements">Child elements contained in the group.</param>
-        /// <returns>Created element.</returns>
-        /// <see cref="RuleElement"/>
-        public static AndElement AndGroup(IEnumerable<RuleElement> childElements)
-        {
-            if (childElements == null)
-                throw new ArgumentNullException(nameof(childElements), "Child elements not provided");
-
-            var element = new AndElement(childElements);
-            ElementValidator.ValidateGroup(element);
-            ElementValidator.ValidateUniqueDeclarations(element.ChildElements);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates a left-hand side group element that combines contained elements using an OR operator.
-        /// </summary>
-        /// <param name="childElements">Child elements contained in the group.</param>
-        /// <returns>Created element.</returns>
-        /// <see cref="RuleElement"/>
-        public static OrElement OrGroup(params RuleElement[] childElements)
-        {
-            var element = OrGroup(childElements.AsEnumerable());
-            return element;
-        }
-
-        /// <summary>
-        /// Creates a left-hand side group element that combines contained elements using an OR operator.
-        /// </summary>
-        /// <param name="childElements">Child elements contained in the group.</param>
-        /// <returns>Created element.</returns>
-        /// <see cref="RuleElement"/>
-        public static OrElement OrGroup(IEnumerable<RuleElement> childElements)
-        {
-            if (childElements == null)
-                throw new ArgumentNullException(nameof(childElements), "Child elements not provided");
-
-            var element = new OrElement(childElements);
-            ElementValidator.ValidateGroup(element);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an element that represents an existential quantifier.
-        /// </summary>
-        /// <param name="source">Source element to apply the existential quantifier to.</param>
-        /// <returns>Created element.</returns>
-        /// <see cref="RuleElement"/>
-        public static ExistsElement Exists(RuleElement source)
-        {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source), "Source element not provided");
-
-            var element = new ExistsElement(source);
-            ElementValidator.ValidateExists(element);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an element that represents a negative existential quantifier.
-        /// </summary>
-        /// <param name="source">Source element to apply the negative existential quantifier to.</param>
-        /// <returns>Created element.</returns>
-        public static NotElement Not(RuleElement source)
-        {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source), "Source element not provided");
-
-            var element = new NotElement(source);
-            ElementValidator.ValidateNot(element);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an element that represents a universal quantifier.
-        /// Facts that match the <c>basePattern</c> must also match all other <c>patterns</c>.
-        /// </summary>
-        /// <param name="basePattern">Base patterns of the universal quantifier that defines the universe of facts to consider.</param>
-        /// <param name="patterns">Additional patterns of the universal quantifier that the fact matched by the base pattern must also satisfy.</param>
-        /// <returns>Created element.</returns>
-        public static ForAllElement ForAll(PatternElement basePattern, IEnumerable<PatternElement> patterns)
-        {
-            if (basePattern == null)
-                throw new ArgumentNullException(nameof(basePattern), "Base pattern not provided");
-            if (patterns == null)
-                throw new ArgumentNullException(nameof(patterns), "Patterns not provided");
-
-            var element = new ForAllElement(basePattern, patterns);
-            ElementValidator.ValidateForAll(element);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates a pattern element that represents a match of facts in rules engine's working memory.
-        /// </summary>
-        /// <param name="type">Type of facts matched by the pattern.</param>
-        /// <param name="name">Pattern name.</param>
-        /// <param name="expressions">Expressions used by the pattern to match elements.</param>
-        /// <returns>Created element.</returns>
-        public static PatternElement Pattern(Type type, string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions)
-        {
-            var element = Pattern(type, name, expressions, null);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates a pattern element that represents a match of facts in rules engine's working memory.
-        /// </summary>
-        /// <param name="declaration">Declaration that references the pattern.</param>
-        /// <param name="expressions">Expressions used by the pattern to match elements.</param>
-        /// <returns>Created element.</returns>
-        public static PatternElement Pattern(Declaration declaration, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions)
-        {
-            var element = Pattern(declaration, expressions, null);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates a pattern element that represents a match over results of the source element.
-        /// </summary>
-        /// <param name="type">Type of elements matched by the pattern.</param>
-        /// <param name="name">Pattern name.</param>
-        /// <param name="expressions">Expressions used by the pattern to match elements.</param>
-        /// <param name="source">Source of the elements matched by the pattern. If it's <c>null</c>, the pattern matches facts in rules engine's working memory.</param>
-        /// <returns>Created element.</returns>
-        public static PatternElement Pattern(Type type, string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, RuleElement source)
-        {
-            var declaration = Declaration(type, name);
-            var element = Pattern(declaration, expressions, source);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates a pattern element that represents a match over results of the source element.
-        /// </summary>
-        /// <param name="declaration">Declaration that references the pattern.</param>
-        /// <param name="expressions">Expressions used by the pattern to match elements.</param>
-        /// <param name="source">Source of the elements matched by the pattern. If it's <c>null</c>, the pattern matches facts in rules engine's working memory.</param>
-        /// <returns>Created element.</returns>
-        public static PatternElement Pattern(Declaration declaration, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, RuleElement source)
-        {
-            if (expressions == null)
-                throw new ArgumentNullException(nameof(expressions), "Pattern expressions not provided");
-
-            var expressionElements = expressions.Select(x => new NamedExpressionElement(x.Key, x.Value));
-            var element = Pattern(declaration, expressionElements, source);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates a pattern element that represents a match over results of the source element.
-        /// </summary>
-        /// <param name="type">Type of elements matched by the pattern.</param>
-        /// <param name="name">Pattern name.</param>
-        /// <param name="expressions">Expressions used by the pattern to match elements.</param>
-        /// <param name="source">Source of the elements matched by the pattern. If it's <c>null</c>, the pattern matches facts in rules engine's working memory.</param>
-        /// <returns>Created element.</returns>
-        public static PatternElement Pattern(Type type, string name, IEnumerable<NamedExpressionElement> expressions, RuleElement source)
-        {
-            var declaration = Declaration(type, name);
-            var element = Pattern(declaration, expressions, source);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates a pattern element that represents a match over results of the source element.
-        /// </summary>
-        /// <param name="declaration">Declaration that references the pattern.</param>
-        /// <param name="expressions">Expressions used by the pattern to match elements.</param>
-        /// <param name="source">Source of the elements matched by the pattern. If it's <c>null</c>, the pattern matches facts in rules engine's working memory.</param>
-        /// <returns>Created element.</returns>
-        public static PatternElement Pattern(Declaration declaration, IEnumerable<NamedExpressionElement> expressions, RuleElement source)
-        {
-            if (declaration == null)
-                throw new ArgumentNullException(nameof(declaration), "Pattern declaration not provided");
-            if (expressions == null)
-                throw new ArgumentNullException(nameof(expressions), "Pattern expressions not provided");
-
-            var expressionCollection = new ExpressionCollection(expressions);
-            var element = new PatternElement(declaration, expressionCollection, source);
-            declaration.Target = element;
-            ElementValidator.ValidatePattern(element);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates a condition element that represents a condition applied to elements matched by a pattern.
-        /// </summary>
-        /// <param name="expression">Condition expression. It must have <c>Boolean</c> as its return type.</param>
-        /// <returns>Created element.</returns>
-        public static NamedExpressionElement Condition(LambdaExpression expression)
-        {
-            if (expression == null)
-                throw new ArgumentNullException(nameof(expression), "Condition expression not provided");
-            if (expression.ReturnType != typeof(bool))
-                throw new ArgumentException($"Pattern condition must return a Boolean result. Condition={expression}");
-
-            var element = new NamedExpressionElement(PatternElement.ConditionName, expression);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates a named expression element that can be used by other rule elements.
-        /// </summary>
-        /// <param name="name">Name of the expression.</param>
-        /// <param name="expression">The actual expression that this element represents.</param>
-        /// <returns>Created element.</returns>
-        public static NamedExpressionElement Expression(string name, LambdaExpression expression)
-        {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name), "Expression name not provided");
-            if (expression == null)
-                throw new ArgumentNullException(nameof(expression), "Expression not provided");
-
-            var element = new NamedExpressionElement(name, expression);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates a declaration with a given name and type to be used in other rule elements.
-        /// </summary>
-        /// <param name="type">Declaration type.</param>
-        /// <param name="name">Declaration name.</param>
-        /// <returns>Created declaration.</returns>
-        public static Declaration Declaration(Type type, string name)
-        {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type), "Declaration type not provided");
-            if (string.IsNullOrEmpty(name))
-                throw new ArgumentNullException(nameof(name), "Declaration name not provided");
-
-            var declaration = new Declaration(type, name);
-            return declaration;
-        }
-
-        /// <summary>
-        /// Creates an element that represents results of an expression evaluation.
-        /// </summary>
-        /// <param name="resultType">Type of the expression result.</param>
-        /// <param name="expression">Binding expression.</param>
-        /// <returns>Created element.</returns>
-        public static BindingElement Binding(Type resultType, LambdaExpression expression)
-        {
-            if (expression == null)
-                throw new ArgumentNullException(nameof(expression), "Binding expression not provided");
-            if (resultType == null)
-                throw new ArgumentNullException(nameof(resultType), "Binding result type not provided");
-
-            var element = new BindingElement(resultType, expression);
-            ElementValidator.ValidateBinding(element);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an element that represents results of an expression evaluation.
-        /// </summary>
-        /// <param name="expression">Binding expression.</param>
-        /// <returns>Created element.</returns>
-        public static BindingElement Binding(LambdaExpression expression)
-        {
-            var element = Binding(expression.ReturnType, expression);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an element that represents an aggregation of facts.
-        /// </summary>
-        /// <param name="resultType">Type of the aggregate result.</param>
-        /// <param name="name">Aggregate name.</param>
-        /// <param name="expressions">Expressions used to construct aggregates from individual facts.</param>
-        /// <param name="source">Pattern that matches facts for aggregation.</param>
-        /// <returns>Created element.</returns>
-        public static AggregateElement Aggregate(Type resultType, string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, PatternElement source)
-        {
-            return Aggregate(resultType, name, expressions, source, null);
-        }
-
-        /// <summary>
-        /// Creates an element that represents an aggregation of facts.
-        /// </summary>
-        /// <param name="resultType">Type of the aggregate result.</param>
-        /// <param name="name">Aggregate name.</param>
-        /// <param name="expressions">Expressions used to construct aggregates from individual facts.</param>
-        /// <param name="source">Pattern that matches facts for aggregation.</param>
-        /// <param name="customFactoryType">Factory type used construct aggregators for this aggregation.</param>
-        /// <returns>Created element.</returns>
-        public static AggregateElement Aggregate(Type resultType, string name, IEnumerable<KeyValuePair<string, LambdaExpression>> expressions, PatternElement source, Type customFactoryType)
-        {
-            if (expressions == null)
-                throw new ArgumentNullException(nameof(expressions), "Aggregate expressions not provided");
-
-            var expressionElements = expressions.Select(x => new NamedExpressionElement(x.Key, x.Value));
-            var element = Aggregate(resultType, name, expressionElements, source, customFactoryType);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an element that represents an aggregation of facts.
-        /// </summary>
-        /// <param name="resultType">Type of the aggregate result.</param>
-        /// <param name="name">Aggregate name.</param>
-        /// <param name="expressions">Expressions used to construct aggregates from individual facts.</param>
-        /// <param name="source">Pattern that matches facts for aggregation.</param>
-        /// <returns>Created element.</returns>
-        public static AggregateElement Aggregate(Type resultType, string name, IEnumerable<NamedExpressionElement> expressions, PatternElement source)
-        {
-            return Aggregate(resultType, name, expressions, source, null);
-        }
-
-        /// <summary>
-        /// Creates an element that represents an aggregation of facts.
-        /// </summary>
-        /// <param name="resultType">Type of the aggregate result.</param>
-        /// <param name="name">Aggregate name.</param>
-        /// <param name="expressions">Expressions used to construct aggregates from individual facts.</param>
-        /// <param name="source">Pattern that matches facts for aggregation.</param>
-        /// <param name="customFactoryType">Factory type used construct aggregators for this aggregation.</param>
-        /// <returns>Created element.</returns>
-        public static AggregateElement Aggregate(Type resultType, string name, IEnumerable<NamedExpressionElement> expressions, PatternElement source, Type customFactoryType)
-        {
-            if (resultType == null)
-                throw new ArgumentNullException(nameof(resultType), "Aggregate result type not provided");
-            if (string.IsNullOrEmpty(name))
-                throw new ArgumentNullException(nameof(name), "Aggregate name not provided");
-            if (expressions == null)
-                throw new ArgumentNullException(nameof(expressions), "Aggregate expressions not provided");
-            if (source == null)
-                throw new ArgumentNullException(nameof(source), "Aggregate source pattern not provided");
-
-            var expressionCollection = new ExpressionCollection(expressions);
-            var element = new AggregateElement(resultType, name, expressionCollection, source, customFactoryType);
-            ElementValidator.ValidateAggregate(element);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an element that aggregates matching facts into a collection.
-        /// </summary>
-        /// <param name="source">Pattern that matches facts for aggregation.</param>
-        /// <returns>Created element.</returns>
-        public static AggregateElement Collect(PatternElement source)
-        {
-            var element = Collect(null, source);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an element that aggregates matching facts into a collection.
-        /// </summary>
-        /// <param name="resultType">Type of the aggregate result.</param>
-        /// <param name="source">Pattern that matches facts for aggregation.</param>
-        /// <returns>Created element.</returns>
-        public static AggregateElement Collect(Type resultType, PatternElement source)
-        {
-            if (resultType == null)
-            {
-                var enumerableType = typeof(IEnumerable<>);
-                resultType = enumerableType.MakeGenericType(source.ValueType);
-            }
-
-            var expressions = Array.Empty<KeyValuePair<string, LambdaExpression>>();
-            var element = Aggregate(resultType, AggregateElement.CollectName, expressions, source);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an element that aggregates matching facts into groups.
-        /// </summary>
-        /// <param name="keySelector">Expression that extracts grouping keys from source element.</param>
-        /// <param name="elementSelector">Expression that extracts elements to put into resulting groups.</param>
-        /// <param name="source">Pattern that matches facts for aggregation.</param>
-        /// <returns>Created element.</returns>
-        public static AggregateElement GroupBy(LambdaExpression keySelector, LambdaExpression elementSelector, PatternElement source)
-        {
-            var element = GroupBy(null, keySelector, elementSelector, source);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an element that aggregates matching facts into groups.
-        /// </summary>
-        /// <param name="resultType">Type of the aggregate result.</param>
-        /// <param name="keySelector">Expression that extracts grouping keys from source element.</param>
-        /// <param name="elementSelector">Expression that extracts elements to put into resulting groups.</param>
-        /// <param name="source">Pattern that matches facts for aggregation.</param>
-        /// <returns>Created element.</returns>
-        public static AggregateElement GroupBy(Type resultType, LambdaExpression keySelector, LambdaExpression elementSelector, PatternElement source)
-        {
-            if (keySelector == null)
-                throw new ArgumentNullException(nameof(keySelector), "GroupBy key selector not provided");
-            if (elementSelector == null)
-                throw new ArgumentNullException(nameof(elementSelector), "GroupBy element selector not provided");
-
-            if (resultType == null)
-            {
-                var groupingType = typeof(IGrouping<,>);
-                resultType = groupingType.MakeGenericType(keySelector.ReturnType, elementSelector.ReturnType);
-            }
-
-            var expressions = new List<KeyValuePair<string, LambdaExpression>>
-            {
-                new(AggregateElement.KeySelectorName, keySelector),
-                new(AggregateElement.ElementSelectorName, elementSelector)
-            };
-            var element = Aggregate(resultType, AggregateElement.GroupByName, expressions, source);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an element that projects matching facts into different elements.
-        /// </summary>
-        /// <param name="selector">Expression that translates a matching element into a different element.</param>
-        /// <param name="source">Pattern that matches facts for aggregation.</param>
-        /// <returns>Created element.</returns>
-        public static AggregateElement Project(LambdaExpression selector, PatternElement source)
-        {
-            var element = Project(null, selector, source);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an element that projects matching facts into different elements.
-        /// </summary>
-        /// <param name="resultType">Type of the aggregate result.</param>
-        /// <param name="selector">Expression that translates a matching element into a different element.</param>
-        /// <param name="source">Pattern that matches facts for aggregation.</param>
-        /// <returns>Created element.</returns>
-        public static AggregateElement Project(Type resultType, LambdaExpression selector, PatternElement source)
-        {
-            if (selector == null)
-                throw new ArgumentNullException(nameof(selector), "Projection selector not provided");
-
-            if (resultType == null)
-            {
-                resultType = selector.ReturnType;
-            }
-
-            var expressions = new List<KeyValuePair<string, LambdaExpression>>
-            {
-                new(AggregateElement.SelectorName, selector)
-            };
-            var element = Aggregate(resultType, AggregateElement.ProjectName, expressions, source);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an element that flattens collections of elements from matching facts into a single set of facts.
-        /// </summary>
-        /// <param name="resultType">Type of the aggregate result.</param>
-        /// <param name="selector">Expression that selects a collection of elements from a matching fact.</param>
-        /// <param name="source">Pattern that matches facts for aggregation.</param>
-        /// <returns>Created element.</returns>
-        public static AggregateElement Flatten(Type resultType, LambdaExpression selector, PatternElement source)
-        {
-            if (selector == null)
-                throw new ArgumentNullException(nameof(selector), "Flattening selector not provided");
-
-            var expressions = new List<KeyValuePair<string, LambdaExpression>>
-            {
-                new(AggregateElement.SelectorName, selector)
-            };
-            var element = Aggregate(resultType, AggregateElement.FlattenName, expressions, source);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an agenda filter group element.
-        /// </summary>
-        /// <param name="filters">Agenda filter elements in the group.</param>
-        /// <returns>Created element.</returns>
-        /// <seealso cref="FilterElement"/>
-        public static FilterGroupElement FilterGroup(params FilterElement[] filters)
-        {
-            var element = FilterGroup(filters.AsEnumerable());
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an agenda filter group element.
-        /// </summary>
-        /// <param name="filters">Agenda filter elements in the group.</param>
-        /// <returns>Created element.</returns>
-        /// <seealso cref="FilterElement"/>
-        public static FilterGroupElement FilterGroup(IEnumerable<FilterElement> filters)
-        {
-            var element = new FilterGroupElement(filters);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an agenda filter element.
-        /// </summary>
-        /// <param name="filterType">Type of agenda filter.</param>
-        /// <param name="expression">Filter expression.</param>
-        /// <returns>Created element.</returns>
-        public static FilterElement Filter(FilterType filterType, LambdaExpression expression)
-        {
-            var element = new FilterElement(filterType, expression);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an action group element.
-        /// </summary>
-        /// <param name="actions">Action elements in the group.</param>
-        /// <returns>Created element.</returns>
-        /// <seealso cref="ActionElement"/>
-        public static ActionGroupElement ActionGroup(params ActionElement[] actions)
-        {
-            var element = ActionGroup(actions.AsEnumerable());
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an action group element.
-        /// </summary>
-        /// <param name="actions">Action elements in the group.</param>
-        /// <returns>Created element.</returns>
-        /// <seealso cref="ActionElement"/>
-        public static ActionGroupElement ActionGroup(IEnumerable<ActionElement> actions)
-        {
-            var element = new ActionGroupElement(actions);
-            var insertActions = element.Actions.Where(x => x.ActionTrigger.HasFlag(ActionTrigger.Activated)).ToList();
-            if (insertActions.Count == 0)
-            {
-                throw new ArgumentException("Rule must have at least one match action");
-            }
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an action element that represents an action taken by the engine when the rule fires.
-        /// </summary>
-        /// <param name="expression">Action expression. It must have <see cref="IContext"/> as it's first parameter.</param>
-        /// <param name="actionTrigger">Action trigger that indicates when the action should execute.</param>
-        /// <returns>Created element.</returns>
-        public static ActionElement Action(LambdaExpression expression, ActionTrigger actionTrigger)
-        {
-            if (expression == null)
-                throw new ArgumentNullException(nameof(expression), "Action expression not provided");
-            if (actionTrigger == ActionTrigger.None)
-                throw new ArgumentException("Action trigger not provided");
-            if (expression.Parameters.Count == 0 ||
-                expression.Parameters.First().Type != typeof(IContext))
-                throw new ArgumentException($"Action expression must have {typeof(IContext)} as its first parameter. Action={expression}");
-
-            var element = new ActionElement(expression, actionTrigger);
-            return element;
-        }
-
-        /// <summary>
-        /// Creates an action element that represents an action taken by the engine when the rule fires.
-        /// The action element is created with the default trigger, which executes the action when rule
-        /// is <see cref="ActionTrigger.Activated"/> or <see cref="ActionTrigger.Reactivated"/>.
-        /// </summary>
-        /// <param name="expression">Action expression. It must have <see cref="IContext"/> as it's first parameter.</param>
-        /// <returns>Created element.</returns>
-        public static ActionElement Action(LambdaExpression expression)
-        {
-            var defaultTrigger = ActionTrigger.Activated | ActionTrigger.Reactivated;
-            var element = Action(expression, defaultTrigger);
-            return element;
-        }
+    /// <summary>
+    /// Creates an action element that represents an action taken by the engine when the rule fires.
+    /// The action element is created with the default trigger, which executes the action when rule
+    /// is <see cref="ActionTrigger.Activated"/> or <see cref="ActionTrigger.Reactivated"/>.
+    /// </summary>
+    /// <param name="expression">Action expression. It must have <see cref="IContext"/> as it's first parameter.</param>
+    /// <returns>Created element.</returns>
+    public static ActionElement Action(LambdaExpression expression)
+    {
+        var defaultTrigger = ActionTrigger.Activated | ActionTrigger.Reactivated;
+        var element = Action(expression, defaultTrigger);
+        return element;
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/ExistsBuilder.cs
+++ b/src/NRules/NRules.RuleModel/Builders/ExistsBuilder.cs
@@ -1,114 +1,113 @@
 ﻿using System;
 
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+/// <summary>
+/// Builder to compose an existential element.
+/// </summary>
+public class ExistsBuilder : RuleElementBuilder, IBuilder<ExistsElement>
 {
+    private IBuilder<RuleElement> _sourceBuilder;
+
     /// <summary>
-    /// Builder to compose an existential element.
+    /// Initializes a new instance of the <see cref="ExistsBuilder"/>.
     /// </summary>
-    public class ExistsBuilder : RuleElementBuilder, IBuilder<ExistsElement>
+    public ExistsBuilder()
     {
-        private IBuilder<RuleElement> _sourceBuilder;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ExistsBuilder"/>.
-        /// </summary>
-        public ExistsBuilder()
-        {
-        }
+    /// <summary>
+    /// Sets a pattern as the source of the existential element.
+    /// </summary>
+    /// <param name="element">Element to set as the source.</param>
+    public void Pattern(PatternElement element)
+    {
+        AssertSingleSource();
+        _sourceBuilder = BuilderAdapter.Create(element);
+    }
 
-        /// <summary>
-        /// Sets a pattern as the source of the existential element.
-        /// </summary>
-        /// <param name="element">Element to set as the source.</param>
-        public void Pattern(PatternElement element)
-        {
-            AssertSingleSource();
-            _sourceBuilder = BuilderAdapter.Create(element);
-        }
+    /// <summary>
+    /// Sets a pattern builder as the source of the existential element.
+    /// </summary>
+    /// <param name="builder">Element builder to set as the source.</param>
+    public void Pattern(PatternBuilder builder)
+    {
+        AssertSingleSource();
+        _sourceBuilder = builder;
+    }
 
-        /// <summary>
-        /// Sets a pattern builder as the source of the existential element.
-        /// </summary>
-        /// <param name="builder">Element builder to set as the source.</param>
-        public void Pattern(PatternBuilder builder)
-        {
-            AssertSingleSource();
-            _sourceBuilder = builder;
-        }
+    /// <summary>
+    /// Creates a pattern builder that builds the source of the existential element.
+    /// </summary>
+    /// <param name="type">Type of the element the pattern matches.</param>
+    /// <param name="name">Pattern name (optional).</param>
+    /// <returns>Pattern builder.</returns>
+    public PatternBuilder Pattern(Type type, string name = null)
+    {
+        var declaration = Element.Declaration(type, DeclarationName(name));
+        return Pattern(declaration);
+    }
 
-        /// <summary>
-        /// Creates a pattern builder that builds the source of the existential element.
-        /// </summary>
-        /// <param name="type">Type of the element the pattern matches.</param>
-        /// <param name="name">Pattern name (optional).</param>
-        /// <returns>Pattern builder.</returns>
-        public PatternBuilder Pattern(Type type, string name = null)
-        {
-            var declaration = Element.Declaration(type, DeclarationName(name));
-            return Pattern(declaration);
-        }
+    /// <summary>
+    /// Creates a pattern builder that builds the source of the existential element.
+    /// </summary>
+    /// <param name="declaration">Pattern declaration.</param>
+    /// <returns>Pattern builder.</returns>
+    public PatternBuilder Pattern(Declaration declaration)
+    {
+        AssertSingleSource();
+        var sourceBuilder = new PatternBuilder(declaration);
+        _sourceBuilder = sourceBuilder;
+        return sourceBuilder;
+    }
 
-        /// <summary>
-        /// Creates a pattern builder that builds the source of the existential element.
-        /// </summary>
-        /// <param name="declaration">Pattern declaration.</param>
-        /// <returns>Pattern builder.</returns>
-        public PatternBuilder Pattern(Declaration declaration)
-        {
-            AssertSingleSource();
-            var sourceBuilder = new PatternBuilder(declaration);
-            _sourceBuilder = sourceBuilder;
-            return sourceBuilder;
-        }
+    /// <summary>
+    /// Sets a group as the source of the existential element.
+    /// </summary>
+    /// <param name="element">Element to set as the source.</param>
+    public void Group(GroupElement element)
+    {
+        AssertSingleSource();
+        var builder = BuilderAdapter.Create(element);
+        _sourceBuilder = builder;
+    }
 
-        /// <summary>
-        /// Sets a group as the source of the existential element.
-        /// </summary>
-        /// <param name="element">Element to set as the source.</param>
-        public void Group(GroupElement element)
-        {
-            AssertSingleSource();
-            var builder = BuilderAdapter.Create(element);
-            _sourceBuilder = builder;
-        }
+    /// <summary>
+    /// Sets a group builder as the source of the existential element.
+    /// </summary>
+    /// <param name="builder">Element builder to set as the source.</param>
+    public void Group(GroupBuilder builder)
+    {
+        AssertSingleSource();
+        _sourceBuilder = builder;
+    }
 
-        /// <summary>
-        /// Sets a group builder as the source of the existential element.
-        /// </summary>
-        /// <param name="builder">Element builder to set as the source.</param>
-        public void Group(GroupBuilder builder)
-        {
-            AssertSingleSource();
-            _sourceBuilder = builder;
-        }
+    /// <summary>
+    /// Creates a group builder that builds a group as the source of the existential element.
+    /// </summary>
+    /// <param name="groupType">Group type.</param>
+    /// <returns>Group builder.</returns>
+    public GroupBuilder Group(GroupType groupType)
+    {
+        AssertSingleSource();
+        var sourceBuilder = new GroupBuilder();
+        sourceBuilder.GroupType(groupType);
+        _sourceBuilder = sourceBuilder;
+        return sourceBuilder;
+    }
 
-        /// <summary>
-        /// Creates a group builder that builds a group as the source of the existential element.
-        /// </summary>
-        /// <param name="groupType">Group type.</param>
-        /// <returns>Group builder.</returns>
-        public GroupBuilder Group(GroupType groupType)
-        {
-            AssertSingleSource();
-            var sourceBuilder = new GroupBuilder();
-            sourceBuilder.GroupType(groupType);
-            _sourceBuilder = sourceBuilder;
-            return sourceBuilder;
-        }
+    ExistsElement IBuilder<ExistsElement>.Build()
+    {
+        var sourceElement = _sourceBuilder?.Build();
+        var existsElement = Element.Exists(sourceElement);
+        return existsElement;
+    }
 
-        ExistsElement IBuilder<ExistsElement>.Build()
+    private void AssertSingleSource()
+    {
+        if (_sourceBuilder != null)
         {
-            var sourceElement = _sourceBuilder?.Build();
-            var existsElement = Element.Exists(sourceElement);
-            return existsElement;
-        }
-
-        private void AssertSingleSource()
-        {
-            if (_sourceBuilder != null)
-            {
-                throw new InvalidOperationException("EXISTS element can only have a single source");
-            }
+            throw new InvalidOperationException("EXISTS element can only have a single source");
         }
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/FilterGroupBuilder.cs
+++ b/src/NRules/NRules.RuleModel/Builders/FilterGroupBuilder.cs
@@ -1,46 +1,45 @@
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+/// <summary>
+/// Builder to compose a group of rule match filters.
+/// </summary>
+public class FilterGroupBuilder : RuleElementBuilder, IBuilder<FilterGroupElement>
 {
+    private readonly List<FilterElement> _filters = new();
+
     /// <summary>
-    /// Builder to compose a group of rule match filters.
+    /// Initializes a new instance of the <see cref="FilterGroupBuilder"/>.
     /// </summary>
-    public class FilterGroupBuilder : RuleElementBuilder, IBuilder<FilterGroupElement>
+    public FilterGroupBuilder()
     {
-        private readonly List<FilterElement> _filters = new();
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FilterGroupBuilder"/>.
-        /// </summary>
-        public FilterGroupBuilder()
-        {
-        }
+    /// <summary>
+    /// Adds a filter element to the group element.
+    /// </summary>
+    /// <param name="element">Element to add.</param>
+    public void Filter(FilterElement element)
+    {
+        _filters.Add(element);
+    }
 
-        /// <summary>
-        /// Adds a filter element to the group element.
-        /// </summary>
-        /// <param name="element">Element to add.</param>
-        public void Filter(FilterElement element)
-        {
-            _filters.Add(element);
-        }
+    /// <summary>
+    /// Adds a filter to the group element.
+    /// </summary>
+    /// <param name="filterType">Type of filter.</param>
+    /// <param name="expression">Filter expression.</param>
+    public void Filter(FilterType filterType, LambdaExpression expression)
+    {
+        var filter = Element.Filter(filterType, expression);
+        _filters.Add(filter);
+    }
 
-        /// <summary>
-        /// Adds a filter to the group element.
-        /// </summary>
-        /// <param name="filterType">Type of filter.</param>
-        /// <param name="expression">Filter expression.</param>
-        public void Filter(FilterType filterType, LambdaExpression expression)
-        {
-            var filter = Element.Filter(filterType, expression);
-            _filters.Add(filter);
-        }
-
-        FilterGroupElement IBuilder<FilterGroupElement>.Build()
-        {
-            var filterGroup = Element.FilterGroup(_filters);
-            return filterGroup;
-        }
+    FilterGroupElement IBuilder<FilterGroupElement>.Build()
+    {
+        var filterGroup = Element.FilterGroup(_filters);
+        return filterGroup;
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/ForAllBuilder.cs
+++ b/src/NRules/NRules.RuleModel/Builders/ForAllBuilder.cs
@@ -1,109 +1,108 @@
 using System;
 using System.Collections.Generic;
 
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+/// <summary>
+/// Builder to compose a forall element (universal quantifier).
+/// </summary>
+public class ForAllBuilder : RuleElementBuilder, IBuilder<ForAllElement>
 {
+    private IBuilder<PatternElement> _sourceBuilder;
+    private readonly List<IBuilder<PatternElement>> _patternBuilders = new();
+
     /// <summary>
-    /// Builder to compose a forall element (universal quantifier).
+    /// Initializes a new instance of the <see cref="ForAllBuilder"/>.
     /// </summary>
-    public class ForAllBuilder : RuleElementBuilder, IBuilder<ForAllElement>
+    public ForAllBuilder()
     {
-        private IBuilder<PatternElement> _sourceBuilder;
-        private readonly List<IBuilder<PatternElement>> _patternBuilders = new();
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ForAllBuilder"/>.
-        /// </summary>
-        public ForAllBuilder()
+    /// <summary>
+    /// Sets the base pattern of the forall element.
+    /// </summary>
+    /// <param name="element">Element to set as the base pattern.</param>
+    public void BasePattern(PatternElement element)
+    {
+        AssertSingleSource();
+        _sourceBuilder = BuilderAdapter.Create(element);
+    }
+
+    /// <summary>
+    /// Sets the base pattern builder of the forall element.
+    /// </summary>
+    /// <param name="builder">Element builder to set as the base pattern.</param>
+    public void BasePattern(PatternBuilder builder)
+    {
+        AssertSingleSource();
+        _sourceBuilder = builder;
+    }
+
+    /// <summary>
+    /// Creates a pattern builder that builds the base pattern of the forall element.
+    /// </summary>
+    /// <param name="type">Type of the element the pattern matches.</param>
+    /// <returns>Pattern builder.</returns>
+    public PatternBuilder BasePattern(Type type)
+    {
+        AssertSingleSource();
+        var declaration = Element.Declaration(type, DeclarationName(null));
+        var builder = new PatternBuilder(declaration);
+        _sourceBuilder = builder;
+        return builder;
+    }
+    
+    /// <summary>
+    /// Adds a pattern to the forall element.
+    /// </summary>
+    /// <param name="element">Element to add.</param>
+    public void Pattern(PatternElement element)
+    {
+        var builder = BuilderAdapter.Create(element);
+        _patternBuilders.Add(builder);
+    }
+
+    /// <summary>
+    /// Adds a pattern builder to the forall element.
+    /// </summary>
+    /// <param name="builder">Element builder to add.</param>
+    public void Pattern(PatternBuilder builder)
+    {
+        _patternBuilders.Add(builder);
+    }
+
+    /// <summary>
+    /// Creates a pattern builder that builds a pattern of the forall element.
+    /// </summary>
+    /// <param name="type">Type of the element the pattern matches.</param>
+    /// <returns>Pattern builder.</returns>
+    public PatternBuilder Pattern(Type type)
+    {
+        var declaration = Element.Declaration(type, DeclarationName(null));
+        var patternBuilder = new PatternBuilder(declaration);
+        _patternBuilders.Add(patternBuilder);
+        return patternBuilder;
+    }
+
+    ForAllElement IBuilder<ForAllElement>.Build()
+    {
+        PatternElement basePatternElement = _sourceBuilder?.Build();
+
+        var patternElements = new List<PatternElement>();
+        foreach (var patternBuilder in _patternBuilders)
         {
+            patternElements.Add(patternBuilder.Build());
         }
 
-        /// <summary>
-        /// Sets the base pattern of the forall element.
-        /// </summary>
-        /// <param name="element">Element to set as the base pattern.</param>
-        public void BasePattern(PatternElement element)
-        {
-            AssertSingleSource();
-            _sourceBuilder = BuilderAdapter.Create(element);
-        }
+        var forAllElement = Element.ForAll(basePatternElement, patternElements);
+        return forAllElement;
+    }
 
-        /// <summary>
-        /// Sets the base pattern builder of the forall element.
-        /// </summary>
-        /// <param name="builder">Element builder to set as the base pattern.</param>
-        public void BasePattern(PatternBuilder builder)
+    private void AssertSingleSource()
+    {
+        if (_sourceBuilder != null)
         {
-            AssertSingleSource();
-            _sourceBuilder = builder;
-        }
-
-        /// <summary>
-        /// Creates a pattern builder that builds the base pattern of the forall element.
-        /// </summary>
-        /// <param name="type">Type of the element the pattern matches.</param>
-        /// <returns>Pattern builder.</returns>
-        public PatternBuilder BasePattern(Type type)
-        {
-            AssertSingleSource();
-            var declaration = Element.Declaration(type, DeclarationName(null));
-            var builder = new PatternBuilder(declaration);
-            _sourceBuilder = builder;
-            return builder;
-        }
-        
-        /// <summary>
-        /// Adds a pattern to the forall element.
-        /// </summary>
-        /// <param name="element">Element to add.</param>
-        public void Pattern(PatternElement element)
-        {
-            var builder = BuilderAdapter.Create(element);
-            _patternBuilders.Add(builder);
-        }
-
-        /// <summary>
-        /// Adds a pattern builder to the forall element.
-        /// </summary>
-        /// <param name="builder">Element builder to add.</param>
-        public void Pattern(PatternBuilder builder)
-        {
-            _patternBuilders.Add(builder);
-        }
-
-        /// <summary>
-        /// Creates a pattern builder that builds a pattern of the forall element.
-        /// </summary>
-        /// <param name="type">Type of the element the pattern matches.</param>
-        /// <returns>Pattern builder.</returns>
-        public PatternBuilder Pattern(Type type)
-        {
-            var declaration = Element.Declaration(type, DeclarationName(null));
-            var patternBuilder = new PatternBuilder(declaration);
-            _patternBuilders.Add(patternBuilder);
-            return patternBuilder;
-        }
-
-        ForAllElement IBuilder<ForAllElement>.Build()
-        {
-            PatternElement basePatternElement = _sourceBuilder?.Build();
-
-            var patternElements = new List<PatternElement>();
-            foreach (var patternBuilder in _patternBuilders)
-            {
-                patternElements.Add(patternBuilder.Build());
-            }
-
-            var forAllElement = Element.ForAll(basePatternElement, patternElements);
-            return forAllElement;
-        }
-
-        private void AssertSingleSource()
-        {
-            if (_sourceBuilder != null)
-            {
-                throw new InvalidOperationException("FORALL element can only have a single source");
-            }
+            throw new InvalidOperationException("FORALL element can only have a single source");
         }
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/GroupBuilder.cs
+++ b/src/NRules/NRules.RuleModel/Builders/GroupBuilder.cs
@@ -1,223 +1,222 @@
 using System;
 using System.Collections.Generic;
 
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+/// <summary>
+/// Type of group element.
+/// </summary>
+public enum GroupType
 {
     /// <summary>
-    /// Type of group element.
+    /// Logical AND.
     /// </summary>
-    public enum GroupType
-    {
-        /// <summary>
-        /// Logical AND.
-        /// </summary>
-        And = 0,
+    And = 0,
 
-        /// <summary>
-        /// Logical OR.
-        /// </summary>
-        Or = 1,
+    /// <summary>
+    /// Logical OR.
+    /// </summary>
+    Or = 1,
+}
+
+/// <summary>
+/// Builder to compose a group element.
+/// </summary>
+public class GroupBuilder : RuleElementBuilder, IBuilder<GroupElement>
+{
+    private readonly List<IBuilder<RuleElement>> _nestedBuilders = new();
+    private GroupType _groupType;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GroupBuilder"/>.
+    /// </summary>
+    public GroupBuilder()
+    {
     }
 
     /// <summary>
-    /// Builder to compose a group element.
+    /// Sets type of the group element.
     /// </summary>
-    public class GroupBuilder : RuleElementBuilder, IBuilder<GroupElement>
+    /// <param name="groupType">Group type to set.</param>
+    public void GroupType(GroupType groupType)
     {
-        private readonly List<IBuilder<RuleElement>> _nestedBuilders = new();
-        private GroupType _groupType;
+        _groupType = groupType;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GroupBuilder"/>.
-        /// </summary>
-        public GroupBuilder()
-        {
-        }
+    /// <summary>
+    /// Adds a pattern to the group element.
+    /// </summary>
+    /// <param name="element">Element to add.</param>
+    public void Pattern(PatternElement element)
+    {
+        var builder = BuilderAdapter.Create(element);
+        _nestedBuilders.Add(builder);
+    }
 
-        /// <summary>
-        /// Sets type of the group element.
-        /// </summary>
-        /// <param name="groupType">Group type to set.</param>
-        public void GroupType(GroupType groupType)
-        {
-            _groupType = groupType;
-        }
+    /// <summary>
+    /// Adds a pattern builder to the group element.
+    /// </summary>
+    /// <param name="builder">Element builder to add.</param>
+    public void Pattern(PatternBuilder builder)
+    {
+        _nestedBuilders.Add(builder);
+    }
 
-        /// <summary>
-        /// Adds a pattern to the group element.
-        /// </summary>
-        /// <param name="element">Element to add.</param>
-        public void Pattern(PatternElement element)
-        {
-            var builder = BuilderAdapter.Create(element);
-            _nestedBuilders.Add(builder);
-        }
+    /// <summary>
+    /// Creates a pattern builder that builds a pattern as part of the current group element.
+    /// </summary>
+    /// <param name="type">Pattern type.</param>
+    /// <param name="name">Pattern name (optional).</param>
+    /// <returns>Pattern builder.</returns>
+    public PatternBuilder Pattern(Type type, string name = null)
+    {
+        var declaration = Element.Declaration(type, DeclarationName(name));
+        return Pattern(declaration);
+    }
 
-        /// <summary>
-        /// Adds a pattern builder to the group element.
-        /// </summary>
-        /// <param name="builder">Element builder to add.</param>
-        public void Pattern(PatternBuilder builder)
-        {
-            _nestedBuilders.Add(builder);
-        }
+    /// <summary>
+    /// Creates a pattern builder that builds a pattern as part of the current group element.
+    /// </summary>
+    /// <param name="declaration">Pattern declaration.</param>
+    /// <returns>Pattern builder.</returns>
+    public PatternBuilder Pattern(Declaration declaration)
+    {
+        var builder = new PatternBuilder(declaration);
+        _nestedBuilders.Add(builder);
+        return builder;            
+    }
 
-        /// <summary>
-        /// Creates a pattern builder that builds a pattern as part of the current group element.
-        /// </summary>
-        /// <param name="type">Pattern type.</param>
-        /// <param name="name">Pattern name (optional).</param>
-        /// <returns>Pattern builder.</returns>
-        public PatternBuilder Pattern(Type type, string name = null)
-        {
-            var declaration = Element.Declaration(type, DeclarationName(name));
-            return Pattern(declaration);
-        }
+    /// <summary>
+    /// Adds a nested group to this group element.
+    /// </summary>
+    /// <param name="element">Element to add.</param>
+    public void Group(GroupElement element)
+    {
+        var builder = BuilderAdapter.Create(element);
+        _nestedBuilders.Add(builder);
+    }
 
-        /// <summary>
-        /// Creates a pattern builder that builds a pattern as part of the current group element.
-        /// </summary>
-        /// <param name="declaration">Pattern declaration.</param>
-        /// <returns>Pattern builder.</returns>
-        public PatternBuilder Pattern(Declaration declaration)
-        {
-            var builder = new PatternBuilder(declaration);
-            _nestedBuilders.Add(builder);
-            return builder;            
-        }
+    /// <summary>
+    /// Adds a nested group builder to this group element.
+    /// </summary>
+    /// <param name="builder">Element builder to add.</param>
+    public void Group(GroupBuilder builder)
+    {
+        _nestedBuilders.Add(builder);
+    }
 
-        /// <summary>
-        /// Adds a nested group to this group element.
-        /// </summary>
-        /// <param name="element">Element to add.</param>
-        public void Group(GroupElement element)
-        {
-            var builder = BuilderAdapter.Create(element);
-            _nestedBuilders.Add(builder);
-        }
+    /// <summary>
+    /// Creates a group builder that builds a group as part of the current group element.
+    /// </summary>
+    /// <param name="groupType">Group type.</param>
+    /// <returns>Group builder.</returns>
+    public GroupBuilder Group(GroupType groupType)
+    {
+        var builder = new GroupBuilder();
+        builder.GroupType(groupType);
+        _nestedBuilders.Add(builder);
+        return builder;
+    }
 
-        /// <summary>
-        /// Adds a nested group builder to this group element.
-        /// </summary>
-        /// <param name="builder">Element builder to add.</param>
-        public void Group(GroupBuilder builder)
-        {
-            _nestedBuilders.Add(builder);
-        }
+    /// <summary>
+    /// Adds an existential element to the group element.
+    /// </summary>
+    /// <param name="element">Element to add.</param>
+    public void Exists(ExistsElement element)
+    {
+        var builder = BuilderAdapter.Create(element);
+        _nestedBuilders.Add(builder);
+    }
 
-        /// <summary>
-        /// Creates a group builder that builds a group as part of the current group element.
-        /// </summary>
-        /// <param name="groupType">Group type.</param>
-        /// <returns>Group builder.</returns>
-        public GroupBuilder Group(GroupType groupType)
-        {
-            var builder = new GroupBuilder();
-            builder.GroupType(groupType);
-            _nestedBuilders.Add(builder);
-            return builder;
-        }
+    /// <summary>
+    /// Adds an existential element builder to the group element.
+    /// </summary>
+    /// <param name="builder">Element builder to add.</param>
+    public void Exists(ExistsBuilder builder)
+    {
+        _nestedBuilders.Add(builder);
+    }
 
-        /// <summary>
-        /// Adds an existential element to the group element.
-        /// </summary>
-        /// <param name="element">Element to add.</param>
-        public void Exists(ExistsElement element)
-        {
-            var builder = BuilderAdapter.Create(element);
-            _nestedBuilders.Add(builder);
-        }
+    /// <summary>
+    /// Creates a builder for an existential element as part of the current group element.
+    /// </summary>
+    /// <returns>Existential builder.</returns>
+    public ExistsBuilder Exists()
+    {
+        var builder = new ExistsBuilder();
+        _nestedBuilders.Add(builder);
+        return builder;
+    }
 
-        /// <summary>
-        /// Adds an existential element builder to the group element.
-        /// </summary>
-        /// <param name="builder">Element builder to add.</param>
-        public void Exists(ExistsBuilder builder)
-        {
-            _nestedBuilders.Add(builder);
-        }
+    /// <summary>
+    /// Adds a negative existential element to the group element.
+    /// </summary>
+    /// <param name="element">Element to add.</param>
+    public void Not(NotElement element)
+    {
+        var builder = BuilderAdapter.Create(element);
+        _nestedBuilders.Add(builder);
+    }
 
-        /// <summary>
-        /// Creates a builder for an existential element as part of the current group element.
-        /// </summary>
-        /// <returns>Existential builder.</returns>
-        public ExistsBuilder Exists()
-        {
-            var builder = new ExistsBuilder();
-            _nestedBuilders.Add(builder);
-            return builder;
-        }
+    /// <summary>
+    /// Adds a negative existential element builder to the group element.
+    /// </summary>
+    /// <param name="builder">Element builder to add.</param>
+    public void Not(NotBuilder builder)
+    {
+        _nestedBuilders.Add(builder);
+    }
 
-        /// <summary>
-        /// Adds a negative existential element to the group element.
-        /// </summary>
-        /// <param name="element">Element to add.</param>
-        public void Not(NotElement element)
-        {
-            var builder = BuilderAdapter.Create(element);
-            _nestedBuilders.Add(builder);
-        }
+    /// <summary>
+    /// Creates a builder for a negative existential element as part of the current group element.
+    /// </summary>
+    /// <returns>Negative existential builder.</returns>
+    public NotBuilder Not()
+    {
+        var builder = new NotBuilder();
+        _nestedBuilders.Add(builder);
+        return builder;
+    }
 
-        /// <summary>
-        /// Adds a negative existential element builder to the group element.
-        /// </summary>
-        /// <param name="builder">Element builder to add.</param>
-        public void Not(NotBuilder builder)
-        {
-            _nestedBuilders.Add(builder);
-        }
+    /// <summary>
+    /// Adds a forall element to the group element.
+    /// </summary>
+    /// <param name="element">Element to add.</param>
+    public void ForAll(ForAllElement element)
+    {
+        var builder = BuilderAdapter.Create(element);
+        _nestedBuilders.Add(builder);
+    }
 
-        /// <summary>
-        /// Creates a builder for a negative existential element as part of the current group element.
-        /// </summary>
-        /// <returns>Negative existential builder.</returns>
-        public NotBuilder Not()
-        {
-            var builder = new NotBuilder();
-            _nestedBuilders.Add(builder);
-            return builder;
-        }
+    /// <summary>
+    /// Adds a forall element builder to the group element.
+    /// </summary>
+    /// <param name="builder">Element builder to add.</param>
+    public void ForAll(ForAllBuilder builder)
+    {
+        _nestedBuilders.Add(builder);
+    }
 
-        /// <summary>
-        /// Adds a forall element to the group element.
-        /// </summary>
-        /// <param name="element">Element to add.</param>
-        public void ForAll(ForAllElement element)
-        {
-            var builder = BuilderAdapter.Create(element);
-            _nestedBuilders.Add(builder);
-        }
+    /// <summary>
+    /// Creates a builder for a forall element as part of the current group element.
+    /// </summary>
+    /// <returns>Forall builder.</returns>
+    public ForAllBuilder ForAll()
+    {
+        var builder = new ForAllBuilder();
+        _nestedBuilders.Add(builder);
+        return builder;
+    }
 
-        /// <summary>
-        /// Adds a forall element builder to the group element.
-        /// </summary>
-        /// <param name="builder">Element builder to add.</param>
-        public void ForAll(ForAllBuilder builder)
+    GroupElement IBuilder<GroupElement>.Build()
+    {
+        var childElements = new List<RuleElement>();
+        foreach (var builder in _nestedBuilders)
         {
-            _nestedBuilders.Add(builder);
+            var childElement = builder.Build();
+            childElements.Add(childElement);
         }
-
-        /// <summary>
-        /// Creates a builder for a forall element as part of the current group element.
-        /// </summary>
-        /// <returns>Forall builder.</returns>
-        public ForAllBuilder ForAll()
-        {
-            var builder = new ForAllBuilder();
-            _nestedBuilders.Add(builder);
-            return builder;
-        }
-
-        GroupElement IBuilder<GroupElement>.Build()
-        {
-            var childElements = new List<RuleElement>();
-            foreach (var builder in _nestedBuilders)
-            {
-                var childElement = builder.Build();
-                childElements.Add(childElement);
-            }
-            var groupElement = Element.Group(_groupType, childElements);
-            return groupElement;
-        }
+        var groupElement = Element.Group(_groupType, childElements);
+        return groupElement;
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/IBuilder.cs
+++ b/src/NRules/NRules.RuleModel/Builders/IBuilder.cs
@@ -1,7 +1,6 @@
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+internal interface IBuilder<out TElement> where TElement : RuleElement
 {
-    internal interface IBuilder<out TElement> where TElement : RuleElement
-    {
-        TElement Build();
-    }
+    TElement Build();
 }

--- a/src/NRules/NRules.RuleModel/Builders/NotBuilder.cs
+++ b/src/NRules/NRules.RuleModel/Builders/NotBuilder.cs
@@ -1,114 +1,113 @@
 using System;
 
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+/// <summary>
+/// Builder to compose a negative existential element.
+/// </summary>
+public class NotBuilder : RuleElementBuilder, IBuilder<NotElement>
 {
+    private IBuilder<RuleElement> _sourceBuilder;
+
     /// <summary>
-    /// Builder to compose a negative existential element.
+    /// Initializes a new instance of the <see cref="NotBuilder"/>.
     /// </summary>
-    public class NotBuilder : RuleElementBuilder, IBuilder<NotElement>
+    public NotBuilder()
     {
-        private IBuilder<RuleElement> _sourceBuilder;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NotBuilder"/>.
-        /// </summary>
-        public NotBuilder()
-        {
-        }
+    /// <summary>
+    /// Sets a pattern as the source of the negative existential element.
+    /// </summary>
+    /// <param name="element">Element to set as the source.</param>
+    public void Pattern(PatternElement element)
+    {
+        AssertSingleSource();
+        _sourceBuilder = BuilderAdapter.Create(element);
+    }
 
-        /// <summary>
-        /// Sets a pattern as the source of the negative existential element.
-        /// </summary>
-        /// <param name="element">Element to set as the source.</param>
-        public void Pattern(PatternElement element)
-        {
-            AssertSingleSource();
-            _sourceBuilder = BuilderAdapter.Create(element);
-        }
+    /// <summary>
+    /// Sets a pattern builder as the source of the negative existential element.
+    /// </summary>
+    /// <param name="builder">Element builder to set as the source.</param>
+    public void Pattern(PatternBuilder builder)
+    {
+        AssertSingleSource();
+        _sourceBuilder = builder;
+    }
 
-        /// <summary>
-        /// Sets a pattern builder as the source of the negative existential element.
-        /// </summary>
-        /// <param name="builder">Element builder to set as the source.</param>
-        public void Pattern(PatternBuilder builder)
-        {
-            AssertSingleSource();
-            _sourceBuilder = builder;
-        }
+    /// <summary>
+    /// Creates a pattern builder that builds the source of the negative existential element.
+    /// </summary>
+    /// <param name="type">Type of the element the pattern matches.</param>
+    /// <param name="name">Pattern name (optional).</param>
+    /// <returns>Pattern builder.</returns>
+    public PatternBuilder Pattern(Type type, string name = null)
+    {
+        var declaration = Element.Declaration(type, DeclarationName(name));
+        return Pattern(declaration);
+    }
 
-        /// <summary>
-        /// Creates a pattern builder that builds the source of the negative existential element.
-        /// </summary>
-        /// <param name="type">Type of the element the pattern matches.</param>
-        /// <param name="name">Pattern name (optional).</param>
-        /// <returns>Pattern builder.</returns>
-        public PatternBuilder Pattern(Type type, string name = null)
-        {
-            var declaration = Element.Declaration(type, DeclarationName(name));
-            return Pattern(declaration);
-        }
+    /// <summary>
+    /// Creates a pattern builder that builds the source of the negative existential element.
+    /// </summary>
+    /// <param name="declaration">Pattern declaration.</param>
+    /// <returns>Pattern builder.</returns>
+    public PatternBuilder Pattern(Declaration declaration)
+    {
+        AssertSingleSource();
+        var sourceBuilder = new PatternBuilder(declaration);
+        _sourceBuilder = sourceBuilder;
+        return sourceBuilder;
+    }
 
-        /// <summary>
-        /// Creates a pattern builder that builds the source of the negative existential element.
-        /// </summary>
-        /// <param name="declaration">Pattern declaration.</param>
-        /// <returns>Pattern builder.</returns>
-        public PatternBuilder Pattern(Declaration declaration)
-        {
-            AssertSingleSource();
-            var sourceBuilder = new PatternBuilder(declaration);
-            _sourceBuilder = sourceBuilder;
-            return sourceBuilder;
-        }
+    /// <summary>
+    /// Sets a group as the source of the negative existential element.
+    /// </summary>
+    /// <param name="element">Element to set as the source.</param>
+    public void Group(GroupElement element)
+    {
+        AssertSingleSource();
+        var builder = BuilderAdapter.Create(element);
+        _sourceBuilder = builder;
+    }
 
-        /// <summary>
-        /// Sets a group as the source of the negative existential element.
-        /// </summary>
-        /// <param name="element">Element to set as the source.</param>
-        public void Group(GroupElement element)
-        {
-            AssertSingleSource();
-            var builder = BuilderAdapter.Create(element);
-            _sourceBuilder = builder;
-        }
+    /// <summary>
+    /// Sets a group builder as the source of the negative existential element.
+    /// </summary>
+    /// <param name="builder">Element builder to set as the source.</param>
+    public void Group(GroupBuilder builder)
+    {
+        AssertSingleSource();
+        _sourceBuilder = builder;
+    }
 
-        /// <summary>
-        /// Sets a group builder as the source of the negative existential element.
-        /// </summary>
-        /// <param name="builder">Element builder to set as the source.</param>
-        public void Group(GroupBuilder builder)
-        {
-            AssertSingleSource();
-            _sourceBuilder = builder;
-        }
+    /// <summary>
+    /// Creates a group builder that builds a group as the source of the negative existential element.
+    /// </summary>
+    /// <param name="groupType">Group type.</param>
+    /// <returns>Group builder.</returns>
+    public GroupBuilder Group(GroupType groupType)
+    {
+        AssertSingleSource();
+        var sourceBuilder = new GroupBuilder();
+        sourceBuilder.GroupType(groupType);
+        _sourceBuilder = sourceBuilder;
+        return sourceBuilder;
+    }
 
-        /// <summary>
-        /// Creates a group builder that builds a group as the source of the negative existential element.
-        /// </summary>
-        /// <param name="groupType">Group type.</param>
-        /// <returns>Group builder.</returns>
-        public GroupBuilder Group(GroupType groupType)
-        {
-            AssertSingleSource();
-            var sourceBuilder = new GroupBuilder();
-            sourceBuilder.GroupType(groupType);
-            _sourceBuilder = sourceBuilder;
-            return sourceBuilder;
-        }
+    NotElement IBuilder<NotElement>.Build()
+    {
+        var sourceElement = _sourceBuilder?.Build();
+        var notElement = Element.Not(sourceElement);
+        return notElement;
+    }
 
-        NotElement IBuilder<NotElement>.Build()
+    private void AssertSingleSource()
+    {
+        if (_sourceBuilder != null)
         {
-            var sourceElement = _sourceBuilder?.Build();
-            var notElement = Element.Not(sourceElement);
-            return notElement;
-        }
-
-        private void AssertSingleSource()
-        {
-            if (_sourceBuilder != null)
-            {
-                throw new InvalidOperationException("NOT element can only have a single source");
-            }
+            throw new InvalidOperationException("NOT element can only have a single source");
         }
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/PatternBuilder.cs
+++ b/src/NRules/NRules.RuleModel/Builders/PatternBuilder.cs
@@ -2,137 +2,136 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+/// <summary>
+/// Builder to compose a rule pattern.
+/// </summary>
+public class PatternBuilder : RuleElementBuilder, IBuilder<PatternElement>
 {
+    private readonly List<KeyValuePair<string, LambdaExpression>> _expressions = new();
+    private IBuilder<RuleElement> _sourceBuilder;
+
     /// <summary>
-    /// Builder to compose a rule pattern.
+    /// Initializes a new instance of the <see cref="PatternBuilder"/>.
     /// </summary>
-    public class PatternBuilder : RuleElementBuilder, IBuilder<PatternElement>
+    /// <param name="type">Pattern type.</param>
+    /// <param name="name">Pattern name.</param>
+    public PatternBuilder(Type type, string name)
     {
-        private readonly List<KeyValuePair<string, LambdaExpression>> _expressions = new();
-        private IBuilder<RuleElement> _sourceBuilder;
+        Declaration = Element.Declaration(type, name ?? "$this$");
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PatternBuilder"/>.
-        /// </summary>
-        /// <param name="type">Pattern type.</param>
-        /// <param name="name">Pattern name.</param>
-        public PatternBuilder(Type type, string name)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PatternBuilder"/>.
+    /// </summary>
+    /// <param name="declaration">Pattern declaration.</param>
+    public PatternBuilder(Declaration declaration)
+    {
+        Declaration = declaration;
+    }
+
+    /// <summary>
+    /// Adds a condition expression to the pattern element.
+    /// </summary>
+    /// <param name="expression">Condition expression.
+    /// Names and types of the expression parameters must match the names and types defined in the pattern declarations.</param>
+    public void Condition(LambdaExpression expression)
+    {
+        AddExpression(PatternElement.ConditionName, expression);
+    }
+
+    /// <summary>
+    /// Pattern declaration.
+    /// </summary>
+    public Declaration Declaration { get; }
+
+    /// <summary>
+    /// Sets an aggregate element as the source of the pattern element.
+    /// </summary>
+    /// <param name="element">Element to set as the source.</param>
+    public void Aggregate(AggregateElement element)
+    {
+        AssertSingleSource();
+        var builder = BuilderAdapter.Create(element);
+        _sourceBuilder = builder;
+    }
+
+    /// <summary>
+    /// Sets an aggregate builder as the source of the pattern element.
+    /// </summary>
+    /// <param name="builder">Element builder to set as the source.</param>
+    public void Aggregate(AggregateBuilder builder)
+    {
+        AssertSingleSource();
+        builder.ResultType(Declaration.Type);
+        _sourceBuilder = builder;
+    }
+
+    /// <summary>
+    /// Creates an aggregate builder that builds the source of the pattern element.
+    /// </summary>
+    /// <returns>Aggregate builder.</returns>
+    public AggregateBuilder Aggregate()
+    {
+        AssertSingleSource();
+        var builder = new AggregateBuilder();
+        builder.ResultType(Declaration.Type);
+        _sourceBuilder = builder;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets a binding element as the source of the pattern element.
+    /// </summary>
+    /// <param name="element">Element to set as the source.</param>
+    public void Binding(BindingElement element)
+    {
+        AssertSingleSource();
+        var builder = BuilderAdapter.Create(element);
+        _sourceBuilder = builder;
+    }
+
+    /// <summary>
+    /// Sets a binding builder as the source of the pattern element.
+    /// </summary>
+    /// <param name="builder">Element builder to set as the source.</param>
+    public void Binding(BindingBuilder builder)
+    {
+        AssertSingleSource();
+        builder.ResultType(Declaration.Type);
+        _sourceBuilder = builder;
+    }
+
+    /// <summary>
+    /// Creates a binding builder that builds the source of the pattern element.
+    /// </summary>
+    /// <returns>Binding builder.</returns>
+    public BindingBuilder Binding()
+    {
+        var builder = new BindingBuilder();
+        builder.ResultType(Declaration.Type);
+        _sourceBuilder = builder;
+        return builder;
+    }
+
+    PatternElement IBuilder<PatternElement>.Build()
+    {
+        var source = _sourceBuilder?.Build();
+        var patternElement = Element.Pattern(Declaration, _expressions, source);
+        return patternElement;
+    }
+
+    private void AddExpression(string name, LambdaExpression expression)
+    {
+        _expressions.Add(new KeyValuePair<string, LambdaExpression>(name, expression));
+    }
+
+    private void AssertSingleSource()
+    {
+        if (_sourceBuilder != null)
         {
-            Declaration = Element.Declaration(type, name ?? "$this$");
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PatternBuilder"/>.
-        /// </summary>
-        /// <param name="declaration">Pattern declaration.</param>
-        public PatternBuilder(Declaration declaration)
-        {
-            Declaration = declaration;
-        }
-
-        /// <summary>
-        /// Adds a condition expression to the pattern element.
-        /// </summary>
-        /// <param name="expression">Condition expression.
-        /// Names and types of the expression parameters must match the names and types defined in the pattern declarations.</param>
-        public void Condition(LambdaExpression expression)
-        {
-            AddExpression(PatternElement.ConditionName, expression);
-        }
-
-        /// <summary>
-        /// Pattern declaration.
-        /// </summary>
-        public Declaration Declaration { get; }
-
-        /// <summary>
-        /// Sets an aggregate element as the source of the pattern element.
-        /// </summary>
-        /// <param name="element">Element to set as the source.</param>
-        public void Aggregate(AggregateElement element)
-        {
-            AssertSingleSource();
-            var builder = BuilderAdapter.Create(element);
-            _sourceBuilder = builder;
-        }
-
-        /// <summary>
-        /// Sets an aggregate builder as the source of the pattern element.
-        /// </summary>
-        /// <param name="builder">Element builder to set as the source.</param>
-        public void Aggregate(AggregateBuilder builder)
-        {
-            AssertSingleSource();
-            builder.ResultType(Declaration.Type);
-            _sourceBuilder = builder;
-        }
-
-        /// <summary>
-        /// Creates an aggregate builder that builds the source of the pattern element.
-        /// </summary>
-        /// <returns>Aggregate builder.</returns>
-        public AggregateBuilder Aggregate()
-        {
-            AssertSingleSource();
-            var builder = new AggregateBuilder();
-            builder.ResultType(Declaration.Type);
-            _sourceBuilder = builder;
-            return builder;
-        }
-
-        /// <summary>
-        /// Sets a binding element as the source of the pattern element.
-        /// </summary>
-        /// <param name="element">Element to set as the source.</param>
-        public void Binding(BindingElement element)
-        {
-            AssertSingleSource();
-            var builder = BuilderAdapter.Create(element);
-            _sourceBuilder = builder;
-        }
-
-        /// <summary>
-        /// Sets a binding builder as the source of the pattern element.
-        /// </summary>
-        /// <param name="builder">Element builder to set as the source.</param>
-        public void Binding(BindingBuilder builder)
-        {
-            AssertSingleSource();
-            builder.ResultType(Declaration.Type);
-            _sourceBuilder = builder;
-        }
-
-        /// <summary>
-        /// Creates a binding builder that builds the source of the pattern element.
-        /// </summary>
-        /// <returns>Binding builder.</returns>
-        public BindingBuilder Binding()
-        {
-            var builder = new BindingBuilder();
-            builder.ResultType(Declaration.Type);
-            _sourceBuilder = builder;
-            return builder;
-        }
-
-        PatternElement IBuilder<PatternElement>.Build()
-        {
-            var source = _sourceBuilder?.Build();
-            var patternElement = Element.Pattern(Declaration, _expressions, source);
-            return patternElement;
-        }
-
-        private void AddExpression(string name, LambdaExpression expression)
-        {
-            _expressions.Add(new KeyValuePair<string, LambdaExpression>(name, expression));
-        }
-
-        private void AssertSingleSource()
-        {
-            if (_sourceBuilder != null)
-            {
-                throw new InvalidOperationException("Pattern element can only have a single source");
-            }
+            throw new InvalidOperationException("Pattern element can only have a single source");
         }
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/RuleBuilder.cs
+++ b/src/NRules/NRules.RuleModel/Builders/RuleBuilder.cs
@@ -1,230 +1,229 @@
 using System;
 using System.Collections.Generic;
 
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+/// <summary>
+/// Builder to compose a rule definition.
+/// Contains methods to specify rule's metadata, as well as create child builders for rule's left-hand side and right-hand side.
+/// Creates <see cref="IRuleDefinition"/>.
+/// </summary>
+/// <threadsafety instance="false" />
+public class RuleBuilder
 {
+    private string _name;
+    private string _description = string.Empty;
+    private int _priority = RuleDefinition.DefaultPriority;
+    private RuleRepeatability _repeatability = RuleDefinition.DefaultRepeatability;
+    private readonly List<string> _tags = new();
+    private readonly List<RuleProperty> _properties = new();
+
+    private DependencyGroupBuilder _dependencyGroupBuilder;
+    private GroupBuilder _lhsBuilder;
+    private FilterGroupBuilder _filterGroupBuilder;
+    private ActionGroupBuilder _rhsBuilder;
+
     /// <summary>
-    /// Builder to compose a rule definition.
-    /// Contains methods to specify rule's metadata, as well as create child builders for rule's left-hand side and right-hand side.
-    /// Creates <see cref="IRuleDefinition"/>.
+    /// Constructs an empty rule builder.
     /// </summary>
-    /// <threadsafety instance="false" />
-    public class RuleBuilder
+    public RuleBuilder()
     {
-        private string _name;
-        private string _description = string.Empty;
-        private int _priority = RuleDefinition.DefaultPriority;
-        private RuleRepeatability _repeatability = RuleDefinition.DefaultRepeatability;
-        private readonly List<string> _tags = new();
-        private readonly List<RuleProperty> _properties = new();
+    }
 
-        private DependencyGroupBuilder _dependencyGroupBuilder;
-        private GroupBuilder _lhsBuilder;
-        private FilterGroupBuilder _filterGroupBuilder;
-        private ActionGroupBuilder _rhsBuilder;
+    /// <summary>
+    /// Sets rule's name.
+    /// </summary>
+    /// <param name="name">Rule name value.</param>
+    public void Name(string name)
+    {
+        _name = name;
+    }
 
-        /// <summary>
-        /// Constructs an empty rule builder.
-        /// </summary>
-        public RuleBuilder()
-        {
-        }
+    /// <summary>
+    /// Sets rule's description.
+    /// </summary>
+    /// <param name="description">Rule description value.</param>
+    public void Description(string description)
+    {
+        _description = description;
+    }
 
-        /// <summary>
-        /// Sets rule's name.
-        /// </summary>
-        /// <param name="name">Rule name value.</param>
-        public void Name(string name)
-        {
-            _name = name;
-        }
+    /// <summary>
+    /// Adds rule's tags.
+    /// </summary>
+    /// <param name="tags">Rule tag values.</param>
+    public void Tags(IEnumerable<string> tags)
+    {
+        _tags.AddRange(tags);
+    }
 
-        /// <summary>
-        /// Sets rule's description.
-        /// </summary>
-        /// <param name="description">Rule description value.</param>
-        public void Description(string description)
-        {
-            _description = description;
-        }
+    /// <summary>
+    /// Adds rule's tag.
+    /// </summary>
+    /// <param name="tag">Rule tag value.</param>
+    public void Tag(string tag)
+    {
+        _tags.Add(tag);
+    }
 
-        /// <summary>
-        /// Adds rule's tags.
-        /// </summary>
-        /// <param name="tags">Rule tag values.</param>
-        public void Tags(IEnumerable<string> tags)
-        {
-            _tags.AddRange(tags);
-        }
+    /// <summary>
+    /// Adds rule's properties.
+    /// </summary>
+    /// <param name="properties">Rule property.</param>
+    public void Properties(IEnumerable<RuleProperty> properties)
+    {
+        _properties.AddRange(properties);
+    }
 
-        /// <summary>
-        /// Adds rule's tag.
-        /// </summary>
-        /// <param name="tag">Rule tag value.</param>
-        public void Tag(string tag)
-        {
-            _tags.Add(tag);
-        }
+    /// <summary>
+    /// Adds rule's property.
+    /// </summary>
+    /// <param name="name">Property name.</param>
+    /// <param name="value">Property value.</param>
+    public void Property(string name, object value)
+    {
+        var property = new RuleProperty(name, value);
+        _properties.Add(property);
+    }
 
-        /// <summary>
-        /// Adds rule's properties.
-        /// </summary>
-        /// <param name="properties">Rule property.</param>
-        public void Properties(IEnumerable<RuleProperty> properties)
-        {
-            _properties.AddRange(properties);
-        }
+    /// <summary>
+    /// Sets rule's priority.
+    /// Default priority is 0.
+    /// </summary>
+    /// <param name="priority">Rule priority value.</param>
+    public void Priority(int priority)
+    {
+        _priority = priority;
+    }
 
-        /// <summary>
-        /// Adds rule's property.
-        /// </summary>
-        /// <param name="name">Property name.</param>
-        /// <param name="value">Property value.</param>
-        public void Property(string name, object value)
-        {
-            var property = new RuleProperty(name, value);
-            _properties.Add(property);
-        }
+    /// <summary>
+    /// Sets rule's repeatability.
+    /// Default repeatability is <see cref="RuleRepeatability.Repeatable"/>.
+    /// </summary>
+    public void Repeatability(RuleRepeatability repeatability)
+    {
+        _repeatability = repeatability;
+    }
 
-        /// <summary>
-        /// Sets rule's priority.
-        /// Default priority is 0.
-        /// </summary>
-        /// <param name="priority">Rule priority value.</param>
-        public void Priority(int priority)
-        {
-            _priority = priority;
-        }
+    /// <summary>
+    /// Retrieves dependencies builder.
+    /// </summary>
+    /// <returns>Dependencies builder.</returns>
+    public DependencyGroupBuilder Dependencies()
+    {
+        if (_dependencyGroupBuilder == null)
+            _dependencyGroupBuilder = new DependencyGroupBuilder();
 
-        /// <summary>
-        /// Sets rule's repeatability.
-        /// Default repeatability is <see cref="RuleRepeatability.Repeatable"/>.
-        /// </summary>
-        public void Repeatability(RuleRepeatability repeatability)
-        {
-            _repeatability = repeatability;
-        }
+        return _dependencyGroupBuilder;
+    }
 
-        /// <summary>
-        /// Retrieves dependencies builder.
-        /// </summary>
-        /// <returns>Dependencies builder.</returns>
-        public DependencyGroupBuilder Dependencies()
-        {
-            if (_dependencyGroupBuilder == null)
-                _dependencyGroupBuilder = new DependencyGroupBuilder();
+    /// <summary>
+    /// Sets dependencies builder.
+    /// </summary>
+    /// <param name="builder">Builder to set.</param>
+    public void Dependencies(DependencyGroupBuilder builder)
+    {
+        if (_dependencyGroupBuilder != null)
+            throw new ArgumentException("Builder for dependencies is already set", nameof(builder));
 
-            return _dependencyGroupBuilder;
-        }
+        _dependencyGroupBuilder = builder;
+    }
 
-        /// <summary>
-        /// Sets dependencies builder.
-        /// </summary>
-        /// <param name="builder">Builder to set.</param>
-        public void Dependencies(DependencyGroupBuilder builder)
-        {
-            if (_dependencyGroupBuilder != null)
-                throw new ArgumentException("Builder for dependencies is already set", nameof(builder));
+    /// <summary>
+    /// Retrieves left-hand side builder (conditions).
+    /// </summary>
+    /// <returns>Left hand side builder.</returns>
+    public GroupBuilder LeftHandSide()
+    {
+        if (_lhsBuilder == null)
+            _lhsBuilder = new GroupBuilder();
 
-            _dependencyGroupBuilder = builder;
-        }
+        return _lhsBuilder;
+    }
 
-        /// <summary>
-        /// Retrieves left-hand side builder (conditions).
-        /// </summary>
-        /// <returns>Left hand side builder.</returns>
-        public GroupBuilder LeftHandSide()
-        {
-            if (_lhsBuilder == null)
-                _lhsBuilder = new GroupBuilder();
+    /// <summary>
+    /// Sets left-hand side builder (conditions).
+    /// </summary>
+    /// <param name="builder">Builder to set.</param>
+    public void LeftHandSide(GroupBuilder builder)
+    {
+        if (_lhsBuilder != null)
+            throw new ArgumentException("Builder for left-hand side is already set", nameof(builder));
 
-            return _lhsBuilder;
-        }
+        _lhsBuilder = builder;
+    }
 
-        /// <summary>
-        /// Sets left-hand side builder (conditions).
-        /// </summary>
-        /// <param name="builder">Builder to set.</param>
-        public void LeftHandSide(GroupBuilder builder)
-        {
-            if (_lhsBuilder != null)
-                throw new ArgumentException("Builder for left-hand side is already set", nameof(builder));
+    /// <summary>
+    /// Retrieves filters builder.
+    /// </summary>
+    /// <returns>Filters builder.</returns>
+    public FilterGroupBuilder Filters()
+    {
+        if (_filterGroupBuilder == null)
+            _filterGroupBuilder = new FilterGroupBuilder();
 
-            _lhsBuilder = builder;
-        }
+        return _filterGroupBuilder;
+    }
 
-        /// <summary>
-        /// Retrieves filters builder.
-        /// </summary>
-        /// <returns>Filters builder.</returns>
-        public FilterGroupBuilder Filters()
-        {
-            if (_filterGroupBuilder == null)
-                _filterGroupBuilder = new FilterGroupBuilder();
+    /// <summary>
+    /// Sets filters builder.
+    /// </summary>
+    /// <param name="builder">Builder to set.</param>
+    public void Filters(FilterGroupBuilder builder)
+    {
+        if (_filterGroupBuilder != null)
+            throw new ArgumentException($"Builder for filters is already set", nameof(builder));
 
-            return _filterGroupBuilder;
-        }
+        _filterGroupBuilder = builder;
+    }
 
-        /// <summary>
-        /// Sets filters builder.
-        /// </summary>
-        /// <param name="builder">Builder to set.</param>
-        public void Filters(FilterGroupBuilder builder)
-        {
-            if (_filterGroupBuilder != null)
-                throw new ArgumentException($"Builder for filters is already set", nameof(builder));
+    /// <summary>
+    /// Retrieves right-hand side builder (actions).
+    /// </summary>
+    /// <returns>Right hand side builder.</returns>
+    public ActionGroupBuilder RightHandSide()
+    {
+        if (_rhsBuilder == null)
+            _rhsBuilder = new ActionGroupBuilder();
 
-            _filterGroupBuilder = builder;
-        }
+        return _rhsBuilder;
+    }
 
-        /// <summary>
-        /// Retrieves right-hand side builder (actions).
-        /// </summary>
-        /// <returns>Right hand side builder.</returns>
-        public ActionGroupBuilder RightHandSide()
-        {
-            if (_rhsBuilder == null)
-                _rhsBuilder = new ActionGroupBuilder();
+    /// <summary>
+    /// Sets right-hand side builder.
+    /// </summary>
+    /// <param name="builder">Builder to set.</param>
+    public void RightHandSide(ActionGroupBuilder builder)
+    {
+        if (_rhsBuilder != null)
+            throw new ArgumentException($"Builder for right-hand side is already set", nameof(builder));
 
-            return _rhsBuilder;
-        }
+        _rhsBuilder = builder;
+    }
 
-        /// <summary>
-        /// Sets right-hand side builder.
-        /// </summary>
-        /// <param name="builder">Builder to set.</param>
-        public void RightHandSide(ActionGroupBuilder builder)
-        {
-            if (_rhsBuilder != null)
-                throw new ArgumentException($"Builder for right-hand side is already set", nameof(builder));
+    /// <summary>
+    /// Creates rule definition using current state of the builder.
+    /// </summary>
+    /// <returns>Rule definition.</returns>
+    public IRuleDefinition Build()
+    {
+        IBuilder<DependencyGroupElement> dependencyGroupBuilder = _dependencyGroupBuilder;
+        DependencyGroupElement dependencies = dependencyGroupBuilder?.Build()
+            ?? Element.DependencyGroup();
 
-            _rhsBuilder = builder;
-        }
+        IBuilder<FilterGroupElement> filterGroupBuilder = _filterGroupBuilder;
+        FilterGroupElement filters = filterGroupBuilder?.Build()
+            ?? Element.FilterGroup();
 
-        /// <summary>
-        /// Creates rule definition using current state of the builder.
-        /// </summary>
-        /// <returns>Rule definition.</returns>
-        public IRuleDefinition Build()
-        {
-            IBuilder<DependencyGroupElement> dependencyGroupBuilder = _dependencyGroupBuilder;
-            DependencyGroupElement dependencies = dependencyGroupBuilder?.Build()
-                ?? Element.DependencyGroup();
+        IBuilder<GroupElement> lhsBuilder = _lhsBuilder;
+        GroupElement lhs = lhsBuilder?.Build()
+            ?? Element.AndGroup();
 
-            IBuilder<FilterGroupElement> filterGroupBuilder = _filterGroupBuilder;
-            FilterGroupElement filters = filterGroupBuilder?.Build()
-                ?? Element.FilterGroup();
+        IBuilder<ActionGroupElement> rhsBuilder = _rhsBuilder;
+        ActionGroupElement rhs = rhsBuilder?.Build()
+            ?? Element.ActionGroup();
 
-            IBuilder<GroupElement> lhsBuilder = _lhsBuilder;
-            GroupElement lhs = lhsBuilder?.Build()
-                ?? Element.AndGroup();
-
-            IBuilder<ActionGroupElement> rhsBuilder = _rhsBuilder;
-            ActionGroupElement rhs = rhsBuilder?.Build()
-                ?? Element.ActionGroup();
-
-            var ruleDefinition = Element.RuleDefinition(_name, _description, _priority, _repeatability, _tags, _properties, dependencies, lhs, filters, rhs);
-            return ruleDefinition;
-        }
+        var ruleDefinition = Element.RuleDefinition(_name, _description, _priority, _repeatability, _tags, _properties, dependencies, lhs, filters, rhs);
+        return ruleDefinition;
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/RuleElementBuilder.cs
+++ b/src/NRules/NRules.RuleModel/Builders/RuleElementBuilder.cs
@@ -1,22 +1,21 @@
 using System.Threading;
 
-namespace NRules.RuleModel.Builders
-{
-    /// <summary>
-    /// Base class for rule element builders.
-    /// </summary>
-    public abstract class RuleElementBuilder
-    {
-        private static int _declarationCounter = 0;
+namespace NRules.RuleModel.Builders;
 
-        protected string DeclarationName(string name)
+/// <summary>
+/// Base class for rule element builders.
+/// </summary>
+public abstract class RuleElementBuilder
+{
+    private static int _declarationCounter = 0;
+
+    protected string DeclarationName(string name)
+    {
+        if (string.IsNullOrEmpty(name))
         {
-            if (string.IsNullOrEmpty(name))
-            {
-                var counter = Interlocked.Increment(ref _declarationCounter);
-                return $"$var{counter}$";
-            }
-            return name;
+            var counter = Interlocked.Increment(ref _declarationCounter);
+            return $"$var{counter}$";
         }
+        return name;
     }
 }

--- a/src/NRules/NRules.RuleModel/Builders/RuleTransformation.cs
+++ b/src/NRules/NRules.RuleModel/Builders/RuleTransformation.cs
@@ -2,259 +2,258 @@
 using System.Linq;
 using System.Linq.Expressions;
 
-namespace NRules.RuleModel.Builders
+namespace NRules.RuleModel.Builders;
+
+public class RuleTransformation : RuleElementVisitor<RuleTransformation.Context>
 {
-    public class RuleTransformation : RuleElementVisitor<RuleTransformation.Context>
+    public class Context
     {
-        public class Context
+        private readonly Stack<RuleElement> _elements = new();
+
+        internal bool IsModified { get; set; }
+
+        internal RuleElement Pop()
         {
-            private readonly Stack<RuleElement> _elements = new();
+            return _elements.Pop();
+        }
 
-            internal bool IsModified { get; set; }
+        internal void Push(RuleElement element)
+        {
+            _elements.Push(element);
+        }
+    }
 
-            internal RuleElement Pop()
+    public IRuleDefinition Transform(IRuleDefinition rule)
+    {
+        var lhsContext = new Context();
+        var lhs = Transform<GroupElement>(lhsContext, rule.LeftHandSide);
+
+        var rhsContext = new Context();
+        var rhs = Transform<ActionGroupElement>(rhsContext, rule.RightHandSide);
+
+        if (lhsContext.IsModified || rhsContext.IsModified)
+        {
+            var transformedRule = Element.RuleDefinition(rule.Name, rule.Description, rule.Priority,
+                rule.Repeatability, rule.Tags, rule.Properties, rule.DependencyGroup, lhs, rule.FilterGroup, rhs);
+            return transformedRule;
+        }
+        return rule;
+    }
+
+    private void Result(Context context, RuleElement element)
+    {
+        context.Pop();
+        context.Push(element);
+        context.IsModified = true;
+    }
+
+    private T Transform<T>(Context context, RuleElement element) where T : RuleElement
+    {
+        if (element == null) return null;
+
+        bool savedIsModified = context.IsModified;
+        context.IsModified = false;
+
+        context.Push(element);
+        Visit(context, element);
+        context.IsModified |= savedIsModified;
+
+        return (T)context.Pop();
+    }
+
+    protected internal override void VisitPattern(Context context, PatternElement element)
+    {
+        var source = Transform<RuleElement>(context, element.Source);
+        if (context.IsModified)
+        {
+            var newElement = Element.Pattern(element.Declaration, element.Expressions, source);
+            Result(context, newElement);
+        }
+    }
+
+    protected internal override void VisitBinding(Context context, BindingElement element)
+    {
+    }
+
+    protected internal override void VisitAggregate(Context context, AggregateElement element)
+    {
+        var source = Transform<PatternElement>(context, element.Source);
+        if (context.IsModified)
+        {
+            var newElement = Element.Aggregate(element.ResultType, element.Name, element.Expressions, source, element.CustomFactoryType);
+            Result(context, newElement);
+        }
+    }
+
+    protected internal override void VisitActionGroup(Context context, ActionGroupElement element)
+    {
+        var actions = element.Actions.Select(x => Transform<ActionElement>(context, x)).ToList();
+        if (context.IsModified)
+        {
+            var newElement = Element.ActionGroup(actions);
+            Result(context, newElement);
+        }
+    }
+
+    protected internal override void VisitAction(Context context, ActionElement element)
+    {
+    }
+
+    protected internal override void VisitAnd(Context context, AndElement element)
+    {
+        var childElements = element.ChildElements.Select(x => Transform<RuleElement>(context, x)).ToList();
+        if (CollapseSingleGroup(context, childElements)) return;
+        if (SplitOrGroup(context, element, childElements)) return;
+        if (context.IsModified)
+        {
+            var newElement = Element.AndGroup(childElements);
+            Result(context, newElement);
+        }
+    }
+
+    protected internal override void VisitOr(Context context, OrElement element)
+    {
+        var childElements = element.ChildElements.Select(x => Transform<RuleElement>(context, x)).ToList();
+        if (CollapseSingleGroup(context, childElements)) return;
+        if (MergeOrGroups(context, element, childElements)) return;
+        if (context.IsModified)
+        {
+            var newElement = Element.OrGroup(childElements);
+            Result(context, newElement);
+        }
+    }
+
+    protected internal override void VisitNot(Context context, NotElement element)
+    {
+        var source = Transform<RuleElement>(context, element.Source);
+        if (context.IsModified)
+        {
+            var newElement = Element.Not(source);
+            Result(context, newElement);
+        }
+    }
+
+    protected internal override void VisitExists(Context context, ExistsElement element)
+    {
+        var source = Transform<RuleElement>(context, element.Source);
+        if (context.IsModified)
+        {
+            var newElement = Element.Exists(source);
+            Result(context, newElement);
+        }
+    }
+
+    protected internal override void VisitForAll(Context context, ForAllElement element)
+    {
+        var basePattern = Transform<PatternElement>(context, element.BasePattern);
+        var patterns = element.Patterns.Select(x => Transform<PatternElement>(context, x)).ToList();
+
+        //forall -> not(base and not(patterns))
+
+        Declaration baseDeclaration = basePattern.Declaration;
+        var baseParameter = baseDeclaration.ToParameterExpression();
+
+        var negatedPatterns = new List<RuleElement>();
+        foreach (var pattern in patterns)
+        {
+            var parameter = pattern.Declaration.ToParameterExpression();
+
+            var expressions = new List<NamedExpressionElement>
             {
-                return _elements.Pop();
-            }
+                Element.Condition(
+                    Expression.Lambda(
+                        Expression.ReferenceEqual(baseParameter, parameter),
+                        baseParameter, parameter))
+            };
+            expressions.AddRange(pattern.Expressions);
 
-            internal void Push(RuleElement element)
-            {
-                _elements.Push(element);
-            }
+            negatedPatterns.Add(
+                Element.Not(
+                    Element.Pattern(pattern.Declaration, expressions, pattern.Source)
+                ));
         }
 
-        public IRuleDefinition Transform(IRuleDefinition rule)
+        var result = Element.Not(
+            Element.AndGroup(
+                new RuleElement[] { basePattern }.Concat(negatedPatterns)));
+        Result(context, result);
+    }
+
+    private bool CollapseSingleGroup(Context context, IList<RuleElement> childElements)
+    {
+        if (childElements.Count == 1 &&
+            childElements.Single() is GroupElement)
         {
-            var lhsContext = new Context();
-            var lhs = Transform<GroupElement>(lhsContext, rule.LeftHandSide);
-
-            var rhsContext = new Context();
-            var rhs = Transform<ActionGroupElement>(rhsContext, rule.RightHandSide);
-
-            if (lhsContext.IsModified || rhsContext.IsModified)
-            {
-                var transformedRule = Element.RuleDefinition(rule.Name, rule.Description, rule.Priority,
-                    rule.Repeatability, rule.Tags, rule.Properties, rule.DependencyGroup, lhs, rule.FilterGroup, rhs);
-                return transformedRule;
-            }
-            return rule;
-        }
-
-        private void Result(Context context, RuleElement element)
-        {
-            context.Pop();
-            context.Push(element);
-            context.IsModified = true;
-        }
-
-        private T Transform<T>(Context context, RuleElement element) where T : RuleElement
-        {
-            if (element == null) return null;
-
-            bool savedIsModified = context.IsModified;
-            context.IsModified = false;
-
-            context.Push(element);
-            Visit(context, element);
-            context.IsModified |= savedIsModified;
-
-            return (T)context.Pop();
-        }
-
-        protected internal override void VisitPattern(Context context, PatternElement element)
-        {
-            var source = Transform<RuleElement>(context, element.Source);
-            if (context.IsModified)
-            {
-                var newElement = Element.Pattern(element.Declaration, element.Expressions, source);
-                Result(context, newElement);
-            }
-        }
-
-        protected internal override void VisitBinding(Context context, BindingElement element)
-        {
-        }
-
-        protected internal override void VisitAggregate(Context context, AggregateElement element)
-        {
-            var source = Transform<PatternElement>(context, element.Source);
-            if (context.IsModified)
-            {
-                var newElement = Element.Aggregate(element.ResultType, element.Name, element.Expressions, source, element.CustomFactoryType);
-                Result(context, newElement);
-            }
-        }
-
-        protected internal override void VisitActionGroup(Context context, ActionGroupElement element)
-        {
-            var actions = element.Actions.Select(x => Transform<ActionElement>(context, x)).ToList();
-            if (context.IsModified)
-            {
-                var newElement = Element.ActionGroup(actions);
-                Result(context, newElement);
-            }
-        }
-
-        protected internal override void VisitAction(Context context, ActionElement element)
-        {
-        }
-
-        protected internal override void VisitAnd(Context context, AndElement element)
-        {
-            var childElements = element.ChildElements.Select(x => Transform<RuleElement>(context, x)).ToList();
-            if (CollapseSingleGroup(context, childElements)) return;
-            if (SplitOrGroup(context, element, childElements)) return;
-            if (context.IsModified)
-            {
-                var newElement = Element.AndGroup(childElements);
-                Result(context, newElement);
-            }
-        }
-
-        protected internal override void VisitOr(Context context, OrElement element)
-        {
-            var childElements = element.ChildElements.Select(x => Transform<RuleElement>(context, x)).ToList();
-            if (CollapseSingleGroup(context, childElements)) return;
-            if (MergeOrGroups(context, element, childElements)) return;
-            if (context.IsModified)
-            {
-                var newElement = Element.OrGroup(childElements);
-                Result(context, newElement);
-            }
-        }
-
-        protected internal override void VisitNot(Context context, NotElement element)
-        {
-            var source = Transform<RuleElement>(context, element.Source);
-            if (context.IsModified)
-            {
-                var newElement = Element.Not(source);
-                Result(context, newElement);
-            }
-        }
-
-        protected internal override void VisitExists(Context context, ExistsElement element)
-        {
-            var source = Transform<RuleElement>(context, element.Source);
-            if (context.IsModified)
-            {
-                var newElement = Element.Exists(source);
-                Result(context, newElement);
-            }
-        }
-
-        protected internal override void VisitForAll(Context context, ForAllElement element)
-        {
-            var basePattern = Transform<PatternElement>(context, element.BasePattern);
-            var patterns = element.Patterns.Select(x => Transform<PatternElement>(context, x)).ToList();
-
-            //forall -> not(base and not(patterns))
-
-            Declaration baseDeclaration = basePattern.Declaration;
-            var baseParameter = baseDeclaration.ToParameterExpression();
-
-            var negatedPatterns = new List<RuleElement>();
-            foreach (var pattern in patterns)
-            {
-                var parameter = pattern.Declaration.ToParameterExpression();
-
-                var expressions = new List<NamedExpressionElement>
-                {
-                    Element.Condition(
-                        Expression.Lambda(
-                            Expression.ReferenceEqual(baseParameter, parameter),
-                            baseParameter, parameter))
-                };
-                expressions.AddRange(pattern.Expressions);
-
-                negatedPatterns.Add(
-                    Element.Not(
-                        Element.Pattern(pattern.Declaration, expressions, pattern.Source)
-                    ));
-            }
-
-            var result = Element.Not(
-                Element.AndGroup(
-                    new RuleElement[] { basePattern }.Concat(negatedPatterns)));
-            Result(context, result);
-        }
-
-        private bool CollapseSingleGroup(Context context, IList<RuleElement> childElements)
-        {
-            if (childElements.Count == 1 &&
-                childElements.Single() is GroupElement)
-            {
-                Result(context, childElements.Single());
-                return true;
-            }
-            return false;
-        }
-
-        private bool SplitOrGroup(Context context, AndElement element, IList<RuleElement> childElements)
-        {
-            if (!childElements.OfType<OrElement>().Any()) return false;
-
-            var groups = new List<IList<RuleElement>>();
-            groups.Add(new List<RuleElement>());
-            ExpandOrElements(groups, childElements, 0);
-
-            var andElements = groups.Select(Element.AndGroup).ToList();
-            var orElement = Element.OrGroup(andElements);
-            Result(context, orElement);
+            Result(context, childElements.Single());
             return true;
         }
+        return false;
+    }
 
-        private bool MergeOrGroups(Context context, OrElement element, IList<RuleElement> childElements)
+    private bool SplitOrGroup(Context context, AndElement element, IList<RuleElement> childElements)
+    {
+        if (!childElements.OfType<OrElement>().Any()) return false;
+
+        var groups = new List<IList<RuleElement>>();
+        groups.Add(new List<RuleElement>());
+        ExpandOrElements(groups, childElements, 0);
+
+        var andElements = groups.Select(Element.AndGroup).ToList();
+        var orElement = Element.OrGroup(andElements);
+        Result(context, orElement);
+        return true;
+    }
+
+    private bool MergeOrGroups(Context context, OrElement element, IList<RuleElement> childElements)
+    {
+        if (!childElements.OfType<OrElement>().Any()) return false;
+        var newChildElements = new List<RuleElement>();
+        foreach (var childElement in childElements)
         {
-            if (!childElements.OfType<OrElement>().Any()) return false;
-            var newChildElements = new List<RuleElement>();
-            foreach (var childElement in childElements)
+            if (childElement is OrElement childOrElement)
             {
-                if (childElement is OrElement childOrElement)
-                {
-                    newChildElements.AddRange(childOrElement.ChildElements);
-                }
-                else
-                {
-                    newChildElements.Add(childElement);
-                }
-
+                newChildElements.AddRange(childOrElement.ChildElements);
             }
-            var orElement = Element.OrGroup(newChildElements);
-            Result(context, orElement);
-            return true;
-        }
-
-        private void ExpandOrElements(IList<IList<RuleElement>> groups, IList<RuleElement> childElements, int index)
-        {
-            if (index == childElements.Count) return;
-
-            var currentElement = childElements[index];
-            var orElement = currentElement as OrElement;
-
-            var count = groups.Count;
-            for (int i = 0; i < count; i++)
+            else
             {
-                if (orElement != null)
-                {
-                    int offset = groups.Count;
-                    var orElementChildren = orElement.ChildElements.ToList();
-                    var firstChild = orElementChildren.First();
-                    var restChildren = orElementChildren.Skip(1).ToList();
-                    for (int j = 0; j < restChildren.Count; j++)
-                    {
-                        groups.Add(new List<RuleElement>(groups[i]));
-                        groups[offset + j].Add(restChildren[j]);
-                    }
-                    groups[i].Add(firstChild);
-                }
-                else
-                {
-                    groups[i].Add(currentElement);
-                }
+                newChildElements.Add(childElement);
             }
 
-            ExpandOrElements(groups, childElements, index + 1);
         }
+        var orElement = Element.OrGroup(newChildElements);
+        Result(context, orElement);
+        return true;
+    }
+
+    private void ExpandOrElements(IList<IList<RuleElement>> groups, IList<RuleElement> childElements, int index)
+    {
+        if (index == childElements.Count) return;
+
+        var currentElement = childElements[index];
+        var orElement = currentElement as OrElement;
+
+        var count = groups.Count;
+        for (int i = 0; i < count; i++)
+        {
+            if (orElement != null)
+            {
+                int offset = groups.Count;
+                var orElementChildren = orElement.ChildElements.ToList();
+                var firstChild = orElementChildren.First();
+                var restChildren = orElementChildren.Skip(1).ToList();
+                for (int j = 0; j < restChildren.Count; j++)
+                {
+                    groups.Add(new List<RuleElement>(groups[i]));
+                    groups[offset + j].Add(restChildren[j]);
+                }
+                groups[i].Add(firstChild);
+            }
+            else
+            {
+                groups[i].Add(currentElement);
+            }
+        }
+
+        ExpandOrElements(groups, childElements, index + 1);
     }
 }

--- a/src/NRules/NRules.RuleModel/Declaration.cs
+++ b/src/NRules/NRules.RuleModel/Declaration.cs
@@ -1,53 +1,52 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Rule element declaration.
+/// </summary>
+[DebuggerDisplay("{Name}: {Type}")]
+public sealed class Declaration : IEquatable<Declaration>
 {
-    /// <summary>
-    /// Rule element declaration.
-    /// </summary>
-    [DebuggerDisplay("{Name}: {Type}")]
-    public sealed class Declaration : IEquatable<Declaration>
+    internal Declaration(Type type, string name)
     {
-        internal Declaration(Type type, string name)
-        {
-            Type = type;
-            Name = name;
-        }
+        Type = type;
+        Name = name;
+    }
 
-        /// <summary>
-        /// Symbol name.
-        /// </summary>
-        public string Name { get; }
+    /// <summary>
+    /// Symbol name.
+    /// </summary>
+    public string Name { get; }
 
-        /// <summary>
-        /// Symbol type.
-        /// </summary>
-        public Type Type { get; }
+    /// <summary>
+    /// Symbol type.
+    /// </summary>
+    public Type Type { get; }
 
-        /// <summary>
-        /// Rule element that this declaration is referencing.
-        /// </summary>
-        public RuleElement Target { get; internal set; }
+    /// <summary>
+    /// Rule element that this declaration is referencing.
+    /// </summary>
+    public RuleElement Target { get; internal set; }
 
-        public bool Equals(Declaration other)
-        {
-            if (ReferenceEquals(null, other)) return false;
-            if (ReferenceEquals(this, other)) return true;
-            return string.Equals(Name, other.Name);
-        }
+    public bool Equals(Declaration other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return string.Equals(Name, other.Name);
+    }
 
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((Declaration) obj);
-        }
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != this.GetType()) return false;
+        return Equals((Declaration) obj);
+    }
 
-        public override int GetHashCode()
-        {
-            return Name.GetHashCode();
-        }
+    public override int GetHashCode()
+    {
+        return Name.GetHashCode();
     }
 }

--- a/src/NRules/NRules.RuleModel/DeclarationExtensions.cs
+++ b/src/NRules/NRules.RuleModel/DeclarationExtensions.cs
@@ -1,28 +1,27 @@
 ﻿using System.Linq.Expressions;
 using NRules.RuleModel.Builders;
 
-namespace NRules.RuleModel
-{
-    public static class DeclarationExtensions
-    {
-        /// <summary>
-        /// Converts rule element <see cref="Declaration"/> to a <see cref="ParameterExpression"/>.
-        /// </summary>
-        /// <param name="declaration">Declaration to convert.</param>
-        /// <returns>Parameter expression.</returns>
-        public static ParameterExpression ToParameterExpression(this Declaration declaration)
-        {
-            return Expression.Parameter(declaration.Type, declaration.Name);
-        }
+namespace NRules.RuleModel;
 
-        /// <summary>
-        /// Converts <see cref="ParameterExpression"/> to a rule element <see cref="Declaration"/>.
-        /// </summary>
-        /// <param name="parameter">Parameter expression to convert</param>
-        /// <returns>Rule element declaration.</returns>
-        public static Declaration ToDeclaration(this ParameterExpression parameter)
-        {
-            return Element.Declaration(parameter.Type, parameter.Name);
-        }
+public static class DeclarationExtensions
+{
+    /// <summary>
+    /// Converts rule element <see cref="Declaration"/> to a <see cref="ParameterExpression"/>.
+    /// </summary>
+    /// <param name="declaration">Declaration to convert.</param>
+    /// <returns>Parameter expression.</returns>
+    public static ParameterExpression ToParameterExpression(this Declaration declaration)
+    {
+        return Expression.Parameter(declaration.Type, declaration.Name);
+    }
+
+    /// <summary>
+    /// Converts <see cref="ParameterExpression"/> to a rule element <see cref="Declaration"/>.
+    /// </summary>
+    /// <param name="parameter">Parameter expression to convert</param>
+    /// <returns>Rule element declaration.</returns>
+    public static Declaration ToDeclaration(this ParameterExpression parameter)
+    {
+        return Element.Declaration(parameter.Type, parameter.Name);
     }
 }

--- a/src/NRules/NRules.RuleModel/DependencyElement.cs
+++ b/src/NRules/NRules.RuleModel/DependencyElement.cs
@@ -1,36 +1,35 @@
 ﻿using System;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Dependency that the rule uses when its actions run.
+/// </summary>
+public class DependencyElement : RuleElement
 {
-    /// <summary>
-    /// Dependency that the rule uses when its actions run.
-    /// </summary>
-    public class DependencyElement : RuleElement
+    internal DependencyElement(Declaration declaration, Type serviceType)
     {
-        internal DependencyElement(Declaration declaration, Type serviceType)
-        {
-            Declaration = declaration;
-            ServiceType = serviceType;
+        Declaration = declaration;
+        ServiceType = serviceType;
 
-            AddExport(declaration);
-        }
+        AddExport(declaration);
+    }
 
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.Dependency;
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.Dependency;
 
-        /// <summary>
-        /// Declaration that references the dependency.
-        /// </summary>
-        public Declaration Declaration { get; }
+    /// <summary>
+    /// Declaration that references the dependency.
+    /// </summary>
+    public Declaration Declaration { get; }
 
-        /// <summary>
-        /// Type of service that this dependency configures.
-        /// </summary>
-        public Type ServiceType { get; }
+    /// <summary>
+    /// Type of service that this dependency configures.
+    /// </summary>
+    public Type ServiceType { get; }
 
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitDependency(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitDependency(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/DependencyGroupElement.cs
+++ b/src/NRules/NRules.RuleModel/DependencyGroupElement.cs
@@ -1,32 +1,31 @@
 using System.Collections.Generic;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Rule element that groups dependencies that the rule uses when its actions runs.
+/// </summary>
+public class DependencyGroupElement : RuleElement
 {
-    /// <summary>
-    /// Rule element that groups dependencies that the rule uses when its actions runs.
-    /// </summary>
-    public class DependencyGroupElement : RuleElement
+    private readonly List<DependencyElement> _dependencies;
+
+    internal DependencyGroupElement(IEnumerable<DependencyElement> dependencies)
     {
-        private readonly List<DependencyElement> _dependencies;
+        _dependencies = new List<DependencyElement>(dependencies);
 
-        internal DependencyGroupElement(IEnumerable<DependencyElement> dependencies)
-        {
-            _dependencies = new List<DependencyElement>(dependencies);
+        AddExports(_dependencies);
+    }
 
-            AddExports(_dependencies);
-        }
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.DependencyGroup;
 
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.DependencyGroup;
+    /// <summary>
+    /// List of dependencies the group element contains.
+    /// </summary>
+    public IEnumerable<DependencyElement> Dependencies => _dependencies;
 
-        /// <summary>
-        /// List of dependencies the group element contains.
-        /// </summary>
-        public IEnumerable<DependencyElement> Dependencies => _dependencies;
-
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitDependencyGroup(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitDependencyGroup(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/ElementType.cs
+++ b/src/NRules/NRules.RuleModel/ElementType.cs
@@ -1,83 +1,82 @@
-﻿namespace NRules.RuleModel
+﻿namespace NRules.RuleModel;
+
+/// <summary>
+/// Describes the element types for the elements of a rule definition.
+/// </summary>
+public enum ElementType
 {
     /// <summary>
-    /// Describes the element types for the elements of a rule definition.
+    /// Action invoked when the rule fires.
     /// </summary>
-    public enum ElementType
-    {
-        /// <summary>
-        /// Action invoked when the rule fires.
-        /// </summary>
-        Action,
+    Action,
 
-        /// <summary>
-        /// Collection of actions associated with the rule.
-        /// </summary>
-        ActionGroup,
+    /// <summary>
+    /// Collection of actions associated with the rule.
+    /// </summary>
+    ActionGroup,
 
-        /// <summary>
-        /// Aggregation of facts into synthetic composite facts.
-        /// </summary>
-        Aggregate,
+    /// <summary>
+    /// Aggregation of facts into synthetic composite facts.
+    /// </summary>
+    Aggregate,
 
-        /// <summary>
-        /// Grouping of the match patterns that matches only when all child patterns match.
-        /// </summary>
-        And,
+    /// <summary>
+    /// Grouping of the match patterns that matches only when all child patterns match.
+    /// </summary>
+    And,
 
-        /// <summary>
-        /// Evaluates an expression and binds the result to a name.
-        /// </summary>
-        Binding,
+    /// <summary>
+    /// Evaluates an expression and binds the result to a name.
+    /// </summary>
+    Binding,
 
-        /// <summary>
-        /// External service the rule depends on.
-        /// </summary>
-        Dependency,
+    /// <summary>
+    /// External service the rule depends on.
+    /// </summary>
+    Dependency,
 
-        /// <summary>
-        /// Collection of dependencies associated with the rule.
-        /// </summary>
-        DependencyGroup,
+    /// <summary>
+    /// Collection of dependencies associated with the rule.
+    /// </summary>
+    DependencyGroup,
 
-        /// <summary>
-        /// Existential quantifier that matches if at least one source fact is present.
-        /// </summary>
-        Exists,
+    /// <summary>
+    /// Existential quantifier that matches if at least one source fact is present.
+    /// </summary>
+    Exists,
 
-        /// <summary>
-        /// Agenda filter applied to complete fact matches to determine if they should be placed on agenda.
-        /// </summary>
-        Filter,
+    /// <summary>
+    /// Agenda filter applied to complete fact matches to determine if they should be placed on agenda.
+    /// </summary>
+    Filter,
 
-        /// <summary>
-        /// Collection of agenda filters associated with the rule.
-        /// </summary>
-        FilterGroup,
+    /// <summary>
+    /// Collection of agenda filters associated with the rule.
+    /// </summary>
+    FilterGroup,
 
-        /// <summary>
-        /// Universal quantifier that matches if all facts matching its first pattern also match all other patterns defined in the quantifier.
-        /// </summary>
-        ForAll,
+    /// <summary>
+    /// Universal quantifier that matches if all facts matching its first pattern also match all other patterns defined in the quantifier.
+    /// </summary>
+    ForAll,
 
-        /// <summary>
-        /// Existential quantifier that matches if no source fact are present.
-        /// </summary>
-        Not,
+    /// <summary>
+    /// Existential quantifier that matches if no source fact are present.
+    /// </summary>
+    Not,
 
-        /// <summary>
-        /// Grouping of the match patterns that matches when any child patterns matches.
-        /// </summary>
-        Or,
+    /// <summary>
+    /// Grouping of the match patterns that matches when any child patterns matches.
+    /// </summary>
+    Or,
 
-        /// <summary>
-        /// A pattern that matches facts.
-        /// </summary>
-        Pattern,
+    /// <summary>
+    /// A pattern that matches facts.
+    /// </summary>
+    Pattern,
 
-        /// <summary>
-        /// An expression evaluated by the rules engine.
-        /// </summary>
-        NamedExpression
-    }
+    /// <summary>
+    /// An expression evaluated by the rules engine.
+    /// </summary>
+    NamedExpression
 }

--- a/src/NRules/NRules.RuleModel/ExistsElement.cs
+++ b/src/NRules/NRules.RuleModel/ExistsElement.cs
@@ -1,28 +1,27 @@
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Existential quantifier.
+/// </summary>
+public class ExistsElement : RuleElement
 {
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.Exists;
+
     /// <summary>
-    /// Existential quantifier.
+    /// Fact source of the existential element.
     /// </summary>
-    public class ExistsElement : RuleElement
+    public RuleElement Source { get; }
+
+    internal ExistsElement(RuleElement source)
     {
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.Exists;
+        Source = source;
 
-        /// <summary>
-        /// Fact source of the existential element.
-        /// </summary>
-        public RuleElement Source { get; }
+        AddImports(source);
+    }
 
-        internal ExistsElement(RuleElement source)
-        {
-            Source = source;
-
-            AddImports(source);
-        }
-
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitExists(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitExists(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/ExpressionCollection.cs
+++ b/src/NRules/NRules.RuleModel/ExpressionCollection.cs
@@ -3,75 +3,74 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Ordered readonly collection of named expressions.
+/// </summary>
+public class ExpressionCollection : IEnumerable<NamedExpressionElement>
 {
-    /// <summary>
-    /// Ordered readonly collection of named expressions.
-    /// </summary>
-    public class ExpressionCollection : IEnumerable<NamedExpressionElement>
+    private readonly List<NamedExpressionElement> _expressions;
+
+    internal ExpressionCollection(IEnumerable<NamedExpressionElement> expressions)
     {
-        private readonly List<NamedExpressionElement> _expressions;
+        _expressions = new List<NamedExpressionElement>(expressions);
+    }
 
-        internal ExpressionCollection(IEnumerable<NamedExpressionElement> expressions)
+    /// <summary>
+    /// Number of expressions in the collection.
+    /// </summary>
+    public int Count => _expressions.Count;
+
+    /// <summary>
+    /// Retrieves single expression by name.
+    /// </summary>
+    /// <param name="name">Expression name.</param>
+    /// <returns>Matching expression.</returns>
+    public NamedExpressionElement this[string name]
+    {
+        get
         {
-            _expressions = new List<NamedExpressionElement>(expressions);
-        }
-
-        /// <summary>
-        /// Number of expressions in the collection.
-        /// </summary>
-        public int Count => _expressions.Count;
-
-        /// <summary>
-        /// Retrieves single expression by name.
-        /// </summary>
-        /// <param name="name">Expression name.</param>
-        /// <returns>Matching expression.</returns>
-        public NamedExpressionElement this[string name]
-        {
-            get
+            var result = FindSingleOrDefault(name);
+            if (result == null)
             {
-                var result = FindSingleOrDefault(name);
-                if (result == null)
-                {
-                    throw new ArgumentException(
-                        $"Expression with the given name not found. Name={name}", nameof(name));
-                }
-                return result;
+                throw new ArgumentException(
+                    $"Expression with the given name not found. Name={name}", nameof(name));
             }
+            return result;
         }
+    }
 
-        /// <summary>
-        /// Retrieves expressions by name.
-        /// </summary>
-        /// <param name="name">Expression name.</param>
-        /// <returns>Matching expression or empty IEnumerable.</returns>
-        public IEnumerable<NamedExpressionElement> Find(string name)
-        {
-            return _expressions.Where(e => e.Name == name);
-        }
+    /// <summary>
+    /// Retrieves expressions by name.
+    /// </summary>
+    /// <param name="name">Expression name.</param>
+    /// <returns>Matching expression or empty IEnumerable.</returns>
+    public IEnumerable<NamedExpressionElement> Find(string name)
+    {
+        return _expressions.Where(e => e.Name == name);
+    }
 
-        /// <summary>
-        /// Retrieves single expression by name.
-        /// </summary>
-        /// <param name="name">Expression name.</param>
-        /// <returns>Matching expression or <c>null</c>.</returns>
-        public NamedExpressionElement FindSingleOrDefault(string name)
-        {
-            return Find(name).SingleOrDefault();
-        }
+    /// <summary>
+    /// Retrieves single expression by name.
+    /// </summary>
+    /// <param name="name">Expression name.</param>
+    /// <returns>Matching expression or <c>null</c>.</returns>
+    public NamedExpressionElement FindSingleOrDefault(string name)
+    {
+        return Find(name).SingleOrDefault();
+    }
 
-        /// <summary>
-        /// Returns an enumerator for the contained expression elements.
-        /// </summary>
-        public IEnumerator<NamedExpressionElement> GetEnumerator()
-        {
-            return _expressions.GetEnumerator();
-        }
+    /// <summary>
+    /// Returns an enumerator for the contained expression elements.
+    /// </summary>
+    public IEnumerator<NamedExpressionElement> GetEnumerator()
+    {
+        return _expressions.GetEnumerator();
+    }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
     }
 }

--- a/src/NRules/NRules.RuleModel/ExpressionElement.cs
+++ b/src/NRules/NRules.RuleModel/ExpressionElement.cs
@@ -2,29 +2,28 @@
 using System.Linq;
 using System.Linq.Expressions;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Rule element that defines an expression.
+/// </summary>
+public abstract class ExpressionElement : RuleElement
 {
-    /// <summary>
-    /// Rule element that defines an expression.
-    /// </summary>
-    public abstract class ExpressionElement : RuleElement
+    internal ExpressionElement(LambdaExpression expression, IEnumerable<ParameterExpression> parameters)
     {
-        internal ExpressionElement(LambdaExpression expression, IEnumerable<ParameterExpression> parameters)
-        {
-            Expression = expression;
+        Expression = expression;
 
-            var imports = parameters.Select(p => p.ToDeclaration());
-            AddImports(imports);
-        }
-
-        internal ExpressionElement(LambdaExpression expression)
-            : this(expression, expression.Parameters)
-        {
-        }
-
-        /// <summary>
-        /// Expression.
-        /// </summary>
-        public LambdaExpression Expression { get; }
+        var imports = parameters.Select(p => p.ToDeclaration());
+        AddImports(imports);
     }
+
+    internal ExpressionElement(LambdaExpression expression)
+        : this(expression, expression.Parameters)
+    {
+    }
+
+    /// <summary>
+    /// Expression.
+    /// </summary>
+    public LambdaExpression Expression { get; }
 }

--- a/src/NRules/NRules.RuleModel/FilterElement.cs
+++ b/src/NRules/NRules.RuleModel/FilterElement.cs
@@ -1,45 +1,44 @@
 ﻿using System.Linq.Expressions;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Type of filter applied to rule matches.
+/// </summary>
+public enum FilterType
 {
     /// <summary>
-    /// Type of filter applied to rule matches.
+    /// Filter based on a predicate expression.
     /// </summary>
-    public enum FilterType
-    {
-        /// <summary>
-        /// Filter based on a predicate expression.
-        /// </summary>
-        Predicate,
-
-        /// <summary>
-        /// Filter that only accepts matches that result in a change of a given key.
-        /// </summary>
-        KeyChange,
-    }
+    Predicate,
 
     /// <summary>
-    /// Filter that determines which rule matches should trigger rule actions.
+    /// Filter that only accepts matches that result in a change of a given key.
     /// </summary>
-    public class FilterElement : ExpressionElement
+    KeyChange,
+}
+
+/// <summary>
+/// Filter that determines which rule matches should trigger rule actions.
+/// </summary>
+public class FilterElement : ExpressionElement
+{
+    internal FilterElement(FilterType filterType, LambdaExpression expression) 
+        : base(expression)
     {
-        internal FilterElement(FilterType filterType, LambdaExpression expression) 
-            : base(expression)
-        {
-            FilterType = filterType;
-        }
+        FilterType = filterType;
+    }
 
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.Filter;
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.Filter;
 
-        /// <summary>
-        /// Type of rule match filter.
-        /// </summary>
-        public FilterType FilterType { get; }
+    /// <summary>
+    /// Type of rule match filter.
+    /// </summary>
+    public FilterType FilterType { get; }
 
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitFilter(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitFilter(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/FilterGroupElement.cs
+++ b/src/NRules/NRules.RuleModel/FilterGroupElement.cs
@@ -1,32 +1,31 @@
 using System.Collections.Generic;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Rule element that groups filters that determine which rule matches should trigger rule actions.
+/// </summary>
+public class FilterGroupElement : RuleElement
 {
-    /// <summary>
-    /// Rule element that groups filters that determine which rule matches should trigger rule actions.
-    /// </summary>
-    public class FilterGroupElement : RuleElement
+    private readonly List<FilterElement> _filters;
+
+    internal FilterGroupElement(IEnumerable<FilterElement> filters)
     {
-        private readonly List<FilterElement> _filters;
+        _filters = new List<FilterElement>(filters);
 
-        internal FilterGroupElement(IEnumerable<FilterElement> filters)
-        {
-            _filters = new List<FilterElement>(filters);
+        AddImports(_filters);
+    }
 
-            AddImports(_filters);
-        }
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.FilterGroup;
 
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.FilterGroup;
+    /// <summary>
+    /// List of filters the group element contains.
+    /// </summary>
+    public IEnumerable<FilterElement> Filters => _filters;
 
-        /// <summary>
-        /// List of filters the group element contains.
-        /// </summary>
-        public IEnumerable<FilterElement> Filters => _filters;
-
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitFilterGroup(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitFilterGroup(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/ForAllElement.cs
+++ b/src/NRules/NRules.RuleModel/ForAllElement.cs
@@ -1,39 +1,38 @@
 ﻿using System.Collections.Generic;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Universal quantifier.
+/// </summary>
+public class ForAllElement : RuleElement
 {
-    /// <summary>
-    /// Universal quantifier.
-    /// </summary>
-    public class ForAllElement : RuleElement
+    private readonly List<PatternElement> _patterns;
+
+    internal ForAllElement(PatternElement source, IEnumerable<PatternElement> patterns)
     {
-        private readonly List<PatternElement> _patterns;
+        BasePattern = source;
+        _patterns = new List<PatternElement>(patterns);
 
-        internal ForAllElement(PatternElement source, IEnumerable<PatternElement> patterns)
-        {
-            BasePattern = source;
-            _patterns = new List<PatternElement>(patterns);
+        AddImports(source);
+        AddImports(_patterns);
+    }
 
-            AddImports(source);
-            AddImports(_patterns);
-        }
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.ForAll;
 
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.ForAll;
+    /// <summary>
+    /// Base pattern that determines the universe of facts that the universal quantifier is applied to.
+    /// </summary>
+    public PatternElement BasePattern { get; }
 
-        /// <summary>
-        /// Base pattern that determines the universe of facts that the universal quantifier is applied to.
-        /// </summary>
-        public PatternElement BasePattern { get; }
+    /// <summary>
+    /// Patterns that must all match for the selected facts.
+    /// </summary>
+    public IEnumerable<PatternElement> Patterns => _patterns;
 
-        /// <summary>
-        /// Patterns that must all match for the selected facts.
-        /// </summary>
-        public IEnumerable<PatternElement> Patterns => _patterns;
-
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitForAll(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitForAll(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/GroupElement.cs
+++ b/src/NRules/NRules.RuleModel/GroupElement.cs
@@ -1,25 +1,24 @@
 ﻿using System.Collections.Generic;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Grouping element that logically combines the patterns or other grouping elements.
+/// </summary>
+public abstract class GroupElement : RuleElement
 {
-    /// <summary>
-    /// Grouping element that logically combines the patterns or other grouping elements.
-    /// </summary>
-    public abstract class GroupElement : RuleElement
+    private readonly List<RuleElement> _childElements;
+
+    internal GroupElement(IEnumerable<RuleElement> childElements)
     {
-        private readonly List<RuleElement> _childElements;
+        _childElements = new List<RuleElement>(childElements);
 
-        internal GroupElement(IEnumerable<RuleElement> childElements)
-        {
-            _childElements = new List<RuleElement>(childElements);
-
-            AddExports(_childElements);
-            AddImports(_childElements);
-        }
-
-        /// <summary>
-        /// List of child elements in the grouping.
-        /// </summary>
-        public IEnumerable<RuleElement> ChildElements => _childElements;
+        AddExports(_childElements);
+        AddImports(_childElements);
     }
+
+    /// <summary>
+    /// List of child elements in the grouping.
+    /// </summary>
+    public IEnumerable<RuleElement> ChildElements => _childElements;
 }

--- a/src/NRules/NRules.RuleModel/IContext.cs
+++ b/src/NRules/NRules.RuleModel/IContext.cs
@@ -2,164 +2,163 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Rules engine execution context.
+/// Can be used by rules to interact with the rules engine, i.e. insert, update, retract facts.
+/// </summary>
+public interface IContext
 {
     /// <summary>
-    /// Rules engine execution context.
-    /// Can be used by rules to interact with the rules engine, i.e. insert, update, retract facts.
+    /// Current rule definition.
     /// </summary>
-    public interface IContext
-    {
-        /// <summary>
-        /// Current rule definition.
-        /// </summary>
-        IRuleDefinition Rule { get; }
+    IRuleDefinition Rule { get; }
 
-        /// <summary>
-        /// Current rule match.
-        /// </summary>
-        IMatch Match { get; }
+    /// <summary>
+    /// Current rule match.
+    /// </summary>
+    IMatch Match { get; }
 
-        /// <summary>
-        /// Enables cooperative cancellation of the rules execution cycle.
-        /// </summary>
-        CancellationToken CancellationToken { get; }
+    /// <summary>
+    /// Enables cooperative cancellation of the rules execution cycle.
+    /// </summary>
+    CancellationToken CancellationToken { get; }
 
-        /// <summary>
-        /// Halts rules execution. The engine continues execution of the current rule and exits the execution cycle.
-        /// </summary>
-        void Halt();
+    /// <summary>
+    /// Halts rules execution. The engine continues execution of the current rule and exits the execution cycle.
+    /// </summary>
+    void Halt();
 
-        /// <summary>
-        /// Inserts a new fact to the rules engine memory.
-        /// </summary>
-        /// <param name="fact">Fact to add.</param>
-        /// <exception cref="ArgumentException">If fact already exists in working memory.</exception>
-        void Insert(object fact);
-        
-        /// <summary>
-        /// Inserts new facts to the rules engine memory.
-        /// </summary>
-        /// <param name="facts">Facts to add.</param>
-        /// <exception cref="ArgumentException">If any fact already exists in working memory.</exception>
-        void InsertAll(IEnumerable<object> facts);
+    /// <summary>
+    /// Inserts a new fact to the rules engine memory.
+    /// </summary>
+    /// <param name="fact">Fact to add.</param>
+    /// <exception cref="ArgumentException">If fact already exists in working memory.</exception>
+    void Insert(object fact);
+    
+    /// <summary>
+    /// Inserts new facts to the rules engine memory.
+    /// </summary>
+    /// <param name="facts">Facts to add.</param>
+    /// <exception cref="ArgumentException">If any fact already exists in working memory.</exception>
+    void InsertAll(IEnumerable<object> facts);
 
-        /// <summary>
-        /// Inserts a fact to the rules engine memory if the fact does not exist.
-        /// </summary>
-        /// <param name="fact">Fact to add.</param>
-        /// <returns>Whether the fact was inserted or not.</returns>
-        bool TryInsert(object fact);
+    /// <summary>
+    /// Inserts a fact to the rules engine memory if the fact does not exist.
+    /// </summary>
+    /// <param name="fact">Fact to add.</param>
+    /// <returns>Whether the fact was inserted or not.</returns>
+    bool TryInsert(object fact);
 
-        /// <summary>
-        /// Updates existing fact in the rules engine memory.
-        /// </summary>
-        /// <param name="fact">Fact to update.</param>
-        /// <exception cref="ArgumentException">If fact does not exist in working memory.</exception>
-        void Update(object fact);
+    /// <summary>
+    /// Updates existing fact in the rules engine memory.
+    /// </summary>
+    /// <param name="fact">Fact to update.</param>
+    /// <exception cref="ArgumentException">If fact does not exist in working memory.</exception>
+    void Update(object fact);
 
-        /// <summary>
-        /// Updates existing facts in the rules engine memory.
-        /// </summary>
-        /// <param name="facts">Facts to update.</param>
-        /// <exception cref="ArgumentException">If any fact does not exist in working memory.</exception>
-        void UpdateAll(IEnumerable<object> facts);
+    /// <summary>
+    /// Updates existing facts in the rules engine memory.
+    /// </summary>
+    /// <param name="facts">Facts to update.</param>
+    /// <exception cref="ArgumentException">If any fact does not exist in working memory.</exception>
+    void UpdateAll(IEnumerable<object> facts);
 
-        /// <summary>
-        /// Updates a fact in the rules engine memory if the fact exists.
-        /// </summary>
-        /// <param name="fact">Fact to update.</param>
-        /// <returns>Whether the fact was updated or not.</returns>
-        bool TryUpdate(object fact);
+    /// <summary>
+    /// Updates a fact in the rules engine memory if the fact exists.
+    /// </summary>
+    /// <param name="fact">Fact to update.</param>
+    /// <returns>Whether the fact was updated or not.</returns>
+    bool TryUpdate(object fact);
 
-        /// <summary>
-        /// Removes existing fact from the rules engine memory.
-        /// </summary>
-        /// <param name="fact">Fact to remove.</param>
-        /// <exception cref="ArgumentException">If fact does not exist in working memory.</exception>
-        void Retract(object fact);
+    /// <summary>
+    /// Removes existing fact from the rules engine memory.
+    /// </summary>
+    /// <param name="fact">Fact to remove.</param>
+    /// <exception cref="ArgumentException">If fact does not exist in working memory.</exception>
+    void Retract(object fact);
 
-        /// <summary>
-        /// Removes existing facts from the rules engine memory.
-        /// </summary>
-        /// <param name="facts">Facts to remove.</param>
-        /// <exception cref="ArgumentException">If any fact does not exist in working memory.</exception>
-        void RetractAll(IEnumerable<object> facts);
+    /// <summary>
+    /// Removes existing facts from the rules engine memory.
+    /// </summary>
+    /// <param name="facts">Facts to remove.</param>
+    /// <exception cref="ArgumentException">If any fact does not exist in working memory.</exception>
+    void RetractAll(IEnumerable<object> facts);
 
-        /// <summary>
-        /// Removes a fact from the rules engine memory if the fact exists.
-        /// </summary>
-        /// <param name="fact">Fact to remove.</param>
-        /// <returns>Whether the fact was retracted or not.</returns>
-        bool TryRetract(object fact);
+    /// <summary>
+    /// Removes a fact from the rules engine memory if the fact exists.
+    /// </summary>
+    /// <param name="fact">Fact to remove.</param>
+    /// <returns>Whether the fact was retracted or not.</returns>
+    bool TryRetract(object fact);
 
-        /// <summary>
-        /// Retrieves keys of facts linked to the current rule activation.
-        /// </summary>
-        /// <returns>Keys for linked facts.</returns>
-        IEnumerable<object> GetLinkedKeys();
+    /// <summary>
+    /// Retrieves keys of facts linked to the current rule activation.
+    /// </summary>
+    /// <returns>Keys for linked facts.</returns>
+    IEnumerable<object> GetLinkedKeys();
 
-        /// <summary>
-        /// Retrieves a fact linked to the current rule activation by key.
-        /// </summary>
-        /// <param name="key">Key for the linked fact.</param>
-        /// <returns>Linked fact if it exists, <c>null</c> otherwise.</returns>
-        object GetLinked(object key);
+    /// <summary>
+    /// Retrieves a fact linked to the current rule activation by key.
+    /// </summary>
+    /// <param name="key">Key for the linked fact.</param>
+    /// <returns>Linked fact if it exists, <c>null</c> otherwise.</returns>
+    object GetLinked(object key);
 
-        /// <summary>
-        /// Inserts a new fact and links it to the current rule activation.
-        /// The fact will be automatically retracted if this activation is removed.
-        /// </summary>
-        /// <param name="key">Key for the linked fact. Must be unique for a given rule.</param>
-        /// <param name="fact">Fact to insert.</param>
-        void InsertLinked(object key, object fact);
+    /// <summary>
+    /// Inserts a new fact and links it to the current rule activation.
+    /// The fact will be automatically retracted if this activation is removed.
+    /// </summary>
+    /// <param name="key">Key for the linked fact. Must be unique for a given rule.</param>
+    /// <param name="fact">Fact to insert.</param>
+    void InsertLinked(object key, object fact);
 
-        /// <summary>
-        /// Inserts new facts and links them to the current rule activation.
-        /// The facts will be automatically retracted if this activation is removed.
-        /// </summary>
-        /// <param name="keyedFacts">Keyed facts to insert. Keys must be unique for a given rule.</param>
-        void InsertAllLinked(IEnumerable<KeyValuePair<object, object>> keyedFacts);
+    /// <summary>
+    /// Inserts new facts and links them to the current rule activation.
+    /// The facts will be automatically retracted if this activation is removed.
+    /// </summary>
+    /// <param name="keyedFacts">Keyed facts to insert. Keys must be unique for a given rule.</param>
+    void InsertAllLinked(IEnumerable<KeyValuePair<object, object>> keyedFacts);
 
-        /// <summary>
-        /// Updates existing fact that's linked to the current rule activation.
-        /// </summary>
-        /// <param name="key">Key for the linked fact. Must be unique for a given rule.</param>
-        /// <param name="fact">Fact to update.</param>
-        void UpdateLinked(object key, object fact);
+    /// <summary>
+    /// Updates existing fact that's linked to the current rule activation.
+    /// </summary>
+    /// <param name="key">Key for the linked fact. Must be unique for a given rule.</param>
+    /// <param name="fact">Fact to update.</param>
+    void UpdateLinked(object key, object fact);
 
-        /// <summary>
-        /// Updates existing facts that are linked to the current rule activation.
-        /// </summary>
-        /// <param name="keyedFacts">Keyed facts to update. Keys must be unique for a given rule.</param>
-        void UpdateAllLinked(IEnumerable<KeyValuePair<object, object>> keyedFacts);
+    /// <summary>
+    /// Updates existing facts that are linked to the current rule activation.
+    /// </summary>
+    /// <param name="keyedFacts">Keyed facts to update. Keys must be unique for a given rule.</param>
+    void UpdateAllLinked(IEnumerable<KeyValuePair<object, object>> keyedFacts);
 
-        /// <summary>
-        /// Retracts existing fact that's linked to the current rule activation.
-        /// </summary>
-        /// <remarks>Linked facts are retracted automatically, when activation is deleted, but 
-        /// this method can be used in complex scenarios, when linked facts need to be retracted explicitly,
-        /// prior to activation getting deleted.
-        /// </remarks>
-        /// <param name="key">Key for the linked fact. Must be unique for a given rule.</param>
-        /// <param name="fact">Fact to retract.</param>
-        void RetractLinked(object key, object fact);
+    /// <summary>
+    /// Retracts existing fact that's linked to the current rule activation.
+    /// </summary>
+    /// <remarks>Linked facts are retracted automatically, when activation is deleted, but 
+    /// this method can be used in complex scenarios, when linked facts need to be retracted explicitly,
+    /// prior to activation getting deleted.
+    /// </remarks>
+    /// <param name="key">Key for the linked fact. Must be unique for a given rule.</param>
+    /// <param name="fact">Fact to retract.</param>
+    void RetractLinked(object key, object fact);
 
-        /// <summary>
-        /// Retracts existing facts that are linked to the current rule activation.
-        /// </summary>
-        /// <remarks>Linked facts are retracted automatically, when activation is deleted, but 
-        /// this method can be used in complex scenarios, when linked facts need to be retracted explicitly,
-        /// prior to activation getting deleted.
-        /// </remarks>
-        /// <param name="keyedFacts">Keyed facts to retract. Keys must be unique for a given rule.</param>
-        void RetractAllLinked(IEnumerable<KeyValuePair<object, object>> keyedFacts);
+    /// <summary>
+    /// Retracts existing facts that are linked to the current rule activation.
+    /// </summary>
+    /// <remarks>Linked facts are retracted automatically, when activation is deleted, but 
+    /// this method can be used in complex scenarios, when linked facts need to be retracted explicitly,
+    /// prior to activation getting deleted.
+    /// </remarks>
+    /// <param name="keyedFacts">Keyed facts to retract. Keys must be unique for a given rule.</param>
+    void RetractAllLinked(IEnumerable<KeyValuePair<object, object>> keyedFacts);
 
-        /// <summary>
-        /// Resolves a registered service (normally via an IoC container).
-        /// </summary>
-        /// <param name="serviceType">Type of service to resolve.</param>
-        /// <returns>Service instance.</returns>
-        object Resolve(Type serviceType);
-    }
+    /// <summary>
+    /// Resolves a registered service (normally via an IoC container).
+    /// </summary>
+    /// <param name="serviceType">Type of service to resolve.</param>
+    /// <returns>Service instance.</returns>
+    object Resolve(Type serviceType);
 }

--- a/src/NRules/NRules.RuleModel/IFact.cs
+++ b/src/NRules/NRules.RuleModel/IFact.cs
@@ -1,25 +1,24 @@
 ﻿using System;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Fact in the engine's working memory.
+/// </summary>
+public interface IFact
 {
     /// <summary>
-    /// Fact in the engine's working memory.
+    /// Fact runtime type.
     /// </summary>
-    public interface IFact
-    {
-        /// <summary>
-        /// Fact runtime type.
-        /// </summary>
-        Type Type { get; }
+    Type Type { get; }
 
-        /// <summary>
-        /// Fact value.
-        /// </summary>
-        object Value { get; }
+    /// <summary>
+    /// Fact value.
+    /// </summary>
+    object Value { get; }
 
-        /// <summary>
-        /// Source of this fact, for synthetic facts, or <c>null</c>.
-        /// </summary>
-        IFactSource Source { get; }
-    }
+    /// <summary>
+    /// Source of this fact, for synthetic facts, or <c>null</c>.
+    /// </summary>
+    IFactSource Source { get; }
 }

--- a/src/NRules/NRules.RuleModel/IFactMatch.cs
+++ b/src/NRules/NRules.RuleModel/IFactMatch.cs
@@ -1,14 +1,13 @@
-﻿namespace NRules.RuleModel
+﻿namespace NRules.RuleModel;
+
+/// <summary>
+/// Represents a fact matched by a rule.
+/// </summary>
+/// <seealso cref="IFact"/>
+public interface IFactMatch : IFact
 {
     /// <summary>
-    /// Represents a fact matched by a rule.
+    /// Variable declaration that corresponds to the fact.
     /// </summary>
-    /// <seealso cref="IFact"/>
-    public interface IFactMatch : IFact
-    {
-        /// <summary>
-        /// Variable declaration that corresponds to the fact.
-        /// </summary>
-        Declaration Declaration { get; }
-    }
+    Declaration Declaration { get; }
 }

--- a/src/NRules/NRules.RuleModel/IFactSource.cs
+++ b/src/NRules/NRules.RuleModel/IFactSource.cs
@@ -1,36 +1,35 @@
 ﻿using System.Collections.Generic;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Type of source that produced the fact.
+/// </summary>
+public enum FactSourceType
 {
     /// <summary>
-    /// Type of source that produced the fact.
+    /// Fact produced by an aggregation.
     /// </summary>
-    public enum FactSourceType
-    {
-        /// <summary>
-        /// Fact produced by an aggregation.
-        /// </summary>
-        Aggregate = 1,
-
-        /// <summary>
-        /// Fact produced as a linked fact from a rule action.
-        /// </summary>
-        Linked = 2,
-    }
+    Aggregate = 1,
 
     /// <summary>
-    /// Source of the fact, for synthetic facts.
+    /// Fact produced as a linked fact from a rule action.
     /// </summary>
-    public interface IFactSource
-    {
-        /// <summary>
-        /// Type of source that produced this fact.
-        /// </summary>
-        FactSourceType SourceType { get; }
+    Linked = 2,
+}
 
-        /// <summary>
-        /// Facts that produced this fact.
-        /// </summary>
-        IEnumerable<IFact> Facts { get; }
-    }
+/// <summary>
+/// Source of the fact, for synthetic facts.
+/// </summary>
+public interface IFactSource
+{
+    /// <summary>
+    /// Type of source that produced this fact.
+    /// </summary>
+    FactSourceType SourceType { get; }
+
+    /// <summary>
+    /// Facts that produced this fact.
+    /// </summary>
+    IEnumerable<IFact> Facts { get; }
 }

--- a/src/NRules/NRules.RuleModel/IKeyedLookup.cs
+++ b/src/NRules/NRules.RuleModel/IKeyedLookup.cs
@@ -1,20 +1,19 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Collection of facts grouped by a key.
+/// Exposes all keys present in the lookup as a <see cref="Keys"/> collection.
+/// </summary>
+/// <typeparam name="TKey">The type of the keys in the lookup.</typeparam>
+/// <typeparam name="TElement">The type of the elements in the lookup,</typeparam>
+public interface IKeyedLookup<TKey, TElement> : ILookup<TKey, TElement>
 {
     /// <summary>
-    /// Collection of facts grouped by a key.
-    /// Exposes all keys present in the lookup as a <see cref="Keys"/> collection.
+    /// All keys present in the lookup.
+    /// To find the number of keys in the lookup use <see cref="ILookup{TKey,TElement}.Count"/>.
     /// </summary>
-    /// <typeparam name="TKey">The type of the keys in the lookup.</typeparam>
-    /// <typeparam name="TElement">The type of the elements in the lookup,</typeparam>
-    public interface IKeyedLookup<TKey, TElement> : ILookup<TKey, TElement>
-    {
-        /// <summary>
-        /// All keys present in the lookup.
-        /// To find the number of keys in the lookup use <see cref="ILookup{TKey,TElement}.Count"/>.
-        /// </summary>
-        IEnumerable<TKey> Keys { get; }
-    }
+    IEnumerable<TKey> Keys { get; }
 }

--- a/src/NRules/NRules.RuleModel/IMatch.cs
+++ b/src/NRules/NRules.RuleModel/IMatch.cs
@@ -1,51 +1,50 @@
 using System.Collections.Generic;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Event that triggered the match.
+/// </summary>
+public enum MatchTrigger
 {
+    /// <summary>
+    /// Match is not active.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Match is triggered due to activation creation.
+    /// </summary>
+    Created = 1,
+
+    /// <summary>
+    /// Match is triggered due to activation update.
+    /// </summary>
+    Updated = 2,
+
+    /// <summary>
+    /// Match is triggered due to activation removal.
+    /// </summary>
+    Removed = 4,
+}
+
+/// <summary>
+/// Represents a match of all rule's conditions.
+/// </summary>
+public interface IMatch
+{
+    /// <summary>
+    /// Rule that matched the given facts.
+    /// </summary>
+    IRuleDefinition Rule { get; }
+
+    /// <summary>
+    /// Facts matched by the rule.
+    /// </summary>
+    IEnumerable<IFactMatch> Facts { get; }
+
     /// <summary>
     /// Event that triggered the match.
     /// </summary>
-    public enum MatchTrigger
-    {
-        /// <summary>
-        /// Match is not active.
-        /// </summary>
-        None = 0,
-
-        /// <summary>
-        /// Match is triggered due to activation creation.
-        /// </summary>
-        Created = 1,
-
-        /// <summary>
-        /// Match is triggered due to activation update.
-        /// </summary>
-        Updated = 2,
-
-        /// <summary>
-        /// Match is triggered due to activation removal.
-        /// </summary>
-        Removed = 4,
-    }
-
-    /// <summary>
-    /// Represents a match of all rule's conditions.
-    /// </summary>
-    public interface IMatch
-    {
-        /// <summary>
-        /// Rule that matched the given facts.
-        /// </summary>
-        IRuleDefinition Rule { get; }
-
-        /// <summary>
-        /// Facts matched by the rule.
-        /// </summary>
-        IEnumerable<IFactMatch> Facts { get; }
-
-        /// <summary>
-        /// Event that triggered the match.
-        /// </summary>
-        MatchTrigger Trigger { get; }
-    }
+    MatchTrigger Trigger { get; }
 }

--- a/src/NRules/NRules.RuleModel/IRuleRepository.cs
+++ b/src/NRules/NRules.RuleModel/IRuleRepository.cs
@@ -1,17 +1,16 @@
 using System.Collections.Generic;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// In-memory database of production rules arranged into rule sets.
+/// <seealso cref="IRuleSet"/>
+/// </summary>
+public interface IRuleRepository
 {
     /// <summary>
-    /// In-memory database of production rules arranged into rule sets.
-    /// <seealso cref="IRuleSet"/>
+    /// Retrieves all rule sets contained in the repository.
     /// </summary>
-    public interface IRuleRepository
-    {
-        /// <summary>
-        /// Retrieves all rule sets contained in the repository.
-        /// </summary>
-        /// <returns>Collection of rule sets.</returns>
-        IEnumerable<IRuleSet> GetRuleSets();
-    }
+    /// <returns>Collection of rule sets.</returns>
+    IEnumerable<IRuleSet> GetRuleSets();
 }

--- a/src/NRules/NRules.RuleModel/ITuple.cs
+++ b/src/NRules/NRules.RuleModel/ITuple.cs
@@ -1,22 +1,21 @@
 using System.Collections.Generic;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Set of facts matched by the rules engine.
+/// </summary>
+/// <seealso cref="IFact"/>
+public interface ITuple
 {
     /// <summary>
-    /// Set of facts matched by the rules engine.
+    /// Facts in the tuple, representing a partial match in the engine's working memory.
     /// </summary>
-    /// <seealso cref="IFact"/>
-    public interface ITuple
-    {
-        /// <summary>
-        /// Facts in the tuple, representing a partial match in the engine's working memory.
-        /// </summary>
-        /// <remarks>Facts in the tuple are stored in the reverse order.</remarks>
-        IEnumerable<IFact> Facts { get; }
+    /// <remarks>Facts in the tuple are stored in the reverse order.</remarks>
+    IEnumerable<IFact> Facts { get; }
 
-        /// <summary>
-        /// Number of facts in the tuple.
-        /// </summary>
-        int Count { get; }
-    }
+    /// <summary>
+    /// Number of facts in the tuple.
+    /// </summary>
+    int Count { get; }
 }

--- a/src/NRules/NRules.RuleModel/NRules.RuleModel.csproj
+++ b/src/NRules/NRules.RuleModel/NRules.RuleModel.csproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NRules/NRules.RuleModel/NamedExpressionElement.cs
+++ b/src/NRules/NRules.RuleModel/NamedExpressionElement.cs
@@ -1,31 +1,30 @@
 using System.Diagnostics;
 using System.Linq.Expressions;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Expression with a name used by an aggregator.
+/// </summary>
+[DebuggerDisplay("{Name}={Expression.ToString()}")]
+public class NamedExpressionElement : ExpressionElement
 {
-    /// <summary>
-    /// Expression with a name used by an aggregator.
-    /// </summary>
-    [DebuggerDisplay("{Name}={Expression.ToString()}")]
-    public class NamedExpressionElement : ExpressionElement
+    internal NamedExpressionElement(string name, LambdaExpression lambdaExpression)
+        : base(lambdaExpression)
     {
-        internal NamedExpressionElement(string name, LambdaExpression lambdaExpression)
-            : base(lambdaExpression)
-        {
-            Name = name;
-        }
+        Name = name;
+    }
 
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.NamedExpression;
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.NamedExpression;
 
-        /// <summary>
-        /// Expression name.
-        /// </summary>
-        public string Name { get; }
+    /// <summary>
+    /// Expression name.
+    /// </summary>
+    public string Name { get; }
 
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitNamedExpression(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitNamedExpression(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/NotElement.cs
+++ b/src/NRules/NRules.RuleModel/NotElement.cs
@@ -1,28 +1,27 @@
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Negative existential quantifier.
+/// </summary>
+public class NotElement : RuleElement
 {
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.Not;
+
     /// <summary>
-    /// Negative existential quantifier.
+    /// Fact source of the not element.
     /// </summary>
-    public class NotElement : RuleElement
+    public RuleElement Source { get; }
+
+    internal NotElement(RuleElement source)
     {
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.Not;
+        Source = source;
 
-        /// <summary>
-        /// Fact source of the not element.
-        /// </summary>
-        public RuleElement Source { get; }
+        AddImports(source);
+    }
 
-        internal NotElement(RuleElement source)
-        {
-            Source = source;
-
-            AddImports(source);
-        }
-
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitNot(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitNot(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/OrElement.cs
+++ b/src/NRules/NRules.RuleModel/OrElement.cs
@@ -1,23 +1,22 @@
 using System.Collections.Generic;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Grouping element based on the logical OR condition.
+/// </summary>
+public class OrElement : GroupElement
 {
-    /// <summary>
-    /// Grouping element based on the logical OR condition.
-    /// </summary>
-    public class OrElement : GroupElement
+    internal OrElement(IEnumerable<RuleElement> childElements)
+        : base(childElements)
     {
-        internal OrElement(IEnumerable<RuleElement> childElements)
-            : base(childElements)
-        {
-        }
+    }
 
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.Or;
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.Or;
 
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitOr(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitOr(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/PatternElement.cs
+++ b/src/NRules/NRules.RuleModel/PatternElement.cs
@@ -1,52 +1,51 @@
 using System;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Rule element that represents a pattern that matches facts.
+/// </summary>
+public class PatternElement : RuleElement
 {
-    /// <summary>
-    /// Rule element that represents a pattern that matches facts.
-    /// </summary>
-    public class PatternElement : RuleElement
+    public const string ConditionName = "Condition";
+
+    internal PatternElement(Declaration declaration, ExpressionCollection expressions, RuleElement source)
     {
-        public const string ConditionName = "Condition";
+        Declaration = declaration;
+        ValueType = declaration.Type;
+        Expressions = expressions;
+        Source = source;
 
-        internal PatternElement(Declaration declaration, ExpressionCollection expressions, RuleElement source)
-        {
-            Declaration = declaration;
-            ValueType = declaration.Type;
-            Expressions = expressions;
-            Source = source;
+        AddExport(declaration);
+        AddImports(expressions);
+        AddImports(source);
+    }
 
-            AddExport(declaration);
-            AddImports(expressions);
-            AddImports(source);
-        }
+    /// <inheritdoc cref="RuleElement.ElementType"/>
+    public override ElementType ElementType => ElementType.Pattern;
 
-        /// <inheritdoc cref="RuleElement.ElementType"/>
-        public override ElementType ElementType => ElementType.Pattern;
+    /// <summary>
+    /// Declaration that references the pattern.
+    /// </summary>
+    public Declaration Declaration { get; }
 
-        /// <summary>
-        /// Declaration that references the pattern.
-        /// </summary>
-        public Declaration Declaration { get; }
+    /// <summary>
+    /// Optional pattern source element.
+    /// </summary>
+    public RuleElement Source { get; }
 
-        /// <summary>
-        /// Optional pattern source element.
-        /// </summary>
-        public RuleElement Source { get; }
+    /// <summary>
+    /// Type of the values that the pattern matches.
+    /// </summary>
+    public Type ValueType { get; }
 
-        /// <summary>
-        /// Type of the values that the pattern matches.
-        /// </summary>
-        public Type ValueType { get; }
+    /// <summary>
+    /// Expressions used by the pattern to match elements.
+    /// </summary>
+    public ExpressionCollection Expressions { get; }
 
-        /// <summary>
-        /// Expressions used by the pattern to match elements.
-        /// </summary>
-        public ExpressionCollection Expressions { get; }
-
-        internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
-        {
-            visitor.VisitPattern(context, this);
-        }
+    internal override void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor)
+    {
+        visitor.VisitPattern(context, this);
     }
 }

--- a/src/NRules/NRules.RuleModel/PropertyMap.cs
+++ b/src/NRules/NRules.RuleModel/PropertyMap.cs
@@ -4,73 +4,72 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Readonly map of rule properties.
+/// </summary>
+public class PropertyMap : IEnumerable<RuleProperty>
 {
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    private readonly Dictionary<string, RuleProperty> _properties;
+
     /// <summary>
-    /// Readonly map of rule properties.
+    /// Creates new map of rule properties.
     /// </summary>
-    public class PropertyMap : IEnumerable<RuleProperty>
+    /// <param name="properties">Rule properties to put in the map.</param>
+    public PropertyMap(IEnumerable<RuleProperty> properties)
     {
-        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        private readonly Dictionary<string, RuleProperty> _properties;
+        _properties = new Dictionary<string, RuleProperty>(properties.ToDictionary(x => x.Name));
+    }
 
-        /// <summary>
-        /// Creates new map of rule properties.
-        /// </summary>
-        /// <param name="properties">Rule properties to put in the map.</param>
-        public PropertyMap(IEnumerable<RuleProperty> properties)
+    /// <summary>
+    /// Number of properties in the map.
+    /// </summary>
+    public int Count => _properties.Count;
+
+    /// <summary>
+    /// Retrieves property by name.
+    /// </summary>
+    /// <param name="name">Property name.</param>
+    /// <returns>Matching property value.</returns>
+    public object this[string name]
+    {
+        get
         {
-            _properties = new Dictionary<string, RuleProperty>(properties.ToDictionary(x => x.Name));
-        }
-
-        /// <summary>
-        /// Number of properties in the map.
-        /// </summary>
-        public int Count => _properties.Count;
-
-        /// <summary>
-        /// Retrieves property by name.
-        /// </summary>
-        /// <param name="name">Property name.</param>
-        /// <returns>Matching property value.</returns>
-        public object this[string name]
-        {
-            get
+            var found = _properties.TryGetValue(name, out var result);
+            if (!found)
             {
-                var found = _properties.TryGetValue(name, out var result);
-                if (!found)
-                {
-                    throw new ArgumentException(
-                        $"Property with the given name not found. Name={name}", nameof(name));
-                }
-                return result.Value;
+                throw new ArgumentException(
+                    $"Property with the given name not found. Name={name}", nameof(name));
             }
+            return result.Value;
         }
+    }
 
-        /// <summary>
-        /// Retrieves property by name if it exists.
-        /// </summary>
-        /// <param name="name">Property name.</param>
-        /// <param name="property">Matching property if found.</param>
-        /// <returns>If found <c>true</c>, otherwise <c>false</c>.</returns>
-        public bool TryGetProperty(string name, out RuleProperty property)
-        {
-            var found = _properties.TryGetValue(name, out property);
-            return found;
-        }
+    /// <summary>
+    /// Retrieves property by name if it exists.
+    /// </summary>
+    /// <param name="name">Property name.</param>
+    /// <param name="property">Matching property if found.</param>
+    /// <returns>If found <c>true</c>, otherwise <c>false</c>.</returns>
+    public bool TryGetProperty(string name, out RuleProperty property)
+    {
+        var found = _properties.TryGetValue(name, out property);
+        return found;
+    }
 
-        /// <summary>
-        /// Returns an enumerator for the contained rule properties.
-        /// </summary>
-        /// <returns></returns>
-        public IEnumerator<RuleProperty> GetEnumerator()
-        {
-            return _properties.Values.GetEnumerator();
-        }
+    /// <summary>
+    /// Returns an enumerator for the contained rule properties.
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerator<RuleProperty> GetEnumerator()
+    {
+        return _properties.Values.GetEnumerator();
+    }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
     }
 }

--- a/src/NRules/NRules.RuleModel/RuleDefinition.cs
+++ b/src/NRules/NRules.RuleModel/RuleDefinition.cs
@@ -1,114 +1,113 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Rule repeatability.
+/// </summary>
+public enum RuleRepeatability
 {
+    /// <summary>
+    /// Rule will fire every time a matching set of facts is inserted or updated.
+    /// </summary>
+    Repeatable = 0,
+
+    /// <summary>
+    /// Rule will not fire with the same combination of facts, unless that combination was previously deactivated (i.e. through retraction).
+    /// </summary>
+    NonRepeatable = 1,
+}
+
+/// <summary>
+/// Production rule definition in the canonical rule model.
+/// </summary>
+public interface IRuleDefinition
+{
+    /// <summary>
+    /// Rule name.
+    /// </summary>
+    string Name { get; }
+    
+    /// <summary>
+    /// Rule description.
+    /// </summary>
+    string Description { get; }
+
+    /// <summary>
+    /// Rule priority.
+    /// </summary>
+    int Priority { get; }
+
     /// <summary>
     /// Rule repeatability.
     /// </summary>
-    public enum RuleRepeatability
-    {
-        /// <summary>
-        /// Rule will fire every time a matching set of facts is inserted or updated.
-        /// </summary>
-        Repeatable = 0,
-
-        /// <summary>
-        /// Rule will not fire with the same combination of facts, unless that combination was previously deactivated (i.e. through retraction).
-        /// </summary>
-        NonRepeatable = 1,
-    }
+    RuleRepeatability Repeatability { get; }
 
     /// <summary>
-    /// Production rule definition in the canonical rule model.
+    /// Tags applied to the rule.
     /// </summary>
-    public interface IRuleDefinition
+    IEnumerable<string> Tags { get; }
+
+    /// <summary>
+    /// Properties attached to the rule.
+    /// </summary>
+    PropertyMap Properties { get; }
+
+    /// <summary>
+    /// Rule's dependencies.
+    /// </summary>
+    DependencyGroupElement DependencyGroup { get; }
+
+    /// <summary>
+    /// Rule's filters, that determine whether rule's match triggers actions.
+    /// </summary>
+    FilterGroupElement FilterGroup { get; }
+
+    /// <summary>
+    /// Rule left-hand side (conditions).
+    /// </summary>
+    GroupElement LeftHandSide { get; }
+
+    /// <summary>
+    /// Rule right-hand side (actions).
+    /// </summary>
+    ActionGroupElement RightHandSide { get; }
+}
+
+[DebuggerDisplay("{Name} ({Priority})")]
+internal class RuleDefinition : IRuleDefinition
+{
+    private readonly List<string> _tags;
+
+    public static int DefaultPriority => 0;
+    public static RuleRepeatability DefaultRepeatability => RuleRepeatability.Repeatable;
+
+    public RuleDefinition(string name, string description, int priority, 
+        RuleRepeatability repeatability, IEnumerable<string> tags, IEnumerable<RuleProperty> properties,
+        DependencyGroupElement dependencies, GroupElement leftHandSide, FilterGroupElement filters, ActionGroupElement rightHandSide)
     {
-        /// <summary>
-        /// Rule name.
-        /// </summary>
-        string Name { get; }
-        
-        /// <summary>
-        /// Rule description.
-        /// </summary>
-        string Description { get; }
+        Name = name;
+        Description = description;
+        Repeatability = repeatability;
+        Priority = priority;
+        _tags = new List<string>(tags);
+        Properties = new PropertyMap(properties);
 
-        /// <summary>
-        /// Rule priority.
-        /// </summary>
-        int Priority { get; }
-
-        /// <summary>
-        /// Rule repeatability.
-        /// </summary>
-        RuleRepeatability Repeatability { get; }
-
-        /// <summary>
-        /// Tags applied to the rule.
-        /// </summary>
-        IEnumerable<string> Tags { get; }
-
-        /// <summary>
-        /// Properties attached to the rule.
-        /// </summary>
-        PropertyMap Properties { get; }
-
-        /// <summary>
-        /// Rule's dependencies.
-        /// </summary>
-        DependencyGroupElement DependencyGroup { get; }
-
-        /// <summary>
-        /// Rule's filters, that determine whether rule's match triggers actions.
-        /// </summary>
-        FilterGroupElement FilterGroup { get; }
-
-        /// <summary>
-        /// Rule left-hand side (conditions).
-        /// </summary>
-        GroupElement LeftHandSide { get; }
-
-        /// <summary>
-        /// Rule right-hand side (actions).
-        /// </summary>
-        ActionGroupElement RightHandSide { get; }
+        DependencyGroup = dependencies;
+        LeftHandSide = leftHandSide;
+        FilterGroup = filters;
+        RightHandSide = rightHandSide;
     }
 
-    [DebuggerDisplay("{Name} ({Priority})")]
-    internal class RuleDefinition : IRuleDefinition
-    {
-        private readonly List<string> _tags;
-
-        public static int DefaultPriority => 0;
-        public static RuleRepeatability DefaultRepeatability => RuleRepeatability.Repeatable;
-
-        public RuleDefinition(string name, string description, int priority, 
-            RuleRepeatability repeatability, IEnumerable<string> tags, IEnumerable<RuleProperty> properties,
-            DependencyGroupElement dependencies, GroupElement leftHandSide, FilterGroupElement filters, ActionGroupElement rightHandSide)
-        {
-            Name = name;
-            Description = description;
-            Repeatability = repeatability;
-            Priority = priority;
-            _tags = new List<string>(tags);
-            Properties = new PropertyMap(properties);
-
-            DependencyGroup = dependencies;
-            LeftHandSide = leftHandSide;
-            FilterGroup = filters;
-            RightHandSide = rightHandSide;
-        }
-
-        public string Name { get; }
-        public int Priority { get; }
-        public string Description { get; }
-        public RuleRepeatability Repeatability { get; }
-        public PropertyMap Properties { get; }
-        public DependencyGroupElement DependencyGroup { get; }
-        public FilterGroupElement FilterGroup { get; }
-        public GroupElement LeftHandSide { get; }
-        public ActionGroupElement RightHandSide { get; }
-        public IEnumerable<string> Tags => _tags;
-    }
+    public string Name { get; }
+    public int Priority { get; }
+    public string Description { get; }
+    public RuleRepeatability Repeatability { get; }
+    public PropertyMap Properties { get; }
+    public DependencyGroupElement DependencyGroup { get; }
+    public FilterGroupElement FilterGroup { get; }
+    public GroupElement LeftHandSide { get; }
+    public ActionGroupElement RightHandSide { get; }
+    public IEnumerable<string> Tags => _tags;
 }

--- a/src/NRules/NRules.RuleModel/RuleElement.cs
+++ b/src/NRules/NRules.RuleModel/RuleElement.cs
@@ -1,71 +1,70 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Base class for rule elements.
+/// </summary>
+public abstract class RuleElement
 {
+    private readonly HashSet<Declaration> _exports;
+    private readonly HashSet<Declaration> _imports;
+
     /// <summary>
-    /// Base class for rule elements.
+    /// Element type of this rule element.
     /// </summary>
-    public abstract class RuleElement
+    public abstract ElementType ElementType { get; }
+
+    /// <summary>
+    /// Rule element declarations exported to the outer scope.
+    /// </summary>
+    public IEnumerable<Declaration> Exports => _exports;
+
+    /// <summary>
+    /// Rule element declarations imported from the outer scope.
+    /// </summary>
+    public IEnumerable<Declaration> Imports => _imports;
+
+    internal RuleElement()
     {
-        private readonly HashSet<Declaration> _exports;
-        private readonly HashSet<Declaration> _imports;
-
-        /// <summary>
-        /// Element type of this rule element.
-        /// </summary>
-        public abstract ElementType ElementType { get; }
-
-        /// <summary>
-        /// Rule element declarations exported to the outer scope.
-        /// </summary>
-        public IEnumerable<Declaration> Exports => _exports;
-
-        /// <summary>
-        /// Rule element declarations imported from the outer scope.
-        /// </summary>
-        public IEnumerable<Declaration> Imports => _imports;
-
-        internal RuleElement()
-        {
-            _exports = new HashSet<Declaration>();
-            _imports = new HashSet<Declaration>();
-        }
-
-        internal void AddImports(IEnumerable<Declaration> declarations)
-        {
-            var imports = declarations.Except(_exports);
-            _imports.UnionWith(imports);
-        }
-
-        internal void AddImports(RuleElement element)
-        {
-            if (element != null)
-                AddImports(new[] {element});
-        }
-
-        internal void AddImports(IEnumerable<RuleElement> elements)
-        {
-            var imports = elements.SelectMany(x => x.Imports);
-            AddImports(imports);
-        }
-
-        internal void AddExports(IEnumerable<Declaration> declarations)
-        {
-            _exports.UnionWith(declarations);
-        }
-
-        internal void AddExports(IEnumerable<RuleElement> elements)
-        {
-            var exports = elements.SelectMany(x => x.Exports);
-            AddExports(exports);
-        }
-
-        internal void AddExport(Declaration declaration)
-        {
-            AddExports(new[] {declaration});
-        }
-
-        internal abstract void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor);
+        _exports = new HashSet<Declaration>();
+        _imports = new HashSet<Declaration>();
     }
+
+    internal void AddImports(IEnumerable<Declaration> declarations)
+    {
+        var imports = declarations.Except(_exports);
+        _imports.UnionWith(imports);
+    }
+
+    internal void AddImports(RuleElement element)
+    {
+        if (element != null)
+            AddImports(new[] {element});
+    }
+
+    internal void AddImports(IEnumerable<RuleElement> elements)
+    {
+        var imports = elements.SelectMany(x => x.Imports);
+        AddImports(imports);
+    }
+
+    internal void AddExports(IEnumerable<Declaration> declarations)
+    {
+        _exports.UnionWith(declarations);
+    }
+
+    internal void AddExports(IEnumerable<RuleElement> elements)
+    {
+        var exports = elements.SelectMany(x => x.Exports);
+        AddExports(exports);
+    }
+
+    internal void AddExport(Declaration declaration)
+    {
+        AddExports(new[] {declaration});
+    }
+
+    internal abstract void Accept<TContext>(TContext context, RuleElementVisitor<TContext> visitor);
 }

--- a/src/NRules/NRules.RuleModel/RuleElementExtensions.cs
+++ b/src/NRules/NRules.RuleModel/RuleElementExtensions.cs
@@ -1,84 +1,83 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+public static class RuleElementExtensions
 {
-    public static class RuleElementExtensions
+    /// <summary>
+    /// Matches a rule element to an appropriate action based on the concrete type of the element.
+    /// Type-safe implementation of discriminated union for rule elements.
+    /// </summary>
+    /// <param name="element">Rule element to match.</param>
+    /// <param name="pattern">Action to invoke on the element if the element is a <see cref="PatternElement"/>.</param>
+    /// <param name="aggregate">Action to invoke on the element if the element is an <see cref="AggregateElement"/>.</param>
+    /// <param name="group">Action to invoke on the element if the element is a <see cref="GroupElement"/>.</param>
+    /// <param name="exists">Action to invoke on the element if the element is an <see cref="ExistsElement"/>.</param>
+    /// <param name="not">Action to invoke on the element if the element is a <see cref="NotElement"/>.</param>
+    /// <param name="forall">Action to invoke on the element if the element is a <see cref="ForAllElement"/>.</param>
+    [DebuggerStepThrough]
+    public static void Match(this RuleElement element, 
+        Action<PatternElement> pattern, 
+        Action<AggregateElement> aggregate, 
+        Action<GroupElement> group,
+        Action<ExistsElement> exists, 
+        Action<NotElement> not, 
+        Action<ForAllElement> forall)
     {
-        /// <summary>
-        /// Matches a rule element to an appropriate action based on the concrete type of the element.
-        /// Type-safe implementation of discriminated union for rule elements.
-        /// </summary>
-        /// <param name="element">Rule element to match.</param>
-        /// <param name="pattern">Action to invoke on the element if the element is a <see cref="PatternElement"/>.</param>
-        /// <param name="aggregate">Action to invoke on the element if the element is an <see cref="AggregateElement"/>.</param>
-        /// <param name="group">Action to invoke on the element if the element is a <see cref="GroupElement"/>.</param>
-        /// <param name="exists">Action to invoke on the element if the element is an <see cref="ExistsElement"/>.</param>
-        /// <param name="not">Action to invoke on the element if the element is a <see cref="NotElement"/>.</param>
-        /// <param name="forall">Action to invoke on the element if the element is a <see cref="ForAllElement"/>.</param>
-        [DebuggerStepThrough]
-        public static void Match(this RuleElement element, 
-            Action<PatternElement> pattern, 
-            Action<AggregateElement> aggregate, 
-            Action<GroupElement> group,
-            Action<ExistsElement> exists, 
-            Action<NotElement> not, 
-            Action<ForAllElement> forall)
-        {
-            if (element == null)
-                throw new ArgumentNullException(nameof(element), "Rule element cannot be null");
+        if (element == null)
+            throw new ArgumentNullException(nameof(element), "Rule element cannot be null");
 
-            switch (element)
-            {
-                case PatternElement pe:
-                    pattern.Invoke(pe);
-                    break;
-                case GroupElement ge:
-                    @group.Invoke(ge);
-                    break;
-                case AggregateElement ae:
-                    aggregate.Invoke(ae);
-                    break;
-                case ExistsElement ee:
-                    exists.Invoke(ee);
-                    break;
-                case NotElement ne:
-                    not.Invoke(ne);
-                    break;
-                case ForAllElement fe:
-                    forall.Invoke(fe);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(element),
-                        $"Unsupported rule element. ElementType={element.GetType()}");
-            }
+        switch (element)
+        {
+            case PatternElement pe:
+                pattern.Invoke(pe);
+                break;
+            case GroupElement ge:
+                @group.Invoke(ge);
+                break;
+            case AggregateElement ae:
+                aggregate.Invoke(ae);
+                break;
+            case ExistsElement ee:
+                exists.Invoke(ee);
+                break;
+            case NotElement ne:
+                not.Invoke(ne);
+                break;
+            case ForAllElement fe:
+                forall.Invoke(fe);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(element),
+                    $"Unsupported rule element. ElementType={element.GetType()}");
         }
+    }
 
-        /// <summary>
-        /// Matches a group element to an appropriate action based on the concrete type of the element.
-        /// Type-safe implementation of discriminated union for group elements.
-        /// </summary>
-        /// <param name="element">Group element to match.</param>
-        /// <param name="and">Action to invoke on the element if the element is a <see cref="AndElement"/>.</param>
-        /// <param name="or">Action to invoke on the element if the element is a <see cref="OrElement"/>.</param>
-        [DebuggerStepThrough]
-        public static void Match(this GroupElement element, Action<AndElement> and, Action<OrElement> or)
+    /// <summary>
+    /// Matches a group element to an appropriate action based on the concrete type of the element.
+    /// Type-safe implementation of discriminated union for group elements.
+    /// </summary>
+    /// <param name="element">Group element to match.</param>
+    /// <param name="and">Action to invoke on the element if the element is a <see cref="AndElement"/>.</param>
+    /// <param name="or">Action to invoke on the element if the element is a <see cref="OrElement"/>.</param>
+    [DebuggerStepThrough]
+    public static void Match(this GroupElement element, Action<AndElement> and, Action<OrElement> or)
+    {
+        if (element == null)
+            throw new ArgumentNullException(nameof(element), "Group element cannot be null");
+
+        switch (element)
         {
-            if (element == null)
-                throw new ArgumentNullException(nameof(element), "Group element cannot be null");
-
-            switch (element)
-            {
-                case AndElement ae:
-                    and.Invoke(ae);
-                    break;
-                case OrElement oe:
-                    or.Invoke(oe);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(element),
-                        $"Unsupported group element. ElementType={element.GetType()}");
-            }
+            case AndElement ae:
+                and.Invoke(ae);
+                break;
+            case OrElement oe:
+                or.Invoke(oe);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(element),
+                    $"Unsupported group element. ElementType={element.GetType()}");
         }
     }
 }

--- a/src/NRules/NRules.RuleModel/RuleElementVisitor.cs
+++ b/src/NRules/NRules.RuleModel/RuleElementVisitor.cs
@@ -1,113 +1,112 @@
-﻿namespace NRules.RuleModel
+﻿namespace NRules.RuleModel;
+
+/// <summary>
+/// Visitor to traverse rule definition (or its part).
+/// </summary>
+/// <typeparam name="TContext">Traversal context.</typeparam>
+public class RuleElementVisitor<TContext>
 {
-    /// <summary>
-    /// Visitor to traverse rule definition (or its part).
-    /// </summary>
-    /// <typeparam name="TContext">Traversal context.</typeparam>
-    public class RuleElementVisitor<TContext>
+    public void Visit(TContext context, RuleElement element)
     {
-        public void Visit(TContext context, RuleElement element)
-        {
-            element.Accept(context, this);
-        }
+        element.Accept(context, this);
+    }
 
-        protected internal virtual void VisitPattern(TContext context, PatternElement element)
+    protected internal virtual void VisitPattern(TContext context, PatternElement element)
+    {
+        foreach (var expression in element.Expressions)
         {
-            foreach (var expression in element.Expressions)
-            {
-                expression.Accept(context, this);
-            }
-            element.Source?.Accept(context, this);
+            expression.Accept(context, this);
         }
+        element.Source?.Accept(context, this);
+    }
 
-        protected internal virtual void VisitBinding(TContext context, BindingElement element)
-        {
-        }
+    protected internal virtual void VisitBinding(TContext context, BindingElement element)
+    {
+    }
 
-        protected internal virtual void VisitAggregate(TContext context, AggregateElement element)
+    protected internal virtual void VisitAggregate(TContext context, AggregateElement element)
+    {
+        foreach (var expression in element.Expressions)
         {
-            foreach (var expression in element.Expressions)
-            {
-                expression.Accept(context, this);
-            }
-            element.Source?.Accept(context, this);
+            expression.Accept(context, this);
         }
+        element.Source?.Accept(context, this);
+    }
 
-        protected internal virtual void VisitNamedExpression(TContext context, NamedExpressionElement element)
-        {
-        }
+    protected internal virtual void VisitNamedExpression(TContext context, NamedExpressionElement element)
+    {
+    }
 
-        protected internal virtual void VisitNot(TContext context, NotElement element)
-        {
-            element.Source.Accept(context, this);
-        }
+    protected internal virtual void VisitNot(TContext context, NotElement element)
+    {
+        element.Source.Accept(context, this);
+    }
 
-        protected internal virtual void VisitExists(TContext context, ExistsElement element)
-        {
-            element.Source.Accept(context, this);
-        }
+    protected internal virtual void VisitExists(TContext context, ExistsElement element)
+    {
+        element.Source.Accept(context, this);
+    }
 
-        protected internal virtual void VisitForAll(TContext context, ForAllElement element)
+    protected internal virtual void VisitForAll(TContext context, ForAllElement element)
+    {
+        element.BasePattern.Accept(context, this);
+        foreach (PatternElement pattern in element.Patterns)
         {
-            element.BasePattern.Accept(context, this);
-            foreach (PatternElement pattern in element.Patterns)
-            {
-                pattern.Accept(context, this);
-            }
+            pattern.Accept(context, this);
         }
+    }
 
-        protected internal virtual void VisitAnd(TContext context, AndElement element)
-        {
-            VisitGroup(context, element);
-        }
+    protected internal virtual void VisitAnd(TContext context, AndElement element)
+    {
+        VisitGroup(context, element);
+    }
 
-        protected internal virtual void VisitOr(TContext context, OrElement element)
-        {
-            VisitGroup(context, element);
-        }
+    protected internal virtual void VisitOr(TContext context, OrElement element)
+    {
+        VisitGroup(context, element);
+    }
 
-        private void VisitGroup(TContext context, GroupElement element)
+    private void VisitGroup(TContext context, GroupElement element)
+    {
+        foreach (var childElement in element.ChildElements)
         {
-            foreach (var childElement in element.ChildElements)
-            {
-                childElement.Accept(context, this);
-            }
+            childElement.Accept(context, this);
         }
+    }
 
-        protected internal virtual void VisitActionGroup(TContext context, ActionGroupElement element)
+    protected internal virtual void VisitActionGroup(TContext context, ActionGroupElement element)
+    {
+        foreach (ActionElement action in element.Actions)
         {
-            foreach (ActionElement action in element.Actions)
-            {
-                action.Accept(context, this);
-            }
+            action.Accept(context, this);
         }
+    }
 
-        protected internal virtual void VisitAction(TContext context, ActionElement element)
-        {
-        }
+    protected internal virtual void VisitAction(TContext context, ActionElement element)
+    {
+    }
 
-        protected internal virtual void VisitDependencyGroup(TContext context, DependencyGroupElement element)
+    protected internal virtual void VisitDependencyGroup(TContext context, DependencyGroupElement element)
+    {
+        foreach (DependencyElement dependency in element.Dependencies)
         {
-            foreach (DependencyElement dependency in element.Dependencies)
-            {
-                dependency.Accept(context, this);
-            }
+            dependency.Accept(context, this);
         }
-        
-        protected internal virtual void VisitDependency(TContext context, DependencyElement element)
-        {
-        }
+    }
+    
+    protected internal virtual void VisitDependency(TContext context, DependencyElement element)
+    {
+    }
 
-        protected internal virtual void VisitFilterGroup(TContext context, FilterGroupElement element)
+    protected internal virtual void VisitFilterGroup(TContext context, FilterGroupElement element)
+    {
+        foreach (FilterElement filter in element.Filters)
         {
-            foreach (FilterElement filter in element.Filters)
-            {
-                filter.Accept(context, this);
-            }
+            filter.Accept(context, this);
         }
+    }
 
-        protected internal virtual void VisitFilter(TContext context, FilterElement element)
-        {
-        }
+    protected internal virtual void VisitFilter(TContext context, FilterElement element)
+    {
     }
 }

--- a/src/NRules/NRules.RuleModel/RuleProperty.cs
+++ b/src/NRules/NRules.RuleModel/RuleProperty.cs
@@ -1,32 +1,31 @@
 ﻿using System.Diagnostics;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Arbitrary value associated with a rule.
+/// </summary>
+[DebuggerDisplay("{Name,nq} = {Value}")]
+public class RuleProperty
 {
     /// <summary>
-    /// Arbitrary value associated with a rule.
+    /// Creates a new rule property.
     /// </summary>
-    [DebuggerDisplay("{Name,nq} = {Value}")]
-    public class RuleProperty
+    /// <param name="name">Rule property name.</param>
+    /// <param name="value">Rule property value.</param>
+    public RuleProperty(string name, object value)
     {
-        /// <summary>
-        /// Creates a new rule property.
-        /// </summary>
-        /// <param name="name">Rule property name.</param>
-        /// <param name="value">Rule property value.</param>
-        public RuleProperty(string name, object value)
-        {
-            Name = name;
-            Value = value;
-        }
-
-        /// <summary>
-        /// Rule property name.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Rule property value.
-        /// </summary>
-        public object Value { get; }
+        Name = name;
+        Value = value;
     }
+
+    /// <summary>
+    /// Rule property name.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Rule property value.
+    /// </summary>
+    public object Value { get; }
 }

--- a/src/NRules/NRules.RuleModel/RuleSet.cs
+++ b/src/NRules/NRules.RuleModel/RuleSet.cs
@@ -1,47 +1,46 @@
 using System.Collections.Generic;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Represents a named set of rules.
+/// </summary>
+public interface IRuleSet
 {
     /// <summary>
-    /// Represents a named set of rules.
+    /// Rule set name.
     /// </summary>
-    public interface IRuleSet
-    {
-        /// <summary>
-        /// Rule set name.
-        /// </summary>
-        string Name { get; }
-
-        /// <summary>
-        /// Adds rules to the rule set.
-        /// </summary>
-        /// <param name="ruleDefinitions">Rule definitions to add.</param>
-        void Add(IEnumerable<IRuleDefinition> ruleDefinitions);
-
-        /// <summary>
-        /// Rules in the rule set.
-        /// </summary>
-        IEnumerable<IRuleDefinition> Rules { get; }
-    }
+    string Name { get; }
 
     /// <summary>
-    /// Default implementation of a rule set.
+    /// Adds rules to the rule set.
     /// </summary>
-    public class RuleSet : IRuleSet
+    /// <param name="ruleDefinitions">Rule definitions to add.</param>
+    void Add(IEnumerable<IRuleDefinition> ruleDefinitions);
+
+    /// <summary>
+    /// Rules in the rule set.
+    /// </summary>
+    IEnumerable<IRuleDefinition> Rules { get; }
+}
+
+/// <summary>
+/// Default implementation of a rule set.
+/// </summary>
+public class RuleSet : IRuleSet
+{
+    private readonly List<IRuleDefinition> _rules = new();
+
+    public RuleSet(string name)
     {
-        private readonly List<IRuleDefinition> _rules = new();
+        Name = name;
+    }
 
-        public RuleSet(string name)
-        {
-            Name = name;
-        }
+    public string Name { get; }
+    public IEnumerable<IRuleDefinition> Rules => _rules;
 
-        public string Name { get; }
-        public IEnumerable<IRuleDefinition> Rules => _rules;
-
-        public void Add(IEnumerable<IRuleDefinition> ruleDefinitions)
-        {
-            _rules.AddRange(ruleDefinitions);
-        }
+    public void Add(IEnumerable<IRuleDefinition> ruleDefinitions)
+    {
+        _rules.AddRange(ruleDefinitions);
     }
 }

--- a/src/NRules/NRules.RuleModel/RuleSetExtensions.cs
+++ b/src/NRules/NRules.RuleModel/RuleSetExtensions.cs
@@ -1,17 +1,16 @@
 using System.Linq;
 
-namespace NRules.RuleModel
+namespace NRules.RuleModel;
+
+public static class RuleSetExtensions
 {
-    public static class RuleSetExtensions
+    /// <summary>
+    /// Adds a rule to the rule set.
+    /// </summary>
+    /// <param name="ruleSet">Rule set instance.</param>
+    /// <param name="ruleDefinition">Rule definition to add.</param>
+    public static void Add(this IRuleSet ruleSet, IRuleDefinition ruleDefinition)
     {
-        /// <summary>
-        /// Adds a rule to the rule set.
-        /// </summary>
-        /// <param name="ruleSet">Rule set instance.</param>
-        /// <param name="ruleDefinition">Rule definition to add.</param>
-        public static void Add(this IRuleSet ruleSet, IRuleDefinition ruleDefinition)
-        {
-            ruleSet.Add(Enumerable.Repeat(ruleDefinition, 1));
-        }
+        ruleSet.Add(Enumerable.Repeat(ruleDefinition, 1));
     }
 }

--- a/src/NRules/NRules.RuleModel/SortDirection.cs
+++ b/src/NRules/NRules.RuleModel/SortDirection.cs
@@ -1,18 +1,17 @@
-﻿namespace NRules.RuleModel
+﻿namespace NRules.RuleModel;
+
+/// <summary>
+/// Order that the sort should be performed in.
+/// </summary>
+public enum SortDirection
 {
     /// <summary>
-    /// Order that the sort should be performed in.
+    /// Sort in Ascending order.
     /// </summary>
-    public enum SortDirection
-    {
-        /// <summary>
-        /// Sort in Ascending order.
-        /// </summary>
-        Ascending = 0,
+    Ascending = 0,
 
-        /// <summary>
-        /// Sort in Descending order.
-        /// </summary>
-        Descending = 1
-    }
+    /// <summary>
+    /// Sort in Descending order.
+    /// </summary>
+    Descending = 1
 }

--- a/src/NRules/NRules/ActionContext.cs
+++ b/src/NRules/NRules/ActionContext.cs
@@ -4,148 +4,147 @@ using System.Threading;
 using NRules.Extensibility;
 using NRules.RuleModel;
 
-namespace NRules
+namespace NRules;
+
+internal interface IActionContext : IContext
 {
-    internal interface IActionContext : IContext
+    ICompiledRule CompiledRule { get; }
+    Activation Activation { get; }
+    bool IsHalted { get; }
+}
+
+internal class ActionContext : IActionContext
+{
+    private readonly ISessionInternal _session;
+
+    public ActionContext(ISessionInternal session, Activation activation, CancellationToken cancellationToken)
     {
-        ICompiledRule CompiledRule { get; }
-        Activation Activation { get; }
-        bool IsHalted { get; }
+        _session = session;
+        Activation = activation;
+        CancellationToken = cancellationToken;
+        IsHalted = false;
     }
 
-    internal class ActionContext : IActionContext
+    public IRuleDefinition Rule => CompiledRule.Definition;
+    public IMatch Match => Activation;
+    public ICompiledRule CompiledRule => Activation.CompiledRule;
+
+    public Activation Activation { get; }
+    public CancellationToken CancellationToken { get; }
+    public bool IsHalted { get; private set; }
+
+    public void Halt()
     {
-        private readonly ISessionInternal _session;
+        IsHalted = true;
+    }
 
-        public ActionContext(ISessionInternal session, Activation activation, CancellationToken cancellationToken)
-        {
-            _session = session;
-            Activation = activation;
-            CancellationToken = cancellationToken;
-            IsHalted = false;
-        }
+    public void Insert(object fact)
+    {
+        _session.Insert(fact);
+    }
 
-        public IRuleDefinition Rule => CompiledRule.Definition;
-        public IMatch Match => Activation;
-        public ICompiledRule CompiledRule => Activation.CompiledRule;
+    public void InsertAll(IEnumerable<object> facts)
+    {
+        _session.InsertAll(facts);
+    }
 
-        public Activation Activation { get; }
-        public CancellationToken CancellationToken { get; }
-        public bool IsHalted { get; private set; }
+    public bool TryInsert(object fact)
+    {
+        return _session.TryInsert(fact);
+    }
 
-        public void Halt()
-        {
-            IsHalted = true;
-        }
+    public void Update(object fact)
+    {
+        _session.Update(fact);
+    }
 
-        public void Insert(object fact)
-        {
-            _session.Insert(fact);
-        }
+    public void UpdateAll(IEnumerable<object> facts)
+    {
+        _session.UpdateAll(facts);
+    }
 
-        public void InsertAll(IEnumerable<object> facts)
-        {
-            _session.InsertAll(facts);
-        }
+    public bool TryUpdate(object fact)
+    {
+        return _session.TryUpdate(fact);
+    }
 
-        public bool TryInsert(object fact)
-        {
-            return _session.TryInsert(fact);
-        }
+    public void Retract(object fact)
+    {
+        _session.Retract(fact);
+    }
 
-        public void Update(object fact)
-        {
-            _session.Update(fact);
-        }
+    public void RetractAll(IEnumerable<object> facts)
+    {
+        _session.RetractAll(facts);
+    }
 
-        public void UpdateAll(IEnumerable<object> facts)
-        {
-            _session.UpdateAll(facts);
-        }
+    public bool TryRetract(object fact)
+    {
+        return _session.TryRetract(fact);
+    }
 
-        public bool TryUpdate(object fact)
-        {
-            return _session.TryUpdate(fact);
-        }
+    public IEnumerable<object> GetLinkedKeys()
+    {
+        return _session.GetLinkedKeys(Activation);
+    }
 
-        public void Retract(object fact)
-        {
-            _session.Retract(fact);
-        }
+    public object GetLinked(object key)
+    {
+        return _session.GetLinked(Activation, key);
+    }
 
-        public void RetractAll(IEnumerable<object> facts)
-        {
-            _session.RetractAll(facts);
-        }
+    public void InsertLinked(object key, object fact)
+    {
+        if (key == null)
+            throw new ArgumentNullException(nameof(key));
+        if (fact == null)
+            throw new ArgumentNullException(nameof(fact));
+        
+        var keyedFact = new KeyValuePair<object, object>(key, fact);
+        InsertAllLinked(new[] {keyedFact});
+    }
 
-        public bool TryRetract(object fact)
-        {
-            return _session.TryRetract(fact);
-        }
+    public void InsertAllLinked(IEnumerable<KeyValuePair<object, object>> keyedFacts)
+    {
+        _session.QueueInsertLinked(Activation, keyedFacts);
+    }
 
-        public IEnumerable<object> GetLinkedKeys()
-        {
-            return _session.GetLinkedKeys(Activation);
-        }
+    public void UpdateLinked(object key, object fact)
+    {
+        if (key == null)
+            throw new ArgumentNullException(nameof(key));
+        if (fact == null)
+            throw new ArgumentNullException(nameof(fact));
 
-        public object GetLinked(object key)
-        {
-            return _session.GetLinked(Activation, key);
-        }
+        var keyedFact = new KeyValuePair<object, object>(key, fact);
+        UpdateAllLinked(new[] {keyedFact});
+    }
 
-        public void InsertLinked(object key, object fact)
-        {
-            if (key == null)
-                throw new ArgumentNullException(nameof(key));
-            if (fact == null)
-                throw new ArgumentNullException(nameof(fact));
-            
-            var keyedFact = new KeyValuePair<object, object>(key, fact);
-            InsertAllLinked(new[] {keyedFact});
-        }
+    public void UpdateAllLinked(IEnumerable<KeyValuePair<object, object>> keyedFacts)
+    {
+        _session.QueueUpdateLinked(Activation, keyedFacts);
+    }
 
-        public void InsertAllLinked(IEnumerable<KeyValuePair<object, object>> keyedFacts)
-        {
-            _session.QueueInsertLinked(Activation, keyedFacts);
-        }
+    public void RetractLinked(object key, object fact)
+    {
+        if (key == null)
+            throw new ArgumentNullException(nameof(key));
+        if (fact == null)
+            throw new ArgumentNullException(nameof(fact));
 
-        public void UpdateLinked(object key, object fact)
-        {
-            if (key == null)
-                throw new ArgumentNullException(nameof(key));
-            if (fact == null)
-                throw new ArgumentNullException(nameof(fact));
+        var keyedFact = new KeyValuePair<object, object>(key, fact);
+        RetractAllLinked(new[] {keyedFact});
+    }
 
-            var keyedFact = new KeyValuePair<object, object>(key, fact);
-            UpdateAllLinked(new[] {keyedFact});
-        }
+    public void RetractAllLinked(IEnumerable<KeyValuePair<object, object>> keyedFacts)
+    {
+        _session.QueueRetractLinked(Activation, keyedFacts);
+    }
 
-        public void UpdateAllLinked(IEnumerable<KeyValuePair<object, object>> keyedFacts)
-        {
-            _session.QueueUpdateLinked(Activation, keyedFacts);
-        }
-
-        public void RetractLinked(object key, object fact)
-        {
-            if (key == null)
-                throw new ArgumentNullException(nameof(key));
-            if (fact == null)
-                throw new ArgumentNullException(nameof(fact));
-
-            var keyedFact = new KeyValuePair<object, object>(key, fact);
-            RetractAllLinked(new[] {keyedFact});
-        }
-
-        public void RetractAllLinked(IEnumerable<KeyValuePair<object, object>> keyedFacts)
-        {
-            _session.QueueRetractLinked(Activation, keyedFacts);
-        }
-
-        public object Resolve(Type serviceType)
-        {
-            var resolutionContext = new ResolutionContext(_session, Rule);
-            var service = _session.DependencyResolver.Resolve(resolutionContext, serviceType);
-            return service;
-        }
+    public object Resolve(Type serviceType)
+    {
+        var resolutionContext = new ResolutionContext(_session, Rule);
+        var service = _session.DependencyResolver.Resolve(resolutionContext, serviceType);
+        return service;
     }
 }

--- a/src/NRules/NRules/ActionExecutor.cs
+++ b/src/NRules/NRules/ActionExecutor.cs
@@ -3,59 +3,58 @@ using System.Collections.Generic;
 using NRules.RuleModel;
 using NRules.Utilities;
 
-namespace NRules
+namespace NRules;
+
+internal interface IActionExecutor
 {
-    internal interface IActionExecutor
-    {
-        void Execute(IExecutionContext executionContext, IActionContext actionContext);
-    }
+    void Execute(IExecutionContext executionContext, IActionContext actionContext);
+}
 
-    internal class ActionExecutor : IActionExecutor
+internal class ActionExecutor : IActionExecutor
+{
+    public void Execute(IExecutionContext executionContext, IActionContext actionContext)
     {
-        public void Execute(IExecutionContext executionContext, IActionContext actionContext)
+        ISession session = executionContext.Session;
+        Activation activation = actionContext.Activation;
+
+        var invocations = CreateInvocations(executionContext, actionContext);
+
+        executionContext.EventAggregator.RaiseRuleFiring(session, activation);
+        var interceptor = session.ActionInterceptor;
+        if (interceptor != null)
         {
-            ISession session = executionContext.Session;
-            Activation activation = actionContext.Activation;
-
-            var invocations = CreateInvocations(executionContext, actionContext);
-
-            executionContext.EventAggregator.RaiseRuleFiring(session, activation);
-            var interceptor = session.ActionInterceptor;
-            if (interceptor != null)
+            interceptor.Intercept(actionContext, invocations);
+        }
+        else
+        {
+            foreach (var invocation in invocations)
             {
-                interceptor.Intercept(actionContext, invocations);
-            }
-            else
-            {
-                foreach (var invocation in invocations)
+                try
                 {
-                    try
-                    {
-                        invocation.Invoke();
-                    }
-                    catch (Exception e)
-                    {
-                        throw new RuleRhsExpressionEvaluationException("Failed to evaluate rule action",
-                            actionContext.Rule.Name, invocation.Expression.ToString(), e);
-                    }
+                    invocation.Invoke();
+                }
+                catch (Exception e)
+                {
+                    throw new RuleRhsExpressionEvaluationException("Failed to evaluate rule action",
+                        actionContext.Rule.Name, invocation.Expression.ToString(), e);
                 }
             }
-            executionContext.EventAggregator.RaiseRuleFired(session, activation);
         }
+        executionContext.EventAggregator.RaiseRuleFired(session, activation);
+    }
 
-        private IEnumerable<ActionInvocation> CreateInvocations(IExecutionContext executionContext, IActionContext actionContext)
+    private IEnumerable<ActionInvocation> CreateInvocations(IExecutionContext executionContext, IActionContext actionContext)
+    {
+        ICompiledRule compiledRule = actionContext.CompiledRule;
+        MatchTrigger trigger = actionContext.Activation.Trigger;
+        var invocations = new List<ActionInvocation>();
+        foreach (IRuleAction action in compiledRule.Actions)
         {
-            ICompiledRule compiledRule = actionContext.CompiledRule;
-            MatchTrigger trigger = actionContext.Activation.Trigger;
-            var invocations = new List<ActionInvocation>();
-            foreach (IRuleAction action in compiledRule.Actions)
-            {
-                if (!trigger.Matches(action.Trigger)) continue;
+            if (!trigger.Matches(action.Trigger)) continue;
 
-                var invocation = new ActionInvocation(executionContext, actionContext, action);
-                invocations.Add(invocation);
-            }
-            return invocations;
+            var invocation = new ActionInvocation(executionContext, actionContext, action);
+            invocations.Add(invocation);
         }
+        return invocations;
     }
 }

--- a/src/NRules/NRules/ActionInvocation.cs
+++ b/src/NRules/NRules/ActionInvocation.cs
@@ -2,28 +2,27 @@ using System.Linq.Expressions;
 using NRules.Extensibility;
 using NRules.RuleModel;
 
-namespace NRules
+namespace NRules;
+
+internal class ActionInvocation : IActionInvocation
 {
-    internal class ActionInvocation : IActionInvocation
+    private readonly IExecutionContext _executionContext;
+    private readonly IActionContext _actionContext;
+    private readonly IRuleAction _action;
+
+    public ActionInvocation(IExecutionContext executionContext, IActionContext actionContext, IRuleAction action)
     {
-        private readonly IExecutionContext _executionContext;
-        private readonly IActionContext _actionContext;
-        private readonly IRuleAction _action;
+        _executionContext = executionContext;
+        _actionContext = actionContext;
+        _action = action;
+    }
 
-        public ActionInvocation(IExecutionContext executionContext, IActionContext actionContext, IRuleAction action)
-        {
-            _executionContext = executionContext;
-            _actionContext = actionContext;
-            _action = action;
-        }
+    public object[] Arguments => _action.GetArguments(_actionContext);
+    public Expression Expression => _action.Expression;
+    public ActionTrigger Trigger => _action.Trigger;
 
-        public object[] Arguments => _action.GetArguments(_actionContext);
-        public Expression Expression => _action.Expression;
-        public ActionTrigger Trigger => _action.Trigger;
-
-        public void Invoke()
-        {
-            _action.Invoke(_executionContext, _actionContext);
-        }
+    public void Invoke()
+    {
+        _action.Invoke(_executionContext, _actionContext);
     }
 }

--- a/src/NRules/NRules/Activation.cs
+++ b/src/NRules/NRules/Activation.cs
@@ -6,102 +6,101 @@ using NRules.Rete;
 using NRules.RuleModel;
 using Tuple = NRules.Rete.Tuple;
 
-namespace NRules
+namespace NRules;
+
+/// <summary>
+/// Represents a match of all rule's conditions.
+/// </summary>
+/// <seealso cref="IMatch"/>
+/// <seealso cref="IFactMatch"/>
+[DebuggerDisplay("{Rule.Name} FactCount={Tuple.Count}")]
+public class Activation : IMatch
 {
-    /// <summary>
-    /// Represents a match of all rule's conditions.
-    /// </summary>
-    /// <seealso cref="IMatch"/>
-    /// <seealso cref="IFactMatch"/>
-    [DebuggerDisplay("{Rule.Name} FactCount={Tuple.Count}")]
-    public class Activation : IMatch
+    internal Activation(ICompiledRule compiledRule, Tuple tuple)
     {
-        internal Activation(ICompiledRule compiledRule, Tuple tuple)
+        CompiledRule = compiledRule;
+        Tuple = tuple;
+    }
+
+    /// <summary>
+    /// Rule that got activated.
+    /// </summary>
+    public IRuleDefinition Rule => CompiledRule.Definition;
+
+    /// <summary>
+    /// Facts matched by the rule.
+    /// </summary>
+    public IEnumerable<IFactMatch> Facts => GetMatchedFacts();
+
+    /// <summary>
+    /// Event that triggered the match.
+    /// </summary>
+    public MatchTrigger Trigger { get; private set; }
+
+    internal ICompiledRule CompiledRule { get; }
+    internal Tuple Tuple { get; }
+
+    internal bool IsEnqueued { get; set; }
+    internal bool HasFired { get; set; }
+
+    internal void OnInsert()
+    {
+        Trigger = MatchTrigger.Created;
+    }
+
+    internal void OnUpdate()
+    {
+        Trigger = HasFired ? MatchTrigger.Updated : MatchTrigger.Created;
+    }
+
+    internal void OnRemove()
+    {
+        Trigger = HasFired ? MatchTrigger.Removed : MatchTrigger.None;
+    }
+
+    internal void OnSelect()
+    {
+        HasFired = Trigger != MatchTrigger.Removed;
+    }
+
+    internal void Clear()
+    {
+        HasFired = false;
+        Trigger = MatchTrigger.None;
+    }
+
+    private FactMatch[] GetMatchedFacts()
+    {
+        var matches = CompiledRule.Declarations.Select(x => new FactMatch(x)).ToArray();
+        int index = Tuple.Count - 1;
+        var enumerator = Tuple.GetEnumerator();
+        while (enumerator.MoveNext())
         {
-            CompiledRule = compiledRule;
-            Tuple = tuple;
+            int factIndex = CompiledRule.FactMap[index];
+            var factMatch = matches[factIndex];
+            factMatch.SetFact(enumerator.Current);
+            index--;
+        }
+        return matches;
+    }
+
+    private class FactMatch : IFactMatch
+    {
+        public FactMatch(Declaration declaration)
+        {
+            Declaration = declaration;
         }
 
-        /// <summary>
-        /// Rule that got activated.
-        /// </summary>
-        public IRuleDefinition Rule => CompiledRule.Definition;
+        public Declaration Declaration { get; }
+        public Type Type { get; private set; }
+        public object Value { get; private set; }
+        public IFactSource Source { get; private set; }
 
-        /// <summary>
-        /// Facts matched by the rule.
-        /// </summary>
-        public IEnumerable<IFactMatch> Facts => GetMatchedFacts();
-
-        /// <summary>
-        /// Event that triggered the match.
-        /// </summary>
-        public MatchTrigger Trigger { get; private set; }
-
-        internal ICompiledRule CompiledRule { get; }
-        internal Tuple Tuple { get; }
-
-        internal bool IsEnqueued { get; set; }
-        internal bool HasFired { get; set; }
-
-        internal void OnInsert()
+        public void SetFact(Fact fact)
         {
-            Trigger = MatchTrigger.Created;
-        }
-
-        internal void OnUpdate()
-        {
-            Trigger = HasFired ? MatchTrigger.Updated : MatchTrigger.Created;
-        }
-
-        internal void OnRemove()
-        {
-            Trigger = HasFired ? MatchTrigger.Removed : MatchTrigger.None;
-        }
-
-        internal void OnSelect()
-        {
-            HasFired = Trigger != MatchTrigger.Removed;
-        }
-
-        internal void Clear()
-        {
-            HasFired = false;
-            Trigger = MatchTrigger.None;
-        }
-
-        private FactMatch[] GetMatchedFacts()
-        {
-            var matches = CompiledRule.Declarations.Select(x => new FactMatch(x)).ToArray();
-            int index = Tuple.Count - 1;
-            var enumerator = Tuple.GetEnumerator();
-            while (enumerator.MoveNext())
-            {
-                int factIndex = CompiledRule.FactMap[index];
-                var factMatch = matches[factIndex];
-                factMatch.SetFact(enumerator.Current);
-                index--;
-            }
-            return matches;
-        }
-
-        private class FactMatch : IFactMatch
-        {
-            public FactMatch(Declaration declaration)
-            {
-                Declaration = declaration;
-            }
-
-            public Declaration Declaration { get; }
-            public Type Type { get; private set; }
-            public object Value { get; private set; }
-            public IFactSource Source { get; private set; }
-
-            public void SetFact(Fact fact)
-            {
-                Type = fact.FactType;
-                Value = fact.Object;
-                Source = fact.Source;
-            }
+            Type = fact.FactType;
+            Value = fact.Object;
+            Source = fact.Source;
         }
     }
 }

--- a/src/NRules/NRules/ActivationQueue.cs
+++ b/src/NRules/NRules/ActivationQueue.cs
@@ -1,62 +1,61 @@
 ﻿using NRules.Collections;
 using NRules.Utilities;
 
-namespace NRules
+namespace NRules;
+
+internal class ActivationQueue
 {
-    internal class ActivationQueue
+    private readonly IPriorityQueue<int, Activation> _queue = new OrderedPriorityQueue<int, Activation>();
+
+    public void Enqueue(int priority, Activation activation)
     {
-        private readonly IPriorityQueue<int, Activation> _queue = new OrderedPriorityQueue<int, Activation>();
-
-        public void Enqueue(int priority, Activation activation)
+        if (!activation.IsEnqueued)
         {
-            if (!activation.IsEnqueued)
-            {
-                activation.IsEnqueued = true;
-                _queue.Enqueue(priority, activation);
-            }
+            activation.IsEnqueued = true;
+            _queue.Enqueue(priority, activation);
         }
+    }
 
-        public Activation Peek()
+    public Activation Peek()
+    {
+        Activation activation = _queue.Peek();
+        return activation;
+    }
+
+    public Activation Dequeue()
+    {
+        Activation activation = _queue.Dequeue();
+        activation.IsEnqueued = false;
+        return activation;
+    }
+
+    public void Remove(Activation activation)
+    {
+        activation.IsEnqueued = false;
+    }
+
+    public bool HasActive()
+    {
+        PurgeQueue();
+        return !_queue.IsEmpty;
+    }
+
+    private void PurgeQueue()
+    {
+        while (!_queue.IsEmpty)
         {
-            Activation activation = _queue.Peek();
-            return activation;
+            Activation current = _queue.Peek();
+            if (current.IsEnqueued && current.Trigger.Matches(current.CompiledRule.ActionTriggers)) return;
+            Dequeue();
         }
+    }
 
-        public Activation Dequeue()
+    public void Clear()
+    {
+        while (!_queue.IsEmpty)
         {
-            Activation activation = _queue.Dequeue();
-            activation.IsEnqueued = false;
-            return activation;
-        }
-
-        public void Remove(Activation activation)
-        {
-            activation.IsEnqueued = false;
-        }
-
-        public bool HasActive()
-        {
-            PurgeQueue();
-            return !_queue.IsEmpty;
-        }
-
-        private void PurgeQueue()
-        {
-            while (!_queue.IsEmpty)
-            {
-                Activation current = _queue.Peek();
-                if (current.IsEnqueued && current.Trigger.Matches(current.CompiledRule.ActionTriggers)) return;
-                Dequeue();
-            }
-        }
-
-        public void Clear()
-        {
-            while (!_queue.IsEmpty)
-            {
-                Activation activation = Dequeue();
-                activation.Clear();
-            }
+            Activation activation = Dequeue();
+            activation.Clear();
         }
     }
 }

--- a/src/NRules/NRules/AgendaExpressionEvaluationException.cs
+++ b/src/NRules/NRules/AgendaExpressionEvaluationException.cs
@@ -1,53 +1,52 @@
 using System;
 
-namespace NRules
+namespace NRules;
+
+/// <summary>
+/// Represents errors that occur while evaluating agenda expression.
+/// </summary>
+[Serializable]
+public class AgendaExpressionEvaluationException : RuleExpressionEvaluationException
 {
-    /// <summary>
-    /// Represents errors that occur while evaluating agenda expression.
-    /// </summary>
-    [Serializable]
-    public class AgendaExpressionEvaluationException : RuleExpressionEvaluationException
+    internal AgendaExpressionEvaluationException(string message, string ruleName, string expression, Exception innerException)
+        : base(message, expression, innerException)
     {
-        internal AgendaExpressionEvaluationException(string message, string ruleName, string expression, Exception innerException)
-            : base(message, expression, innerException)
-        {
-            RuleName = ruleName;
-        }
+        RuleName = ruleName;
+    }
 
-        [System.Security.SecuritySafeCritical]
-        protected AgendaExpressionEvaluationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
-        {
-            RuleName = info.GetString("RuleName");
-        }
+    [System.Security.SecuritySafeCritical]
+    protected AgendaExpressionEvaluationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+        : base(info, context)
+    {
+        RuleName = info.GetString("RuleName");
+    }
 
-        [System.Security.SecurityCritical]
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+    [System.Security.SecurityCritical]
+    public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+    {
+        if (info == null)
         {
-            if (info == null)
+            throw new ArgumentNullException(nameof(info));
+        }
+        base.GetObjectData(info, context);
+        info.AddValue("RuleName", RuleName, typeof(string));
+    }
+
+    /// <summary>
+    /// Rule that caused exception.
+    /// </summary>
+    public string RuleName { get; }
+
+    public override string Message
+    {
+        get
+        {
+            string message = base.Message;
+            if (!string.IsNullOrEmpty(RuleName))
             {
-                throw new ArgumentNullException(nameof(info));
+                return message + Environment.NewLine + RuleName;
             }
-            base.GetObjectData(info, context);
-            info.AddValue("RuleName", RuleName, typeof(string));
-        }
-
-        /// <summary>
-        /// Rule that caused exception.
-        /// </summary>
-        public string RuleName { get; }
-
-        public override string Message
-        {
-            get
-            {
-                string message = base.Message;
-                if (!string.IsNullOrEmpty(RuleName))
-                {
-                    return message + Environment.NewLine + RuleName;
-                }
-                return message;
-            }
+            return message;
         }
     }
 }

--- a/src/NRules/NRules/AgendaFilters/AgendaContext.cs
+++ b/src/NRules/NRules/AgendaFilters/AgendaContext.cs
@@ -1,19 +1,18 @@
 ﻿using NRules.Diagnostics;
 
-namespace NRules.AgendaFilters
-{
-    /// <summary>
-    /// Context associated with the agenda operation.
-    /// </summary>
-    public class AgendaContext
-    {
-        internal ISessionInternal Session { get; }
-        internal IEventAggregator EventAggregator { get; }
+namespace NRules.AgendaFilters;
 
-        internal AgendaContext(IExecutionContext context)
-        {
-            Session = context.Session;
-            EventAggregator = context.EventAggregator;
-        }
+/// <summary>
+/// Context associated with the agenda operation.
+/// </summary>
+public class AgendaContext
+{
+    internal ISessionInternal Session { get; }
+    internal IEventAggregator EventAggregator { get; }
+
+    internal AgendaContext(IExecutionContext context)
+    {
+        Session = context.Session;
+        EventAggregator = context.EventAggregator;
     }
 }

--- a/src/NRules/NRules/AgendaFilters/IAgendaFilter.cs
+++ b/src/NRules/NRules/AgendaFilters/IAgendaFilter.cs
@@ -1,17 +1,16 @@
-﻿namespace NRules.AgendaFilters
-{
+﻿namespace NRules.AgendaFilters;
+
+/// <summary>
+/// Base interface for agenda filters.
+/// Agenda filters are applied to rule matches (activations) before they are added to the agenda.
+/// If activation does not pass all the filters, it is not added to the agenda, and so the rule will not fire.
+/// </summary>
+public interface IAgendaFilter  {
     /// <summary>
-    /// Base interface for agenda filters.
-    /// Agenda filters are applied to rule matches (activations) before they are added to the agenda.
-    /// If activation does not pass all the filters, it is not added to the agenda, and so the rule will not fire.
+    /// Tests rule activation whether it should be added to the agenda.
     /// </summary>
-    public interface IAgendaFilter  {
-        /// <summary>
-        /// Tests rule activation whether it should be added to the agenda.
-        /// </summary>
-        /// <param name="context">Agenda context.</param>
-        /// <param name="activation">Rule activation.</param>
-        /// <returns>Whether the activation should be added to the agenda - <c>true</c>, or not - <c>false</c>.</returns>
-        bool Accept(AgendaContext context, Activation activation);
-    }
+    /// <param name="context">Agenda context.</param>
+    /// <param name="activation">Rule activation.</param>
+    /// <returns>Whether the activation should be added to the agenda - <c>true</c>, or not - <c>false</c>.</returns>
+    bool Accept(AgendaContext context, Activation activation);
 }

--- a/src/NRules/NRules/AgendaFilters/IStatefulAgendaFilter.cs
+++ b/src/NRules/NRules/AgendaFilters/IStatefulAgendaFilter.cs
@@ -1,27 +1,26 @@
-﻿namespace NRules.AgendaFilters
+﻿namespace NRules.AgendaFilters;
+
+/// <summary>
+/// Base interface for stateful agenda filters that store some state related to
+/// the activations and need to update that state during the activation lifecycle.
+/// </summary>
+public interface IStatefulAgendaFilter : IAgendaFilter
 {
     /// <summary>
-    /// Base interface for stateful agenda filters that store some state related to
-    /// the activations and need to update that state during the activation lifecycle.
+    /// Called by the engine when activation is selected from the agenda,
+    /// before rule's actions are executed.
     /// </summary>
-    public interface IStatefulAgendaFilter : IAgendaFilter
-    {
-        /// <summary>
-        /// Called by the engine when activation is selected from the agenda,
-        /// before rule's actions are executed.
-        /// </summary>
-        /// <remarks>This method must not evaluate agenda expressions.</remarks>
-        /// <param name="context">Agenda context.</param>
-        /// <param name="activation">Rule activation.</param>
-        void Select(AgendaContext context, Activation activation);
+    /// <remarks>This method must not evaluate agenda expressions.</remarks>
+    /// <param name="context">Agenda context.</param>
+    /// <param name="activation">Rule activation.</param>
+    void Select(AgendaContext context, Activation activation);
 
-        /// <summary>
-        /// Called by the engine when activation is removed from the agenda.
-        /// The agenda filter can use this method to remove any state associated with the activation.
-        /// </summary>
-        /// <remarks>This method must not evaluate agenda expressions.</remarks>
-        /// <param name="context">Agenda context.</param>
-        /// <param name="activation">Rule activation.</param>
-        void Remove(AgendaContext context, Activation activation);
-    }
+    /// <summary>
+    /// Called by the engine when activation is removed from the agenda.
+    /// The agenda filter can use this method to remove any state associated with the activation.
+    /// </summary>
+    /// <remarks>This method must not evaluate agenda expressions.</remarks>
+    /// <param name="context">Agenda context.</param>
+    /// <param name="activation">Rule activation.</param>
+    void Remove(AgendaContext context, Activation activation);
 }

--- a/src/NRules/NRules/AgendaFilters/PredicateAgendaFilter.cs
+++ b/src/NRules/NRules/AgendaFilters/PredicateAgendaFilter.cs
@@ -1,23 +1,22 @@
 using System.Collections.Generic;
 
-namespace NRules.AgendaFilters
+namespace NRules.AgendaFilters;
+
+internal class PredicateAgendaFilter : IAgendaFilter
 {
-    internal class PredicateAgendaFilter : IAgendaFilter
+    private readonly List<IActivationExpression<bool>> _conditions;
+
+    public PredicateAgendaFilter(IEnumerable<IActivationExpression<bool>> conditions)
     {
-        private readonly List<IActivationExpression<bool>> _conditions;
+        _conditions = new List<IActivationExpression<bool>>(conditions);
+    }
 
-        public PredicateAgendaFilter(IEnumerable<IActivationExpression<bool>> conditions)
+    public bool Accept(AgendaContext context, Activation activation)
+    {
+        foreach (var condition in _conditions)
         {
-            _conditions = new List<IActivationExpression<bool>>(conditions);
+            if (!condition.Invoke(context, activation)) return false;
         }
-
-        public bool Accept(AgendaContext context, Activation activation)
-        {
-            foreach (var condition in _conditions)
-            {
-                if (!condition.Invoke(context, activation)) return false;
-            }
-            return true;
-        }
+        return true;
     }
 }

--- a/src/NRules/NRules/Aggregators/AggregateExpression.cs
+++ b/src/NRules/NRules/Aggregators/AggregateExpression.cs
@@ -1,43 +1,42 @@
 ﻿using NRules.Rete;
 using NRules.RuleModel;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Expression used by an aggregator, compiled to an executable form.
+/// </summary>
+public interface IAggregateExpression
 {
     /// <summary>
-    /// Expression used by an aggregator, compiled to an executable form.
+    /// Name of the aggregate expression.
     /// </summary>
-    public interface IAggregateExpression
-    {
-        /// <summary>
-        /// Name of the aggregate expression.
-        /// </summary>
-        string Name { get; }
+    string Name { get; }
 
-        /// <summary>
-        /// Invokes the expression with the given inputs.
-        /// </summary>
-        /// <param name="context">Aggregation context.</param>
-        /// <param name="tuple">Partial match up to the aggregate element.</param>
-        /// <param name="fact">Fact being processed by the aggregate element.</param>
-        /// <returns>Result of the expression.</returns>
-        object Invoke(AggregationContext context, ITuple tuple, IFact fact);
+    /// <summary>
+    /// Invokes the expression with the given inputs.
+    /// </summary>
+    /// <param name="context">Aggregation context.</param>
+    /// <param name="tuple">Partial match up to the aggregate element.</param>
+    /// <param name="fact">Fact being processed by the aggregate element.</param>
+    /// <returns>Result of the expression.</returns>
+    object Invoke(AggregationContext context, ITuple tuple, IFact fact);
+}
+
+internal class AggregateExpression : IAggregateExpression
+{
+    private readonly ILhsExpression<object> _compiledExpression;
+
+    public AggregateExpression(string name, ILhsExpression<object> compiledExpression)
+    {
+        _compiledExpression = compiledExpression;
+        Name = name;
     }
 
-    internal class AggregateExpression : IAggregateExpression
+    public string Name { get; }
+
+    public object Invoke(AggregationContext context, ITuple tuple, IFact fact)
     {
-        private readonly ILhsExpression<object> _compiledExpression;
-
-        public AggregateExpression(string name, ILhsExpression<object> compiledExpression)
-        {
-            _compiledExpression = compiledExpression;
-            Name = name;
-        }
-
-        public string Name { get; }
-
-        public object Invoke(AggregationContext context, ITuple tuple, IFact fact)
-        {
-            return _compiledExpression.Invoke(context.ExecutionContext, context.NodeInfo, tuple as Tuple, fact as Fact);
-        }
+        return _compiledExpression.Invoke(context.ExecutionContext, context.NodeInfo, tuple as Tuple, fact as Fact);
     }
 }

--- a/src/NRules/NRules/Aggregators/AggregateExpressionExtensions.cs
+++ b/src/NRules/NRules/Aggregators/AggregateExpressionExtensions.cs
@@ -1,33 +1,32 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Extension methods used for working with collections of aggregate expressions.
+/// </summary>
+public static class AggregateExpressionExtensions
 {
     /// <summary>
-    /// Extension methods used for working with collections of aggregate expressions.
+    /// Get an enumerable of matching aggregate expressions.
     /// </summary>
-    public static class AggregateExpressionExtensions
+    /// <param name="expressions">The list of aggregate expressions to search through.</param>
+    /// <param name="name">Name of the aggregate expressions to find.</param>
+    /// <returns></returns>
+    public static IEnumerable<IAggregateExpression> Find(this IEnumerable<IAggregateExpression> expressions, string name)
     {
-        /// <summary>
-        /// Get an enumerable of matching aggregate expressions.
-        /// </summary>
-        /// <param name="expressions">The list of aggregate expressions to search through.</param>
-        /// <param name="name">Name of the aggregate expressions to find.</param>
-        /// <returns></returns>
-        public static IEnumerable<IAggregateExpression> Find(this IEnumerable<IAggregateExpression> expressions, string name)
-        {
-            return expressions.Where(e => e.Name == name);
-        }
+        return expressions.Where(e => e.Name == name);
+    }
 
-        /// <summary>
-        /// Get a single matching aggregate expression.
-        /// </summary>
-        /// <param name="expressions">The list of aggregate expressions to search through.</param>
-        /// <param name="name">Name of the aggregate expression to find.</param>
-        /// <returns></returns>
-        public static IAggregateExpression FindSingle(this IEnumerable<IAggregateExpression> expressions, string name)
-        {
-            return expressions.Find(name).Single();
-        }
+    /// <summary>
+    /// Get a single matching aggregate expression.
+    /// </summary>
+    /// <param name="expressions">The list of aggregate expressions to search through.</param>
+    /// <param name="name">Name of the aggregate expression to find.</param>
+    /// <returns></returns>
+    public static IAggregateExpression FindSingle(this IEnumerable<IAggregateExpression> expressions, string name)
+    {
+        return expressions.Find(name).Single();
     }
 }

--- a/src/NRules/NRules/Aggregators/AggregationContext.cs
+++ b/src/NRules/NRules/Aggregators/AggregationContext.cs
@@ -1,19 +1,18 @@
 ﻿using NRules.Diagnostics;
 
-namespace NRules.Aggregators
-{
-    /// <summary>
-    /// Context associated with the aggregation operation.
-    /// </summary>
-    public class AggregationContext
-    {
-        internal IExecutionContext ExecutionContext { get; }
-        internal NodeInfo NodeInfo { get; }
+namespace NRules.Aggregators;
 
-        internal AggregationContext(IExecutionContext executionContext, NodeInfo nodeInfo)
-        {
-            ExecutionContext = executionContext;
-            NodeInfo = nodeInfo;
-        }
+/// <summary>
+/// Context associated with the aggregation operation.
+/// </summary>
+public class AggregationContext
+{
+    internal IExecutionContext ExecutionContext { get; }
+    internal NodeInfo NodeInfo { get; }
+
+    internal AggregationContext(IExecutionContext executionContext, NodeInfo nodeInfo)
+    {
+        ExecutionContext = executionContext;
+        NodeInfo = nodeInfo;
     }
 }

--- a/src/NRules/NRules/Aggregators/AggregationResult.cs
+++ b/src/NRules/NRules/Aggregators/AggregationResult.cs
@@ -3,112 +3,111 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using NRules.RuleModel;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Action that aggregation performed on the aggregate, based on added/modified/removed facts.
+/// </summary>
+public enum AggregationAction
 {
     /// <summary>
-    /// Action that aggregation performed on the aggregate, based on added/modified/removed facts.
+    /// No changes at the aggregate level.
     /// </summary>
-    public enum AggregationAction
+    None = 0,
+
+    /// <summary>
+    /// New aggregate created.
+    /// </summary>
+    Added = 1,
+
+    /// <summary>
+    /// Existing aggregate modified.
+    /// </summary>
+    Modified = 2,
+
+    /// <summary>
+    /// Existing aggregate removed.
+    /// </summary>
+    Removed = 3,
+}
+
+/// <summary>
+/// Result of the aggregation.
+/// </summary>
+[DebuggerDisplay("{Action}")]
+public class AggregationResult
+{
+    public static readonly AggregationResult[] Empty = Array.Empty<AggregationResult>();
+
+    private AggregationResult(AggregationAction action, object aggregate, object previous, IEnumerable<IFact> source)
     {
-        /// <summary>
-        /// No changes at the aggregate level.
-        /// </summary>
-        None = 0,
-
-        /// <summary>
-        /// New aggregate created.
-        /// </summary>
-        Added = 1,
-
-        /// <summary>
-        /// Existing aggregate modified.
-        /// </summary>
-        Modified = 2,
-
-        /// <summary>
-        /// Existing aggregate removed.
-        /// </summary>
-        Removed = 3,
+        Action = action;
+        Aggregate = aggregate;
+        Previous = previous;
+        Source = source;
     }
 
     /// <summary>
-    /// Result of the aggregation.
+    /// Constructs an aggregation result that indicates no changes at the aggregate level.
     /// </summary>
-    [DebuggerDisplay("{Action}")]
-    public class AggregationResult
+    /// <param name="result">Aggregate.</param>
+    /// <param name="source">Aggregate source facts.</param>
+    /// <returns>Aggregation result.</returns>
+    public static AggregationResult None(object result, IEnumerable<IFact> source)
     {
-        public static readonly AggregationResult[] Empty = Array.Empty<AggregationResult>();
-
-        private AggregationResult(AggregationAction action, object aggregate, object previous, IEnumerable<IFact> source)
-        {
-            Action = action;
-            Aggregate = aggregate;
-            Previous = previous;
-            Source = source;
-        }
-
-        /// <summary>
-        /// Constructs an aggregation result that indicates no changes at the aggregate level.
-        /// </summary>
-        /// <param name="result">Aggregate.</param>
-        /// <param name="source">Aggregate source facts.</param>
-        /// <returns>Aggregation result.</returns>
-        public static AggregationResult None(object result, IEnumerable<IFact> source)
-        {
-            return new AggregationResult(AggregationAction.None, result, null, source);
-        }
-
-        /// <summary>
-        /// Constructs an aggregation result that indicates a new aggregate.
-        /// </summary>
-        /// <param name="result">Aggregate.</param>
-        /// <param name="source">Aggregate source facts.</param>
-        /// <returns>Aggregation result.</returns>
-        public static AggregationResult Added(object result, IEnumerable<IFact> source)
-        {
-            return new AggregationResult(AggregationAction.Added, result, null, source);
-        }
-
-        /// <summary>
-        /// Constructs an aggregation result that indicates a modification at the aggregate level.
-        /// </summary>
-        /// <param name="result">Aggregate.</param>
-        /// <param name="previous">Previous aggregate.</param>
-        /// <param name="source">Aggregate source facts.</param>
-        /// <returns>Aggregation result.</returns>
-        public static AggregationResult Modified(object result, object previous, IEnumerable<IFact> source)
-        {
-            return new AggregationResult(AggregationAction.Modified, result, previous, source);
-        }
-
-        /// <summary>
-        /// Constructs an aggregation result that indicates an aggregate was removed.
-        /// </summary>
-        /// <param name="result">Aggregate.</param>
-        /// <returns>Aggregation result.</returns>
-        public static AggregationResult Removed(object result)
-        {
-            return new AggregationResult(AggregationAction.Removed, result, result, null);
-        }
-
-        /// <summary>
-        /// Action that aggregation performed on the aggregate.
-        /// </summary>
-        public AggregationAction Action { get; }
-
-        /// <summary>
-        /// Resulting aggregate.
-        /// </summary>
-        public object Aggregate { get; }
-        
-        /// <summary>
-        /// Previous aggregate.
-        /// </summary>
-        public object Previous { get; }
-
-        /// <summary>
-        /// Facts that produced this aggregation result.
-        /// </summary>
-        public IEnumerable<IFact> Source { get; }
+        return new AggregationResult(AggregationAction.None, result, null, source);
     }
+
+    /// <summary>
+    /// Constructs an aggregation result that indicates a new aggregate.
+    /// </summary>
+    /// <param name="result">Aggregate.</param>
+    /// <param name="source">Aggregate source facts.</param>
+    /// <returns>Aggregation result.</returns>
+    public static AggregationResult Added(object result, IEnumerable<IFact> source)
+    {
+        return new AggregationResult(AggregationAction.Added, result, null, source);
+    }
+
+    /// <summary>
+    /// Constructs an aggregation result that indicates a modification at the aggregate level.
+    /// </summary>
+    /// <param name="result">Aggregate.</param>
+    /// <param name="previous">Previous aggregate.</param>
+    /// <param name="source">Aggregate source facts.</param>
+    /// <returns>Aggregation result.</returns>
+    public static AggregationResult Modified(object result, object previous, IEnumerable<IFact> source)
+    {
+        return new AggregationResult(AggregationAction.Modified, result, previous, source);
+    }
+
+    /// <summary>
+    /// Constructs an aggregation result that indicates an aggregate was removed.
+    /// </summary>
+    /// <param name="result">Aggregate.</param>
+    /// <returns>Aggregation result.</returns>
+    public static AggregationResult Removed(object result)
+    {
+        return new AggregationResult(AggregationAction.Removed, result, result, null);
+    }
+
+    /// <summary>
+    /// Action that aggregation performed on the aggregate.
+    /// </summary>
+    public AggregationAction Action { get; }
+
+    /// <summary>
+    /// Resulting aggregate.
+    /// </summary>
+    public object Aggregate { get; }
+    
+    /// <summary>
+    /// Previous aggregate.
+    /// </summary>
+    public object Previous { get; }
+
+    /// <summary>
+    /// Facts that produced this aggregation result.
+    /// </summary>
+    public IEnumerable<IFact> Source { get; }
 }

--- a/src/NRules/NRules/Aggregators/AggregatorRegistry.cs
+++ b/src/NRules/NRules/Aggregators/AggregatorRegistry.cs
@@ -1,41 +1,40 @@
 using System;
 using System.Collections.Generic;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Registry of custom aggregator factories.
+/// </summary>
+public class AggregatorRegistry
 {
-    /// <summary>
-    /// Registry of custom aggregator factories.
-    /// </summary>
-    public class AggregatorRegistry
+    private readonly Dictionary<string, Type> _factoryMap = new();
+
+    internal AggregatorRegistry()
     {
-        private readonly Dictionary<string, Type> _factoryMap = new();
+    }
 
-        internal AggregatorRegistry()
+    /// <summary>
+    /// Looks up custom aggregator factory type by the aggregator name.
+    /// </summary>
+    /// <param name="name">Name of the custom aggregator.</param>
+    /// <returns>Custom aggregator type or <c>null</c> if a given aggregator type is not registered.</returns>
+    internal Type this[string name]
+    {
+        get
         {
+            _factoryMap.TryGetValue(name, out var factoryType);
+            return factoryType;
         }
+    }
 
-        /// <summary>
-        /// Looks up custom aggregator factory type by the aggregator name.
-        /// </summary>
-        /// <param name="name">Name of the custom aggregator.</param>
-        /// <returns>Custom aggregator type or <c>null</c> if a given aggregator type is not registered.</returns>
-        internal Type this[string name]
-        {
-            get
-            {
-                _factoryMap.TryGetValue(name, out var factoryType);
-                return factoryType;
-            }
-        }
-
-        /// <summary>
-        /// Registers a custom aggregator factory type, so that rules that use it can be successfully compiled.
-        /// </summary>
-        /// <param name="name">Name of the custom aggregator.</param>
-        /// <param name="factoryType">Custom aggregator factory type.</param>
-        public void RegisterFactory(string name, Type factoryType)
-        {
-            _factoryMap.Add(name, factoryType);
-        }
+    /// <summary>
+    /// Registers a custom aggregator factory type, so that rules that use it can be successfully compiled.
+    /// </summary>
+    /// <param name="name">Name of the custom aggregator.</param>
+    /// <param name="factoryType">Custom aggregator factory type.</param>
+    public void RegisterFactory(string name, Type factoryType)
+    {
+        _factoryMap.Add(name, factoryType);
     }
 }

--- a/src/NRules/NRules/Aggregators/CollectionAggregator.cs
+++ b/src/NRules/NRules/Aggregators/CollectionAggregator.cs
@@ -2,64 +2,63 @@
 using NRules.Aggregators.Collections;
 using NRules.RuleModel;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Aggregate that folds matching facts into a collection.
+/// </summary>
+/// <typeparam name="TElement">Type of elements to collect.</typeparam>
+internal class CollectionAggregator<TElement> : IAggregator
 {
-    /// <summary>
-    /// Aggregate that folds matching facts into a collection.
-    /// </summary>
-    /// <typeparam name="TElement">Type of elements to collect.</typeparam>
-    internal class CollectionAggregator<TElement> : IAggregator
+    private readonly FactCollection<TElement> _items = new();
+    private bool _created = false;
+
+    public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
     {
-        private readonly FactCollection<TElement> _items = new();
-        private bool _created = false;
-
-        public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+        AddFacts(facts);
+        if (!_created)
         {
-            AddFacts(facts);
-            if (!_created)
-            {
-                _created = true;
-                return new[] {AggregationResult.Added(_items, _items.Facts)};
-            }
-            return new[] {AggregationResult.Modified(_items, _items, _items.Facts)};
+            _created = true;
+            return new[] {AggregationResult.Added(_items, _items.Facts)};
         }
+        return new[] {AggregationResult.Modified(_items, _items, _items.Facts)};
+    }
 
-        public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        ModifyFacts(facts);
+        return new[] {AggregationResult.Modified(_items, _items, _items.Facts)};
+    }
+
+    public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        RemoveFacts(facts);
+        return new[] {AggregationResult.Modified(_items, _items, _items.Facts)};
+    }
+
+    private void AddFacts(IEnumerable<IFact> facts)
+    {
+        foreach (var fact in facts)
         {
-            ModifyFacts(facts);
-            return new[] {AggregationResult.Modified(_items, _items, _items.Facts)};
+            var item = (TElement)fact.Value;
+            _items.Add(fact, item);
         }
+    }
 
-        public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    private void ModifyFacts(IEnumerable<IFact> facts)
+    {
+        foreach (var fact in facts)
         {
-            RemoveFacts(facts);
-            return new[] {AggregationResult.Modified(_items, _items, _items.Facts)};
+            var item = (TElement)fact.Value;
+            _items.Modify(fact, item);
         }
+    }
 
-        private void AddFacts(IEnumerable<IFact> facts)
+    private void RemoveFacts(IEnumerable<IFact> facts)
+    {
+        foreach (var fact in facts)
         {
-            foreach (var fact in facts)
-            {
-                var item = (TElement)fact.Value;
-                _items.Add(fact, item);
-            }
-        }
-
-        private void ModifyFacts(IEnumerable<IFact> facts)
-        {
-            foreach (var fact in facts)
-            {
-                var item = (TElement)fact.Value;
-                _items.Modify(fact, item);
-            }
-        }
-
-        private void RemoveFacts(IEnumerable<IFact> facts)
-        {
-            foreach (var fact in facts)
-            {
-                _items.Remove(fact);
-            }
+            _items.Remove(fact);
         }
     }
 }

--- a/src/NRules/NRules/Aggregators/CollectionAggregatorFactory.cs
+++ b/src/NRules/NRules/Aggregators/CollectionAggregatorFactory.cs
@@ -4,114 +4,113 @@ using System.Linq;
 using System.Linq.Expressions;
 using NRules.RuleModel;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Aggregator factory for collection aggregator.
+/// Depending on supplied expressions this will create an ordered or an unordered fact aggregator.
+/// </summary>
+internal class CollectionAggregatorFactory : IAggregatorFactory
 {
-    /// <summary>
-    /// Aggregator factory for collection aggregator.
-    /// Depending on supplied expressions this will create an ordered or an unordered fact aggregator.
-    /// </summary>
-    internal class CollectionAggregatorFactory : IAggregatorFactory
+    private Func<IAggregator> _factory;
+
+    public void Compile(AggregateElement element, IEnumerable<IAggregateExpression> compiledExpressions)
     {
-        private Func<IAggregator> _factory;
+        var sourceType = element.Source.ValueType;
 
-        public void Compile(AggregateElement element, IEnumerable<IAggregateExpression> compiledExpressions)
+        var expressions = compiledExpressions.ToList();
+        var sortConditions = expressions.Where(x => Equals(x.Name, AggregateElement.KeySelectorAscendingName) || Equals(x.Name, AggregateElement.KeySelectorDescendingName))
+            .Select(x => new SortCondition(x.Name, GetSortDirection(x.Name), x)).ToArray();
+        var groupConditions = expressions.Where(x => Equals(x.Name, AggregateElement.KeySelectorName)).ToArray();
+
+        switch (element.Name)
         {
-            var sourceType = element.Source.ValueType;
-
-            var expressions = compiledExpressions.ToList();
-            var sortConditions = expressions.Where(x => Equals(x.Name, AggregateElement.KeySelectorAscendingName) || Equals(x.Name, AggregateElement.KeySelectorDescendingName))
-                .Select(x => new SortCondition(x.Name, GetSortDirection(x.Name), x)).ToArray();
-            var groupConditions = expressions.Where(x => Equals(x.Name, AggregateElement.KeySelectorName)).ToArray();
-
-            switch (element.Name)
-            {
-                case AggregateElement.CollectName when sortConditions.Length == 0 && groupConditions.Length == 0:
-                    _factory = CreateCollectAggregator(sourceType);
-                    break;
-                case AggregateElement.CollectName when sortConditions.Length == 1 && groupConditions.Length == 0:
-                    var expression = element.Expressions[sortConditions[0].Name].Expression;
-                    _factory = CreateSingleKeySortedAggregatorFactory(sourceType, sortConditions[0], expression);
-                    break;
-                case AggregateElement.CollectName when sortConditions.Length > 1 && groupConditions.Length == 0:
-                    _factory = CreateMultiKeySortedAggregatorFactory(sourceType, sortConditions);
-                    break;
-                case AggregateElement.CollectName when sortConditions.Length == 0 && groupConditions.Length == 1:
-                    _factory = CreateLookupAggregator(sourceType, expressions, element.Expressions);
-                    break;
-                default:
-                    throw new ArgumentException("Unsupported collection aggregator. " +
-                        $"Name={element.Name}, KeySelectorCount={groupConditions.Length}, SortSelectorCount={sortConditions.Length}");
-            }
+            case AggregateElement.CollectName when sortConditions.Length == 0 && groupConditions.Length == 0:
+                _factory = CreateCollectAggregator(sourceType);
+                break;
+            case AggregateElement.CollectName when sortConditions.Length == 1 && groupConditions.Length == 0:
+                var expression = element.Expressions[sortConditions[0].Name].Expression;
+                _factory = CreateSingleKeySortedAggregatorFactory(sourceType, sortConditions[0], expression);
+                break;
+            case AggregateElement.CollectName when sortConditions.Length > 1 && groupConditions.Length == 0:
+                _factory = CreateMultiKeySortedAggregatorFactory(sourceType, sortConditions);
+                break;
+            case AggregateElement.CollectName when sortConditions.Length == 0 && groupConditions.Length == 1:
+                _factory = CreateLookupAggregator(sourceType, expressions, element.Expressions);
+                break;
+            default:
+                throw new ArgumentException("Unsupported collection aggregator. " +
+                    $"Name={element.Name}, KeySelectorCount={groupConditions.Length}, SortSelectorCount={sortConditions.Length}");
         }
+    }
 
-        public IAggregator Create()
-        {
-            return _factory();
-        }
+    public IAggregator Create()
+    {
+        return _factory();
+    }
 
-        private Func<IAggregator> CreateCollectAggregator(Type sourceType)
-        {
-            var aggregatorType = typeof(CollectionAggregator<>).MakeGenericType(sourceType);
+    private Func<IAggregator> CreateCollectAggregator(Type sourceType)
+    {
+        var aggregatorType = typeof(CollectionAggregator<>).MakeGenericType(sourceType);
 
-            var factoryExpression = Expression.Lambda<Func<IAggregator>>(
-                Expression.New(aggregatorType));
+        var factoryExpression = Expression.Lambda<Func<IAggregator>>(
+            Expression.New(aggregatorType));
 
-            return factoryExpression.Compile();
-        }
+        return factoryExpression.Compile();
+    }
 
-        private static Func<IAggregator> CreateSingleKeySortedAggregatorFactory(Type sourceType, SortCondition sortCondition, LambdaExpression expression)
-        {
-            var keyType = expression.ReturnType;
-            var aggregatorType = typeof(SortedAggregator<,>).MakeGenericType(sourceType, keyType);
+    private static Func<IAggregator> CreateSingleKeySortedAggregatorFactory(Type sourceType, SortCondition sortCondition, LambdaExpression expression)
+    {
+        var keyType = expression.ReturnType;
+        var aggregatorType = typeof(SortedAggregator<,>).MakeGenericType(sourceType, keyType);
 
-            var ctor = aggregatorType.GetConstructors().Single();
-            var factoryExpression = Expression.Lambda<Func<IAggregator>>(
-                Expression.New(ctor, 
-                    Expression.Constant(sortCondition.Expression),
-                    Expression.Constant(sortCondition.Direction)));
+        var ctor = aggregatorType.GetConstructors().Single();
+        var factoryExpression = Expression.Lambda<Func<IAggregator>>(
+            Expression.New(ctor, 
+                Expression.Constant(sortCondition.Expression),
+                Expression.Constant(sortCondition.Direction)));
 
-            return factoryExpression.Compile();
-        }
+        return factoryExpression.Compile();
+    }
 
-        private static Func<IAggregator> CreateMultiKeySortedAggregatorFactory(Type sourceType, SortCondition[] sortConditions)
-        {
-            var aggregatorType = typeof(MultiKeySortedAggregator<>).MakeGenericType(sourceType);
+    private static Func<IAggregator> CreateMultiKeySortedAggregatorFactory(Type sourceType, SortCondition[] sortConditions)
+    {
+        var aggregatorType = typeof(MultiKeySortedAggregator<>).MakeGenericType(sourceType);
 
-            var ctor = aggregatorType.GetConstructors().Single();
-            var factoryExpression = Expression.Lambda<Func<IAggregator>>(
-                Expression.New(ctor, Expression.Constant(sortConditions)));
+        var ctor = aggregatorType.GetConstructors().Single();
+        var factoryExpression = Expression.Lambda<Func<IAggregator>>(
+            Expression.New(ctor, Expression.Constant(sortConditions)));
 
-            return factoryExpression.Compile();
-        }
+        return factoryExpression.Compile();
+    }
 
-        private static SortDirection GetSortDirection(string keySelectorName)
-        {
-            return keySelectorName == AggregateElement.KeySelectorAscendingName 
-                ? SortDirection.Ascending : SortDirection.Descending;
-        }
+    private static SortDirection GetSortDirection(string keySelectorName)
+    {
+        return keySelectorName == AggregateElement.KeySelectorAscendingName 
+            ? SortDirection.Ascending : SortDirection.Descending;
+    }
 
-        private Func<IAggregator> CreateLookupAggregator(Type sourceType, IReadOnlyCollection<IAggregateExpression> compiledExpressions, ExpressionCollection elementExpressions)
-        {
-            var keySelector = compiledExpressions.SingleOrDefault(x => x.Name == AggregateElement.KeySelectorName);
-            var elementSelector = compiledExpressions.SingleOrDefault(x => x.Name == AggregateElement.ElementSelectorName);
+    private Func<IAggregator> CreateLookupAggregator(Type sourceType, IReadOnlyCollection<IAggregateExpression> compiledExpressions, ExpressionCollection elementExpressions)
+    {
+        var keySelector = compiledExpressions.SingleOrDefault(x => x.Name == AggregateElement.KeySelectorName);
+        var elementSelector = compiledExpressions.SingleOrDefault(x => x.Name == AggregateElement.ElementSelectorName);
 
-            if (keySelector == null)
-                throw new ArgumentNullException($"Lookup key selector not provided");
-            if (elementSelector == null)
-                throw new ArgumentNullException($"Lookup element selector not provided");
+        if (keySelector == null)
+            throw new ArgumentNullException($"Lookup key selector not provided");
+        if (elementSelector == null)
+            throw new ArgumentNullException($"Lookup element selector not provided");
 
-            var keySelectorExpression = elementExpressions[keySelector.Name];
-            var elementSelectorExpression = elementExpressions[elementSelector.Name];
+        var keySelectorExpression = elementExpressions[keySelector.Name];
+        var elementSelectorExpression = elementExpressions[elementSelector.Name];
 
-            var aggregatorType = typeof(LookupAggregator<,,>).MakeGenericType(sourceType,
-                keySelectorExpression.Expression.ReturnType, 
-                elementSelectorExpression.Expression.ReturnType);
+        var aggregatorType = typeof(LookupAggregator<,,>).MakeGenericType(sourceType,
+            keySelectorExpression.Expression.ReturnType, 
+            elementSelectorExpression.Expression.ReturnType);
 
-            var ctor = aggregatorType.GetConstructors().Single();
-            var factoryExpression = Expression.Lambda<Func<IAggregator>>(
-                Expression.New(ctor, Expression.Constant(keySelector), Expression.Constant(elementSelector)));
+        var ctor = aggregatorType.GetConstructors().Single();
+        var factoryExpression = Expression.Lambda<Func<IAggregator>>(
+            Expression.New(ctor, Expression.Constant(keySelector), Expression.Constant(elementSelector)));
 
-            return factoryExpression.Compile();
-        }
+        return factoryExpression.Compile();
     }
 }

--- a/src/NRules/NRules/Aggregators/Collections/DefaultKeyMap.cs
+++ b/src/NRules/NRules/Aggregators/Collections/DefaultKeyMap.cs
@@ -1,119 +1,118 @@
 using System;
 using System.Collections.Generic;
 
-namespace NRules.Aggregators.Collections
+namespace NRules.Aggregators.Collections;
+
+/// <summary>
+/// Map (dictionary) that supports mapping using a default value for the key type 
+/// (which is <c>null</c> for reference types).
+/// </summary>
+internal class DefaultKeyMap<TKey, TValue>
 {
-    /// <summary>
-    /// Map (dictionary) that supports mapping using a default value for the key type 
-    /// (which is <c>null</c> for reference types).
-    /// </summary>
-    internal class DefaultKeyMap<TKey, TValue>
+    private readonly Dictionary<TKey, TValue> _map = new();
+    private readonly TKey _defaultKey = default;
+    private TValue _defaultValue;
+    private bool _hasDefault = false;
+
+    public int Count => _map.Count + (_hasDefault ? 1 : 0);
+    public int KeyCount => _map.Keys.Count + (_hasDefault ? 1 : 0);
+
+    public bool ContainsKey(TKey key)
     {
-        private readonly Dictionary<TKey, TValue> _map = new();
-        private readonly TKey _defaultKey = default;
-        private TValue _defaultValue;
-        private bool _hasDefault = false;
-
-        public int Count => _map.Count + (_hasDefault ? 1 : 0);
-        public int KeyCount => _map.Keys.Count + (_hasDefault ? 1 : 0);
-
-        public bool ContainsKey(TKey key)
+        if (Equals(key, _defaultKey))
         {
-            if (Equals(key, _defaultKey))
-            {
-                return _hasDefault;
-            }
-            return _map.ContainsKey(key);
+            return _hasDefault;
         }
+        return _map.ContainsKey(key);
+    }
 
-        public void Add(TKey key, TValue value)
+    public void Add(TKey key, TValue value)
+    {
+        if (Equals(key, _defaultKey))
+        {
+            if (_hasDefault)
+                throw new ArgumentException("An item with the default key has already been added");
+            
+            _hasDefault = true;
+            _defaultValue = value;
+        }
+        else
+        {
+           _map.Add(key, value);
+        }
+    }
+
+    public bool Remove(TKey key)
+    {
+        if (Equals(key, _defaultKey))
+        {
+            if (_hasDefault)
+            {
+                _defaultValue = default;
+                _hasDefault = false;
+                return true;
+            }
+            return false;
+        }
+        return _map.Remove(key);
+    }
+
+    public bool TryGetValue(TKey key, out TValue value)
+    {
+        if (Equals(key, _defaultKey))
+        {
+            value = _defaultValue;
+            return _hasDefault;
+        }
+        return _map.TryGetValue(key, out value);
+    }
+
+    public TValue this[TKey key]
+    {
+        get
         {
             if (Equals(key, _defaultKey))
             {
-                if (_hasDefault)
-                    throw new ArgumentException("An item with the default key has already been added");
-                
+                if (!_hasDefault)
+                    throw new KeyNotFoundException("Default key was not found");
+                return _defaultValue;
+            }
+            return _map[key];
+        }
+        set
+        {
+            if (Equals(key, _defaultKey))
+            {
                 _hasDefault = true;
                 _defaultValue = value;
             }
             else
             {
-               _map.Add(key, value);
+                _map[key] = value;
             }
         }
+    }
 
-        public bool Remove(TKey key)
+    public IEnumerable<TKey> Keys
+    {
+        get
         {
-            if (Equals(key, _defaultKey))
+            if (_hasDefault) yield return _defaultKey;
+            foreach (var item in _map)
             {
-                if (_hasDefault)
-                {
-                    _defaultValue = default;
-                    _hasDefault = false;
-                    return true;
-                }
-                return false;
-            }
-            return _map.Remove(key);
-        }
-
-        public bool TryGetValue(TKey key, out TValue value)
-        {
-            if (Equals(key, _defaultKey))
-            {
-                value = _defaultValue;
-                return _hasDefault;
-            }
-            return _map.TryGetValue(key, out value);
-        }
-
-        public TValue this[TKey key]
-        {
-            get
-            {
-                if (Equals(key, _defaultKey))
-                {
-                    if (!_hasDefault)
-                        throw new KeyNotFoundException("Default key was not found");
-                    return _defaultValue;
-                }
-                return _map[key];
-            }
-            set
-            {
-                if (Equals(key, _defaultKey))
-                {
-                    _hasDefault = true;
-                    _defaultValue = value;
-                }
-                else
-                {
-                    _map[key] = value;
-                }
+                yield return item.Key;
             }
         }
+    }
 
-        public IEnumerable<TKey> Keys
+    public IEnumerable<TValue> Values
+    {
+        get
         {
-            get
+            if (_hasDefault) yield return _defaultValue;
+            foreach (var item in _map)
             {
-                if (_hasDefault) yield return _defaultKey;
-                foreach (var item in _map)
-                {
-                    yield return item.Key;
-                }
-            }
-        }
-
-        public IEnumerable<TValue> Values
-        {
-            get
-            {
-                if (_hasDefault) yield return _defaultValue;
-                foreach (var item in _map)
-                {
-                    yield return item.Value;
-                }
+                yield return item.Value;
             }
         }
     }

--- a/src/NRules/NRules/Aggregators/Collections/FactCollection.cs
+++ b/src/NRules/NRules/Aggregators/Collections/FactCollection.cs
@@ -2,63 +2,62 @@
 using System.Collections.Generic;
 using NRules.RuleModel;
 
-namespace NRules.Aggregators.Collections
+namespace NRules.Aggregators.Collections;
+
+internal class FactCollection<TElement> : IEnumerable<TElement>
 {
-    internal class FactCollection<TElement> : IEnumerable<TElement>
+    private readonly Dictionary<IFact, NodePair> _nodeLookup = new();
+    private readonly LinkedList<TElement> _elements = new();
+    private readonly LinkedList<IFact> _facts = new();
+
+    public void Add(IFact fact, TElement element)
     {
-        private readonly Dictionary<IFact, NodePair> _nodeLookup = new();
-        private readonly LinkedList<TElement> _elements = new();
-        private readonly LinkedList<IFact> _facts = new();
+        var nodePair = new NodePair(fact, element);
+        _facts.AddLast(nodePair.FactNode);
+        _elements.AddLast(nodePair.ElementNode);
+        _nodeLookup[fact] = nodePair;
+    }
 
-        public void Add(IFact fact, TElement element)
+    public void Modify(IFact fact, TElement element)
+    {
+        var nodePair = _nodeLookup[fact];
+        if (!ReferenceEquals(nodePair.ElementNode.Value, element))
         {
-            var nodePair = new NodePair(fact, element);
-            _facts.AddLast(nodePair.FactNode);
-            _elements.AddLast(nodePair.ElementNode);
-            _nodeLookup[fact] = nodePair;
+            nodePair.ElementNode.Value = element;
+        }
+    }
+
+    public void Remove(IFact fact)
+    {
+        var nodePair = _nodeLookup[fact];
+        _facts.Remove(nodePair.FactNode);
+        _elements.Remove(nodePair.ElementNode);
+        _nodeLookup.Remove(fact);
+    }
+
+    public int Count => _elements.Count;
+
+    public IEnumerator<TElement> GetEnumerator()
+    {
+        return _elements.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public IEnumerable<IFact> Facts => _facts;
+
+    private readonly struct NodePair
+    {
+        public NodePair(IFact fact, TElement element)
+        {
+            FactNode = new LinkedListNode<IFact>(fact);
+            ElementNode = new LinkedListNode<TElement>(element);
         }
 
-        public void Modify(IFact fact, TElement element)
-        {
-            var nodePair = _nodeLookup[fact];
-            if (!ReferenceEquals(nodePair.ElementNode.Value, element))
-            {
-                nodePair.ElementNode.Value = element;
-            }
-        }
-
-        public void Remove(IFact fact)
-        {
-            var nodePair = _nodeLookup[fact];
-            _facts.Remove(nodePair.FactNode);
-            _elements.Remove(nodePair.ElementNode);
-            _nodeLookup.Remove(fact);
-        }
-
-        public int Count => _elements.Count;
-
-        public IEnumerator<TElement> GetEnumerator()
-        {
-            return _elements.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
-        public IEnumerable<IFact> Facts => _facts;
-
-        private readonly struct NodePair
-        {
-            public NodePair(IFact fact, TElement element)
-            {
-                FactNode = new LinkedListNode<IFact>(fact);
-                ElementNode = new LinkedListNode<TElement>(element);
-            }
-
-            public LinkedListNode<IFact> FactNode { get; }
-            public LinkedListNode<TElement> ElementNode { get; }
-        }
+        public LinkedListNode<IFact> FactNode { get; }
+        public LinkedListNode<TElement> ElementNode { get; }
     }
 }

--- a/src/NRules/NRules/Aggregators/Collections/FactGrouping.cs
+++ b/src/NRules/NRules/Aggregators/Collections/FactGrouping.cs
@@ -1,14 +1,13 @@
 using System.Linq;
 
-namespace NRules.Aggregators.Collections
-{
-    internal class FactGrouping<TKey, TElement> : FactCollection<TElement>, IGrouping<TKey, TElement>
-    {
-        public FactGrouping(TKey key)
-        {
-            Key = key;
-        }
+namespace NRules.Aggregators.Collections;
 
-        public TKey Key { get; set; }
+internal class FactGrouping<TKey, TElement> : FactCollection<TElement>, IGrouping<TKey, TElement>
+{
+    public FactGrouping(TKey key)
+    {
+        Key = key;
     }
+
+    public TKey Key { get; set; }
 }

--- a/src/NRules/NRules/Aggregators/Collections/FactLookup.cs
+++ b/src/NRules/NRules/Aggregators/Collections/FactLookup.cs
@@ -4,38 +4,37 @@ using System.Collections.Generic;
 using System.Linq;
 using NRules.RuleModel;
 
-namespace NRules.Aggregators.Collections
+namespace NRules.Aggregators.Collections;
+
+internal class FactLookup<TKey, TElement> : IKeyedLookup<TKey, TElement>
 {
-    internal class FactLookup<TKey, TElement> : IKeyedLookup<TKey, TElement>
-    {
-        private readonly DefaultKeyMap<TKey, FactGrouping<TKey, TElement>> _groups = new();
+    private readonly DefaultKeyMap<TKey, FactGrouping<TKey, TElement>> _groups = new();
 
-        public IEnumerator<IGrouping<TKey, TElement>> GetEnumerator() => 
-            _groups.Values.GetEnumerator();
+    public IEnumerator<IGrouping<TKey, TElement>> GetEnumerator() => 
+        _groups.Values.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public bool Contains(TKey key) => _groups.ContainsKey(key);
+    public bool Contains(TKey key) => _groups.ContainsKey(key);
 
-        public int Count => _groups.KeyCount;
+    public int Count => _groups.KeyCount;
 
-        IEnumerable<TElement> ILookup<TKey, TElement>.this[TKey key] =>
-            _groups.TryGetValue(key, out var grouping) ? grouping : Array.Empty<TElement>();
+    IEnumerable<TElement> ILookup<TKey, TElement>.this[TKey key] =>
+        _groups.TryGetValue(key, out var grouping) ? grouping : Array.Empty<TElement>();
 
-        public FactGrouping<TKey, TElement> this[TKey key] => _groups[key];
+    public FactGrouping<TKey, TElement> this[TKey key] => _groups[key];
 
-        public bool TryGetValue(TKey key, out FactGrouping<TKey, TElement> value) =>
-            _groups.TryGetValue(key, out value);
+    public bool TryGetValue(TKey key, out FactGrouping<TKey, TElement> value) =>
+        _groups.TryGetValue(key, out value);
 
-        public void Add(TKey key, FactGrouping<TKey, TElement> value) =>
-            _groups.Add(key, value);
+    public void Add(TKey key, FactGrouping<TKey, TElement> value) =>
+        _groups.Add(key, value);
 
-        public bool Remove(TKey key) =>
-            _groups.Remove(key);
+    public bool Remove(TKey key) =>
+        _groups.Remove(key);
 
-        public IEnumerable<IFact> Facts =>
-            _groups.Values.SelectMany(x => x.Facts);
+    public IEnumerable<IFact> Facts =>
+        _groups.Values.SelectMany(x => x.Facts);
 
-        public IEnumerable<TKey> Keys => _groups.Keys;
-    }
+    public IEnumerable<TKey> Keys => _groups.Keys;
 }

--- a/src/NRules/NRules/Aggregators/FlatteningAggregator.cs
+++ b/src/NRules/NRules/Aggregators/FlatteningAggregator.cs
@@ -3,125 +3,124 @@ using System.Linq;
 using NRules.Collections;
 using NRules.RuleModel;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Aggregator that projects each matching fact into a collection and creates a new fact for each element in that collection.
+/// </summary>
+/// <typeparam name="TSource">Type of source element.</typeparam>
+/// <typeparam name="TResult">Type of result element.</typeparam>
+internal class FlatteningAggregator<TSource, TResult> : IAggregator
 {
-    /// <summary>
-    /// Aggregator that projects each matching fact into a collection and creates a new fact for each element in that collection.
-    /// </summary>
-    /// <typeparam name="TSource">Type of source element.</typeparam>
-    /// <typeparam name="TResult">Type of result element.</typeparam>
-    internal class FlatteningAggregator<TSource, TResult> : IAggregator
+    private readonly IAggregateExpression _selector;
+    private readonly Dictionary<TResult, Counter> _referenceCounter = new();
+    private readonly Dictionary<IFact, OrderedHashSet<TResult>> _sourceToList = new();
+
+    public FlatteningAggregator(IAggregateExpression selector)
     {
-        private readonly IAggregateExpression _selector;
-        private readonly Dictionary<TResult, Counter> _referenceCounter = new();
-        private readonly Dictionary<IFact, OrderedHashSet<TResult>> _sourceToList = new();
+        _selector = selector;
+    }
 
-        public FlatteningAggregator(IAggregateExpression selector)
+    public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var results = new List<AggregationResult>();
+        foreach (var fact in facts)
         {
-            _selector = selector;
-        }
-
-        public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            var results = new List<AggregationResult>();
-            foreach (var fact in facts)
+            var list = new OrderedHashSet<TResult>();
+            _sourceToList[fact] = list;
+            var value = (IEnumerable<TResult>)_selector.Invoke(context, tuple, fact);
+            foreach (var item in value)
             {
-                var list = new OrderedHashSet<TResult>();
-                _sourceToList[fact] = list;
-                var value = (IEnumerable<TResult>)_selector.Invoke(context, tuple, fact);
-                foreach (var item in value)
+                if (list.Add(item) &&
+                    AddRef(item) == 1)
                 {
-                    if (list.Add(item) &&
-                        AddRef(item) == 1)
-                    {
-                        results.Add(AggregationResult.Added(item, Enumerable.Repeat(fact, 1)));
-                    }
+                    results.Add(AggregationResult.Added(item, Enumerable.Repeat(fact, 1)));
                 }
             }
-            return results;
         }
+        return results;
+    }
 
-        public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var results = new List<AggregationResult>();
+        foreach (var fact in facts)
         {
-            var results = new List<AggregationResult>();
-            foreach (var fact in facts)
+            var list = new OrderedHashSet<TResult>();
+            var oldList = _sourceToList[fact];
+            _sourceToList[fact] = list;
+            
+            var value = (IEnumerable<TResult>)_selector.Invoke(context, tuple, fact);
+            foreach (var item in value)
             {
-                var list = new OrderedHashSet<TResult>();
-                var oldList = _sourceToList[fact];
-                _sourceToList[fact] = list;
-                
-                var value = (IEnumerable<TResult>)_selector.Invoke(context, tuple, fact);
-                foreach (var item in value)
-                {
-                    list.Add(item);
-                }
+                list.Add(item);
+            }
 
-                foreach (var item in oldList)
+            foreach (var item in oldList)
+            {
+                if (!list.Contains(item) &&
+                    RemoveRef(item) == 0)
                 {
-                    if (!list.Contains(item) &&
-                        RemoveRef(item) == 0)
-                    {
-                        results.Add(AggregationResult.Removed(item));
-                    }
-                }
-                foreach (var item in list)
-                {
-                    if (oldList.Contains(item))
-                    {
-                        results.Add(AggregationResult.Modified(item, item, Enumerable.Repeat(fact, 1)));
-                    }
-                    else if (AddRef(item) == 1)
-                    {
-                        results.Add(AggregationResult.Added(item, Enumerable.Repeat(fact, 1)));
-                    }
+                    results.Add(AggregationResult.Removed(item));
                 }
             }
-            return results;
-        }
-
-        public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            var results = new List<AggregationResult>();
-            foreach (var fact in facts)
+            foreach (var item in list)
             {
-                var oldList = _sourceToList[fact];
-                _sourceToList.Remove(fact);
-                foreach (var item in oldList)
+                if (oldList.Contains(item))
                 {
-                    if (RemoveRef(item) == 0)
-                    {
-                        results.Add(AggregationResult.Removed(item));
-                    }
+                    results.Add(AggregationResult.Modified(item, item, Enumerable.Repeat(fact, 1)));
+                }
+                else if (AddRef(item) == 1)
+                {
+                    results.Add(AggregationResult.Added(item, Enumerable.Repeat(fact, 1)));
                 }
             }
-            return results;
         }
+        return results;
+    }
 
-        private int AddRef(TResult item)
+    public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var results = new List<AggregationResult>();
+        foreach (var fact in facts)
         {
-            if (!_referenceCounter.TryGetValue(item, out var counter))
+            var oldList = _sourceToList[fact];
+            _sourceToList.Remove(fact);
+            foreach (var item in oldList)
             {
-                counter = new Counter();
-                _referenceCounter[item] = counter;
+                if (RemoveRef(item) == 0)
+                {
+                    results.Add(AggregationResult.Removed(item));
+                }
             }
-            counter.Value++;
-            return counter.Value;
         }
+        return results;
+    }
 
-        private int RemoveRef(TResult item)
+    private int AddRef(TResult item)
+    {
+        if (!_referenceCounter.TryGetValue(item, out var counter))
         {
-            var counter = _referenceCounter[item];
-            counter.Value--;
-            if (counter.Value == 0)
-            {
-                _referenceCounter.Remove(item);
-            }
-            return counter.Value;
+            counter = new Counter();
+            _referenceCounter[item] = counter;
         }
+        counter.Value++;
+        return counter.Value;
+    }
 
-        private class Counter
+    private int RemoveRef(TResult item)
+    {
+        var counter = _referenceCounter[item];
+        counter.Value--;
+        if (counter.Value == 0)
         {
-            public int Value { get; set; }
+            _referenceCounter.Remove(item);
         }
+        return counter.Value;
+    }
+
+    private class Counter
+    {
+        public int Value { get; set; }
     }
 }

--- a/src/NRules/NRules/Aggregators/GroupByAggregator.cs
+++ b/src/NRules/NRules/Aggregators/GroupByAggregator.cs
@@ -2,181 +2,180 @@ using System.Collections.Generic;
 using NRules.Aggregators.Collections;
 using NRules.RuleModel;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Aggregator that groups matching facts into collections of elements with the same key.
+/// </summary>
+/// <typeparam name="TSource">Type of source elements to group.</typeparam>
+/// <typeparam name="TKey">Type of grouping key.</typeparam>
+/// <typeparam name="TElement">Type of elements to group.</typeparam>
+internal class GroupByAggregator<TSource, TKey, TElement> : IAggregator
 {
-    /// <summary>
-    /// Aggregator that groups matching facts into collections of elements with the same key.
-    /// </summary>
-    /// <typeparam name="TSource">Type of source elements to group.</typeparam>
-    /// <typeparam name="TKey">Type of grouping key.</typeparam>
-    /// <typeparam name="TElement">Type of elements to group.</typeparam>
-    internal class GroupByAggregator<TSource, TKey, TElement> : IAggregator
+    private readonly IAggregateExpression _keySelector;
+    private readonly IAggregateExpression _elementSelector;
+    
+    private readonly Dictionary<IFact, TKey> _sourceToKey = new();
+
+    private readonly DefaultKeyMap<TKey, FactGrouping<TKey, TElement>> _groups = new();
+
+    public GroupByAggregator(IAggregateExpression keySelector, IAggregateExpression elementSelector)
     {
-        private readonly IAggregateExpression _keySelector;
-        private readonly IAggregateExpression _elementSelector;
-        
-        private readonly Dictionary<IFact, TKey> _sourceToKey = new();
+        _keySelector = keySelector;
+        _elementSelector = elementSelector;
+    }
 
-        private readonly DefaultKeyMap<TKey, FactGrouping<TKey, TElement>> _groups = new();
-
-        public GroupByAggregator(IAggregateExpression keySelector, IAggregateExpression elementSelector)
+    public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var keys = new List<TKey>();
+        var resultLookup = new DefaultKeyMap<TKey, AggregationResult>();
+        foreach (var fact in facts)
         {
-            _keySelector = keySelector;
-            _elementSelector = elementSelector;
-        }
-
-        public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            var keys = new List<TKey>();
-            var resultLookup = new DefaultKeyMap<TKey, AggregationResult>();
-            foreach (var fact in facts)
+            var key = (TKey)_keySelector.Invoke(context, tuple, fact);
+            var element = (TElement)_elementSelector.Invoke(context, tuple, fact);
+            _sourceToKey[fact] = key;
+            var result = Add(fact, key, element);
+            if (!resultLookup.ContainsKey(key))
             {
-                var key = (TKey)_keySelector.Invoke(context, tuple, fact);
-                var element = (TElement)_elementSelector.Invoke(context, tuple, fact);
-                _sourceToKey[fact] = key;
-                var result = Add(fact, key, element);
+                keys.Add(key);
+                resultLookup[key] = result;
+            }
+        }
+        var results = GetResults(keys, resultLookup);
+        return results;
+    }
+
+    public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var keys = new List<TKey>();
+        var resultLookup = new DefaultKeyMap<TKey, AggregationResult>();
+        var removedKeys = new HashSet<TKey>();
+        foreach (var fact in facts)
+        {
+            var key = (TKey)_keySelector.Invoke(context, tuple, fact);
+            var element = (TElement)_elementSelector.Invoke(context, tuple, fact);
+            var oldKey = _sourceToKey[fact];
+            _sourceToKey[fact] = key;
+    
+            if (Equals(key, oldKey))
+            {
+                var result = Modify(fact, key, element);
                 if (!resultLookup.ContainsKey(key))
                 {
                     keys.Add(key);
                     resultLookup[key] = result;
                 }
             }
-            var results = GetResults(keys, resultLookup);
-            return results;
-        }
-
-        public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            var keys = new List<TKey>();
-            var resultLookup = new DefaultKeyMap<TKey, AggregationResult>();
-            var removedKeys = new HashSet<TKey>();
-            foreach (var fact in facts)
+            else
             {
-                var key = (TKey)_keySelector.Invoke(context, tuple, fact);
-                var element = (TElement)_elementSelector.Invoke(context, tuple, fact);
-                var oldKey = _sourceToKey[fact];
-                _sourceToKey[fact] = key;
-        
-                if (Equals(key, oldKey))
-                {
-                    var result = Modify(fact, key, element);
-                    if (!resultLookup.ContainsKey(key))
-                    {
-                        keys.Add(key);
-                        resultLookup[key] = result;
-                    }
-                }
-                else
-                {
-                    var result1 = RemoveElementOnly(fact, oldKey);
-                    if (!resultLookup.ContainsKey(oldKey))
-                    {
-                        keys.Add(oldKey);
-                    }
-                    if (result1.Action == AggregationAction.Removed)
-                    {
-                        removedKeys.Add(oldKey);
-                    }
-                    resultLookup[oldKey] = result1;
-
-                    var result2 = Add(fact, key, element);
-                    if (!resultLookup.TryGetValue(key, out var previousResult))
-                    {
-                        keys.Add(key);
-                        resultLookup[key] = result2;
-                    }
-                    else if (previousResult.Action == AggregationAction.Removed)
-                    {
-                        resultLookup[key] = result2;
-                        removedKeys.Remove(key);
-                    }
-                }
-            }
-
-            foreach (var removedKey in removedKeys)
-            {
-                _groups.Remove(removedKey);
-            }
-
-            var results = GetResults(keys, resultLookup);
-            return results;
-        }
-
-        public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            var keys = new List<TKey>();
-            var resultLookup = new DefaultKeyMap<TKey, AggregationResult>();
-            foreach (var fact in facts)
-            {
-                var oldKey = _sourceToKey[fact];
-                _sourceToKey.Remove(fact);
-                var result = Remove(fact, oldKey);
+                var result1 = RemoveElementOnly(fact, oldKey);
                 if (!resultLookup.ContainsKey(oldKey))
                 {
                     keys.Add(oldKey);
                 }
-                resultLookup[oldKey] = result;
+                if (result1.Action == AggregationAction.Removed)
+                {
+                    removedKeys.Add(oldKey);
+                }
+                resultLookup[oldKey] = result1;
+
+                var result2 = Add(fact, key, element);
+                if (!resultLookup.TryGetValue(key, out var previousResult))
+                {
+                    keys.Add(key);
+                    resultLookup[key] = result2;
+                }
+                else if (previousResult.Action == AggregationAction.Removed)
+                {
+                    resultLookup[key] = result2;
+                    removedKeys.Remove(key);
+                }
             }
-            var results = GetResults(keys, resultLookup);
-            return results;
         }
 
-        private AggregationResult Add(IFact fact, TKey key, TElement element)
+        foreach (var removedKey in removedKeys)
         {
-            if (!_groups.TryGetValue(key, out var group))
-            {
-                group = new FactGrouping<TKey, TElement>(key);
-                _groups[key] = group;
+            _groups.Remove(removedKey);
+        }
 
-                group.Add(fact, element);
-                return AggregationResult.Added(group, group.Facts);
+        var results = GetResults(keys, resultLookup);
+        return results;
+    }
+
+    public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var keys = new List<TKey>();
+        var resultLookup = new DefaultKeyMap<TKey, AggregationResult>();
+        foreach (var fact in facts)
+        {
+            var oldKey = _sourceToKey[fact];
+            _sourceToKey.Remove(fact);
+            var result = Remove(fact, oldKey);
+            if (!resultLookup.ContainsKey(oldKey))
+            {
+                keys.Add(oldKey);
             }
+            resultLookup[oldKey] = result;
+        }
+        var results = GetResults(keys, resultLookup);
+        return results;
+    }
+
+    private AggregationResult Add(IFact fact, TKey key, TElement element)
+    {
+        if (!_groups.TryGetValue(key, out var group))
+        {
+            group = new FactGrouping<TKey, TElement>(key);
+            _groups[key] = group;
 
             group.Add(fact, element);
-            group.Key = key;
-            return AggregationResult.Modified(group, group, group.Facts);
+            return AggregationResult.Added(group, group.Facts);
         }
 
-        private AggregationResult Modify(IFact fact, TKey key, TElement element)
-        {
-            var group = _groups[key];
-            group.Modify(fact, element);
-            group.Key = key;
-            return AggregationResult.Modified(group, group, group.Facts);
-        }
+        group.Add(fact, element);
+        group.Key = key;
+        return AggregationResult.Modified(group, group, group.Facts);
+    }
 
-        private AggregationResult Remove(IFact fact, TKey key)
-        {
-            var group = _groups[key];
-            group.Remove(fact);
-            if (group.Count == 0)
-            {
-                _groups.Remove(key);
-                return AggregationResult.Removed(group);
-            }
-            return AggregationResult.Modified(group, group, group.Facts);
-        }
+    private AggregationResult Modify(IFact fact, TKey key, TElement element)
+    {
+        var group = _groups[key];
+        group.Modify(fact, element);
+        group.Key = key;
+        return AggregationResult.Modified(group, group, group.Facts);
+    }
 
-        private AggregationResult RemoveElementOnly(IFact fact, TKey key)
+    private AggregationResult Remove(IFact fact, TKey key)
+    {
+        var group = _groups[key];
+        group.Remove(fact);
+        if (group.Count == 0)
         {
-            var group = _groups[key];
-            group.Remove(fact);
-            if (group.Count == 0)
-            {
-                return AggregationResult.Removed(group);
-            }
-            return AggregationResult.Modified(group, group, group.Facts);
+            _groups.Remove(key);
+            return AggregationResult.Removed(group);
         }
+        return AggregationResult.Modified(group, group, group.Facts);
+    }
 
-        private static IEnumerable<AggregationResult> GetResults(IEnumerable<TKey> keys, DefaultKeyMap<TKey, AggregationResult> lookup)
+    private AggregationResult RemoveElementOnly(IFact fact, TKey key)
+    {
+        var group = _groups[key];
+        group.Remove(fact);
+        if (group.Count == 0)
         {
-            var results = new List<AggregationResult>();
-            foreach (var key in keys)
-            {
-                var result = lookup[key];
-                results.Add(result);
-            }
-            return results;
+            return AggregationResult.Removed(group);
         }
+        return AggregationResult.Modified(group, group, group.Facts);
+    }
+
+    private static IEnumerable<AggregationResult> GetResults(IEnumerable<TKey> keys, DefaultKeyMap<TKey, AggregationResult> lookup)
+    {
+        var results = new List<AggregationResult>();
+        foreach (var key in keys)
+        {
+            var result = lookup[key];
+            results.Add(result);
+        }
+        return results;
     }
 }

--- a/src/NRules/NRules/Aggregators/IAggregator.cs
+++ b/src/NRules/NRules/Aggregators/IAggregator.cs
@@ -1,44 +1,43 @@
 ﻿using System.Collections.Generic;
 using NRules.RuleModel;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Base interface for fact aggregators.
+/// An aggregator is a stateful element of the rules engine, that receives matching facts of a particular kind,
+/// and can combine them into a synthetic fact, that is then used by the downstream logic in the rule.
+/// Aggregator also receives updates and removals for the matching facts, so that it can keep the corresponding
+/// aggregate facts in sync.
+/// An aggregator must be supplemented by a corresponding implementation of <see cref="IAggregatorFactory"/> that
+/// knows how to create new instances of the aggregator.
+/// </summary>
+public interface IAggregator
 {
     /// <summary>
-    /// Base interface for fact aggregators.
-    /// An aggregator is a stateful element of the rules engine, that receives matching facts of a particular kind,
-    /// and can combine them into a synthetic fact, that is then used by the downstream logic in the rule.
-    /// Aggregator also receives updates and removals for the matching facts, so that it can keep the corresponding
-    /// aggregate facts in sync.
-    /// An aggregator must be supplemented by a corresponding implementation of <see cref="IAggregatorFactory"/> that
-    /// knows how to create new instances of the aggregator.
+    /// Called by the rules engine when new facts enter corresponding aggregator.
     /// </summary>
-    public interface IAggregator
-    {
-        /// <summary>
-        /// Called by the rules engine when new facts enter corresponding aggregator.
-        /// </summary>
-        /// <param name="context">Aggregation context.</param>
-        /// <param name="tuple">Tuple containing preceding partial matches.</param>
-        /// <param name="facts">New facts to add to the aggregate.</param>
-        /// <returns>Results of the operation on the aggregate, based on the added facts.</returns>
-        IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts);
+    /// <param name="context">Aggregation context.</param>
+    /// <param name="tuple">Tuple containing preceding partial matches.</param>
+    /// <param name="facts">New facts to add to the aggregate.</param>
+    /// <returns>Results of the operation on the aggregate, based on the added facts.</returns>
+    IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts);
 
-        /// <summary>
-        /// Called by the rules engine when existing facts are modified in the corresponding aggregator.
-        /// </summary>
-        /// <param name="context">Aggregation context.</param>
-        /// <param name="tuple">Tuple containing preceding partial matches.</param>
-        /// <param name="facts">Existing facts to update in the aggregate.</param>
-        /// <returns>Results of the operation on the aggregate, based on the modified facts.</returns>
-        IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts);
+    /// <summary>
+    /// Called by the rules engine when existing facts are modified in the corresponding aggregator.
+    /// </summary>
+    /// <param name="context">Aggregation context.</param>
+    /// <param name="tuple">Tuple containing preceding partial matches.</param>
+    /// <param name="facts">Existing facts to update in the aggregate.</param>
+    /// <returns>Results of the operation on the aggregate, based on the modified facts.</returns>
+    IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts);
 
-        /// <summary>
-        /// Called by the rules engine when existing facts are removed from the corresponding aggregator.
-        /// </summary>
-        /// <param name="context">Aggregation context.</param>
-        /// <param name="tuple">Tuple containing preceding partial matches.</param>
-        /// <param name="facts">Existing facts to remove from the aggregate.</param>
-        /// <returns>Results of the operation on the aggregate, based on the removed facts.</returns>
-        IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts);
-    }
+    /// <summary>
+    /// Called by the rules engine when existing facts are removed from the corresponding aggregator.
+    /// </summary>
+    /// <param name="context">Aggregation context.</param>
+    /// <param name="tuple">Tuple containing preceding partial matches.</param>
+    /// <param name="facts">Existing facts to remove from the aggregate.</param>
+    /// <returns>Results of the operation on the aggregate, based on the removed facts.</returns>
+    IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts);
 }

--- a/src/NRules/NRules/Aggregators/IAggregatorFactory.cs
+++ b/src/NRules/NRules/Aggregators/IAggregatorFactory.cs
@@ -1,31 +1,30 @@
 using System.Collections.Generic;
 using NRules.RuleModel;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Base interface for aggregator factories.
+/// Aggregator factory constructs new instances of <see cref="IAggregator"/> of a given type, so that they
+/// can accumulate aggregation results.
+/// An <c>IAggregatorFactory</c> type must either be registered in <see cref="RuleCompiler.AggregatorRegistry"/>,
+/// or provided in the canonical rule model via <see cref="AggregateElement.CustomFactoryType"/>. If both are
+/// provided, the aggregator factory at the <see cref="AggregateElement"/> level takes precedence.
+/// </summary>
+public interface IAggregatorFactory
 {
     /// <summary>
-    /// Base interface for aggregator factories.
-    /// Aggregator factory constructs new instances of <see cref="IAggregator"/> of a given type, so that they
-    /// can accumulate aggregation results.
-    /// An <c>IAggregatorFactory</c> type must either be registered in <see cref="RuleCompiler.AggregatorRegistry"/>,
-    /// or provided in the canonical rule model via <see cref="AggregateElement.CustomFactoryType"/>. If both are
-    /// provided, the aggregator factory at the <see cref="AggregateElement"/> level takes precedence.
+    /// Called by the rules engine to compile the aggregator factory before it is used for the first time.
     /// </summary>
-    public interface IAggregatorFactory
-    {
-        /// <summary>
-        /// Called by the rules engine to compile the aggregator factory before it is used for the first time.
-        /// </summary>
-        /// <param name="element">Corresponding aggregate element from the rule definition.</param>
-        /// <param name="compiledExpressions">Aggregate expressions compiled to an executable form.</param>
-        void Compile(AggregateElement element, IEnumerable<IAggregateExpression> compiledExpressions);
+    /// <param name="element">Corresponding aggregate element from the rule definition.</param>
+    /// <param name="compiledExpressions">Aggregate expressions compiled to an executable form.</param>
+    void Compile(AggregateElement element, IEnumerable<IAggregateExpression> compiledExpressions);
 
-        /// <summary>
-        /// Creates a new aggregator instance.
-        /// This method is called by the engine for each new combination of preceding partial matches, 
-        /// so that a new instance of the aggregator is created to accumulate the results.
-        /// </summary>
-        /// <returns>Aggregator instance.</returns>
-        IAggregator Create();
-    }
+    /// <summary>
+    /// Creates a new aggregator instance.
+    /// This method is called by the engine for each new combination of preceding partial matches, 
+    /// so that a new instance of the aggregator is created to accumulate the results.
+    /// </summary>
+    /// <returns>Aggregator instance.</returns>
+    IAggregator Create();
 }

--- a/src/NRules/NRules/Aggregators/LookupAggregator.cs
+++ b/src/NRules/NRules/Aggregators/LookupAggregator.cs
@@ -2,113 +2,112 @@
 using NRules.Aggregators.Collections;
 using NRules.RuleModel;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Aggregator that folds matching facts into a lookup collection, where facts with the same key are grouped together.
+/// </summary>
+/// <typeparam name="TSource">Type of source elements to group.</typeparam>
+/// <typeparam name="TKey">Type of grouping key.</typeparam>
+/// <typeparam name="TElement">Type of elements to group.</typeparam>
+internal class LookupAggregator<TSource, TKey, TElement> : IAggregator
 {
-    /// <summary>
-    /// Aggregator that folds matching facts into a lookup collection, where facts with the same key are grouped together.
-    /// </summary>
-    /// <typeparam name="TSource">Type of source elements to group.</typeparam>
-    /// <typeparam name="TKey">Type of grouping key.</typeparam>
-    /// <typeparam name="TElement">Type of elements to group.</typeparam>
-    internal class LookupAggregator<TSource, TKey, TElement> : IAggregator
+    private readonly IAggregateExpression _keySelector;
+    private readonly IAggregateExpression _elementSelector;
+
+    private readonly Dictionary<IFact, TKey> _sourceToKey = new();
+
+    private readonly FactLookup<TKey, TElement> _lookup = new();
+    private bool _created = false;
+
+    public LookupAggregator(IAggregateExpression keySelector, IAggregateExpression elementSelector)
     {
-        private readonly IAggregateExpression _keySelector;
-        private readonly IAggregateExpression _elementSelector;
+        _keySelector = keySelector;
+        _elementSelector = elementSelector;
+    }
 
-        private readonly Dictionary<IFact, TKey> _sourceToKey = new();
-
-        private readonly FactLookup<TKey, TElement> _lookup = new();
-        private bool _created = false;
-
-        public LookupAggregator(IAggregateExpression keySelector, IAggregateExpression elementSelector)
+    public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        foreach (var fact in facts)
         {
-            _keySelector = keySelector;
-            _elementSelector = elementSelector;
+            var key = (TKey)_keySelector.Invoke(context, tuple, fact);
+            var element = (TElement)_elementSelector.Invoke(context, tuple, fact);
+
+            _sourceToKey[fact] = key;
+            
+            AddFact(fact, key, element);
         }
 
-        public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+        if (!_created)
         {
-            foreach (var fact in facts)
-            {
-                var key = (TKey)_keySelector.Invoke(context, tuple, fact);
-                var element = (TElement)_elementSelector.Invoke(context, tuple, fact);
-
-                _sourceToKey[fact] = key;
-                
-                AddFact(fact, key, element);
-            }
-
-            if (!_created)
-            {
-                _created = true;
-                return new[] {AggregationResult.Added(_lookup, _lookup.Facts)};
-            }
-            return new[] {AggregationResult.Modified(_lookup, _lookup, _lookup.Facts)};
+            _created = true;
+            return new[] {AggregationResult.Added(_lookup, _lookup.Facts)};
         }
+        return new[] {AggregationResult.Modified(_lookup, _lookup, _lookup.Facts)};
+    }
 
-        public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        foreach (var fact in facts)
         {
-            foreach (var fact in facts)
+            var oldKey = _sourceToKey[fact];
+            var key = (TKey)_keySelector.Invoke(context, tuple, fact);
+            var element = (TElement)_elementSelector.Invoke(context, tuple, fact);
+
+            if (Equals(key, oldKey))
             {
-                var oldKey = _sourceToKey[fact];
-                var key = (TKey)_keySelector.Invoke(context, tuple, fact);
-                var element = (TElement)_elementSelector.Invoke(context, tuple, fact);
-
-                if (Equals(key, oldKey))
-                {
-                    ModifyFact(fact, key, element);
-                }
-                else
-                {
-                    RemoveFact(fact, oldKey);
-                    AddFact(fact, key, element);
-                }
-            }
-
-            return new[] {AggregationResult.Modified(_lookup, _lookup, _lookup.Facts)};
-        }
-
-        public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            foreach (var fact in facts)
-            {
-                var key = _sourceToKey[fact];
-                RemoveFact(fact, key);
-            }
-
-            return new[] {AggregationResult.Modified(_lookup, _lookup, _lookup.Facts)};
-        }
-
-        private void AddFact(IFact fact, TKey key, TElement element)
-        {
-            if (!_lookup.TryGetValue(key, out var grouping))
-            {
-                grouping = new FactGrouping<TKey, TElement>(key);
-                _lookup.Add(key, grouping);
+                ModifyFact(fact, key, element);
             }
             else
             {
-                grouping.Key = key;
+                RemoveFact(fact, oldKey);
+                AddFact(fact, key, element);
             }
-
-            grouping.Add(fact, element);
         }
 
-        private void ModifyFact(IFact fact, TKey key, TElement element)
+        return new[] {AggregationResult.Modified(_lookup, _lookup, _lookup.Facts)};
+    }
+
+    public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        foreach (var fact in facts)
         {
-            var grouping = _lookup[key];
+            var key = _sourceToKey[fact];
+            RemoveFact(fact, key);
+        }
+
+        return new[] {AggregationResult.Modified(_lookup, _lookup, _lookup.Facts)};
+    }
+
+    private void AddFact(IFact fact, TKey key, TElement element)
+    {
+        if (!_lookup.TryGetValue(key, out var grouping))
+        {
+            grouping = new FactGrouping<TKey, TElement>(key);
+            _lookup.Add(key, grouping);
+        }
+        else
+        {
             grouping.Key = key;
-            grouping.Modify(fact, element);
         }
 
-        private void RemoveFact(IFact fact, TKey key)
+        grouping.Add(fact, element);
+    }
+
+    private void ModifyFact(IFact fact, TKey key, TElement element)
+    {
+        var grouping = _lookup[key];
+        grouping.Key = key;
+        grouping.Modify(fact, element);
+    }
+
+    private void RemoveFact(IFact fact, TKey key)
+    {
+        var grouping = _lookup[key];
+        grouping.Remove(fact);
+        if (grouping.Count == 0)
         {
-            var grouping = _lookup[key];
-            grouping.Remove(fact);
-            if (grouping.Count == 0)
-            {
-                _lookup.Remove(key);
-            }
+            _lookup.Remove(key);
         }
     }
 }

--- a/src/NRules/NRules/Aggregators/MultiKeySortedAggregator.cs
+++ b/src/NRules/NRules/Aggregators/MultiKeySortedAggregator.cs
@@ -4,120 +4,119 @@ using NRules.Aggregators.Collections;
 using NRules.RuleModel;
 using NRules.Utilities;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Aggregate that adds matching facts into a collection sorted by a given key selector and sort direction.
+/// </summary>
+/// <typeparam name="TSource">Type of elements to collect.</typeparam>
+internal class MultiKeySortedAggregator<TSource> : IAggregator
 {
-    /// <summary>
-    /// Aggregate that adds matching facts into a collection sorted by a given key selector and sort direction.
-    /// </summary>
-    /// <typeparam name="TSource">Type of elements to collect.</typeparam>
-    internal class MultiKeySortedAggregator<TSource> : IAggregator
+    private readonly SortCondition[] _sortConditions;
+    private readonly SortedFactCollection<TSource, object[]> _sortedFactCollection;
+    private bool _created = false;
+
+    public MultiKeySortedAggregator(IEnumerable<SortCondition> sortConditions)
     {
-        private readonly SortCondition[] _sortConditions;
-        private readonly SortedFactCollection<TSource, object[]> _sortedFactCollection;
-        private bool _created = false;
+        _sortConditions = sortConditions.ToArray();
+        var comparer = CreateComparer(_sortConditions);
+        _sortedFactCollection = new SortedFactCollection<TSource, object[]>(comparer);
+    }
 
-        public MultiKeySortedAggregator(IEnumerable<SortCondition> sortConditions)
+    private static IComparer<object[]> CreateComparer(IEnumerable<SortCondition> sortConditions)
+    {
+        var comparers = new List<IComparer<object>>();
+        foreach (var sortCondition in sortConditions)
         {
-            _sortConditions = sortConditions.ToArray();
-            var comparer = CreateComparer(_sortConditions);
-            _sortedFactCollection = new SortedFactCollection<TSource, object[]>(comparer);
+            var defaultComparer = (IComparer<object>)Comparer<object>.Default;
+            var comparer = sortCondition.Direction == SortDirection.Ascending ? defaultComparer : new ReverseComparer<object>(defaultComparer);
+            comparers.Add(comparer);
         }
 
-        private static IComparer<object[]> CreateComparer(IEnumerable<SortCondition> sortConditions)
+        return new MultiKeyComparer(comparers);
+    }
+
+    private object[] GetKey(AggregationContext context, ITuple tuple, IFact fact)
+    {
+        var key = new object[_sortConditions.Length];
+        for (int i = 0; i < _sortConditions.Length; i++)
         {
-            var comparers = new List<IComparer<object>>();
-            foreach (var sortCondition in sortConditions)
+            key[i] = _sortConditions[i].Expression.Invoke(context, tuple, fact);
+        }
+        return key;
+    }
+
+    public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        AddFacts(context, tuple, facts);
+        if (!_created)
+        {
+            _created = true;
+            return new[] { AggregationResult.Added(_sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
+        }
+        return new[] { AggregationResult.Modified(_sortedFactCollection, _sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
+    }
+
+    public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        ModifyFacts(context, tuple, facts);
+        return new[] { AggregationResult.Modified(_sortedFactCollection, _sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
+    }
+
+    public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        RemoveFacts(context, tuple, facts);
+        return new[] { AggregationResult.Modified(_sortedFactCollection, _sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
+    }
+
+    private void AddFacts(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        foreach (var fact in facts)
+        {
+            var key = GetKey(context, tuple, fact);
+            _sortedFactCollection.AddFact(key, fact);
+        }
+    }
+
+    private void ModifyFacts(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        foreach (var fact in facts)
+        {
+            _sortedFactCollection.RemoveFact(fact);
+
+            var key = GetKey(context, tuple, fact);
+            _sortedFactCollection.AddFact(key, fact);
+        }
+    }
+
+    private void RemoveFacts(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        foreach (var fact in facts)
+        {
+            _sortedFactCollection.RemoveFact(fact);
+        }
+    }
+
+    private class MultiKeyComparer : IComparer<object[]>
+    {
+        private readonly IComparer<object>[] _comparers;
+
+        public MultiKeyComparer(IEnumerable<IComparer<object>> comparers)
+        {
+            _comparers = comparers.ToArray();
+        }
+
+        public int Compare(object[] x, object[] y)
+        {
+            var result = 0;
+
+            for (int i = 0; i < _comparers.Length; i++)
             {
-                var defaultComparer = (IComparer<object>)Comparer<object>.Default;
-                var comparer = sortCondition.Direction == SortDirection.Ascending ? defaultComparer : new ReverseComparer<object>(defaultComparer);
-                comparers.Add(comparer);
+                result = _comparers[i].Compare(x[i], y[i]);
+                if (result != 0) break;
             }
 
-            return new MultiKeyComparer(comparers);
-        }
-
-        private object[] GetKey(AggregationContext context, ITuple tuple, IFact fact)
-        {
-            var key = new object[_sortConditions.Length];
-            for (int i = 0; i < _sortConditions.Length; i++)
-            {
-                key[i] = _sortConditions[i].Expression.Invoke(context, tuple, fact);
-            }
-            return key;
-        }
-
-        public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            AddFacts(context, tuple, facts);
-            if (!_created)
-            {
-                _created = true;
-                return new[] { AggregationResult.Added(_sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
-            }
-            return new[] { AggregationResult.Modified(_sortedFactCollection, _sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
-        }
-
-        public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            ModifyFacts(context, tuple, facts);
-            return new[] { AggregationResult.Modified(_sortedFactCollection, _sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
-        }
-
-        public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            RemoveFacts(context, tuple, facts);
-            return new[] { AggregationResult.Modified(_sortedFactCollection, _sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
-        }
-
-        private void AddFacts(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            foreach (var fact in facts)
-            {
-                var key = GetKey(context, tuple, fact);
-                _sortedFactCollection.AddFact(key, fact);
-            }
-        }
-
-        private void ModifyFacts(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            foreach (var fact in facts)
-            {
-                _sortedFactCollection.RemoveFact(fact);
-
-                var key = GetKey(context, tuple, fact);
-                _sortedFactCollection.AddFact(key, fact);
-            }
-        }
-
-        private void RemoveFacts(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            foreach (var fact in facts)
-            {
-                _sortedFactCollection.RemoveFact(fact);
-            }
-        }
-
-        private class MultiKeyComparer : IComparer<object[]>
-        {
-            private readonly IComparer<object>[] _comparers;
-
-            public MultiKeyComparer(IEnumerable<IComparer<object>> comparers)
-            {
-                _comparers = comparers.ToArray();
-            }
-
-            public int Compare(object[] x, object[] y)
-            {
-                var result = 0;
-
-                for (int i = 0; i < _comparers.Length; i++)
-                {
-                    result = _comparers[i].Compare(x[i], y[i]);
-                    if (result != 0) break;
-                }
-
-                return result;
-            }
+            return result;
         }
     }
 }

--- a/src/NRules/NRules/Aggregators/ProjectionAggregator.cs
+++ b/src/NRules/NRules/Aggregators/ProjectionAggregator.cs
@@ -2,58 +2,57 @@ using System.Collections.Generic;
 using System.Linq;
 using NRules.RuleModel;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Aggregator that projects matching facts into new elements.
+/// </summary>
+/// <typeparam name="TSource">Type of source element.</typeparam>
+/// <typeparam name="TResult">Type of result element.</typeparam>
+internal class ProjectionAggregator<TSource, TResult> : IAggregator
 {
-    /// <summary>
-    /// Aggregator that projects matching facts into new elements.
-    /// </summary>
-    /// <typeparam name="TSource">Type of source element.</typeparam>
-    /// <typeparam name="TResult">Type of result element.</typeparam>
-    internal class ProjectionAggregator<TSource, TResult> : IAggregator
+    private readonly IAggregateExpression _selector;
+    private readonly Dictionary<IFact, object> _sourceToValue = new();
+
+    public ProjectionAggregator(IAggregateExpression selector)
     {
-        private readonly IAggregateExpression _selector;
-        private readonly Dictionary<IFact, object> _sourceToValue = new();
+        _selector = selector;
+    }
 
-        public ProjectionAggregator(IAggregateExpression selector)
+    public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var results = new List<AggregationResult>();
+        foreach (var fact in facts)
         {
-            _selector = selector;
+            var value = _selector.Invoke(context, tuple, fact);
+            _sourceToValue[fact] = value;
+            results.Add(AggregationResult.Added(value, Enumerable.Repeat(fact, 1)));
         }
+        return results;
+    }
 
-        public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var results = new List<AggregationResult>();
+        foreach (var fact in facts)
         {
-            var results = new List<AggregationResult>();
-            foreach (var fact in facts)
-            {
-                var value = _selector.Invoke(context, tuple, fact);
-                _sourceToValue[fact] = value;
-                results.Add(AggregationResult.Added(value, Enumerable.Repeat(fact, 1)));
-            }
-            return results;
+            var value = _selector.Invoke(context, tuple, fact);
+            var oldValue = (TResult)_sourceToValue[fact];
+            _sourceToValue[fact] = value;
+            results.Add(AggregationResult.Modified(value, oldValue, Enumerable.Repeat(fact, 1)));
         }
+        return results;
+    }
 
-        public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var results = new List<AggregationResult>();
+        foreach (var fact in facts)
         {
-            var results = new List<AggregationResult>();
-            foreach (var fact in facts)
-            {
-                var value = _selector.Invoke(context, tuple, fact);
-                var oldValue = (TResult)_sourceToValue[fact];
-                _sourceToValue[fact] = value;
-                results.Add(AggregationResult.Modified(value, oldValue, Enumerable.Repeat(fact, 1)));
-            }
-            return results;
+            var oldValue = _sourceToValue[fact];
+            _sourceToValue.Remove(fact);
+            results.Add(AggregationResult.Removed(oldValue));
         }
-
-        public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            var results = new List<AggregationResult>();
-            foreach (var fact in facts)
-            {
-                var oldValue = _sourceToValue[fact];
-                _sourceToValue.Remove(fact);
-                results.Add(AggregationResult.Removed(oldValue));
-            }
-            return results;
-        }
+        return results;
     }
 }

--- a/src/NRules/NRules/Aggregators/ProjectionAggregatorFactory.cs
+++ b/src/NRules/NRules/Aggregators/ProjectionAggregatorFactory.cs
@@ -4,32 +4,31 @@ using System.Linq;
 using System.Linq.Expressions;
 using NRules.RuleModel;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Aggregator factory for projection aggregator.
+/// </summary>
+internal class ProjectionAggregatorFactory : IAggregatorFactory
 {
-    /// <summary>
-    /// Aggregator factory for projection aggregator.
-    /// </summary>
-    internal class ProjectionAggregatorFactory : IAggregatorFactory
+    private Func<IAggregator> _factory;
+
+    public void Compile(AggregateElement element, IEnumerable<IAggregateExpression> compiledExpressions)
     {
-        private Func<IAggregator> _factory;
+        var selector = element.Expressions[AggregateElement.SelectorName];
+        var sourceType = element.Source.ValueType;
+        var resultType = selector.Expression.ReturnType;
+        Type aggregatorType = typeof(ProjectionAggregator<,>).MakeGenericType(sourceType, resultType);
 
-        public void Compile(AggregateElement element, IEnumerable<IAggregateExpression> compiledExpressions)
-        {
-            var selector = element.Expressions[AggregateElement.SelectorName];
-            var sourceType = element.Source.ValueType;
-            var resultType = selector.Expression.ReturnType;
-            Type aggregatorType = typeof(ProjectionAggregator<,>).MakeGenericType(sourceType, resultType);
+        var compiledSelector = compiledExpressions.FindSingle(AggregateElement.SelectorName);
+        var ctor = aggregatorType.GetConstructors().Single();
+        var factoryExpression = Expression.Lambda<Func<IAggregator>>(
+            Expression.New(ctor, Expression.Constant(compiledSelector)));
+        _factory = factoryExpression.Compile();
+    }
 
-            var compiledSelector = compiledExpressions.FindSingle(AggregateElement.SelectorName);
-            var ctor = aggregatorType.GetConstructors().Single();
-            var factoryExpression = Expression.Lambda<Func<IAggregator>>(
-                Expression.New(ctor, Expression.Constant(compiledSelector)));
-            _factory = factoryExpression.Compile();
-        }
-
-        public IAggregator Create()
-        {
-            return _factory();
-        }
+    public IAggregator Create()
+    {
+        return _factory();
     }
 }

--- a/src/NRules/NRules/Aggregators/SortCondition.cs
+++ b/src/NRules/NRules/Aggregators/SortCondition.cs
@@ -1,18 +1,17 @@
 ﻿using NRules.RuleModel;
 
-namespace NRules.Aggregators
-{
-    internal class SortCondition
-    {
-        public SortCondition(string name, SortDirection direction, IAggregateExpression expression)
-        {
-            Name = name;
-            Direction = direction;
-            Expression = expression;
-        }
+namespace NRules.Aggregators;
 
-        public string Name { get; }
-        public SortDirection Direction { get; }
-        public IAggregateExpression Expression { get; }
+internal class SortCondition
+{
+    public SortCondition(string name, SortDirection direction, IAggregateExpression expression)
+    {
+        Name = name;
+        Direction = direction;
+        Expression = expression;
     }
+
+    public string Name { get; }
+    public SortDirection Direction { get; }
+    public IAggregateExpression Expression { get; }
 }

--- a/src/NRules/NRules/Aggregators/SortedAggregator.cs
+++ b/src/NRules/NRules/Aggregators/SortedAggregator.cs
@@ -3,82 +3,81 @@ using NRules.Aggregators.Collections;
 using NRules.RuleModel;
 using NRules.Utilities;
 
-namespace NRules.Aggregators
+namespace NRules.Aggregators;
+
+/// <summary>
+/// Aggregate that adds matching facts into a collection sorted by a given key selector and sort direction.
+/// </summary>
+/// <typeparam name="TSource">Type of source element.</typeparam>
+/// <typeparam name="TKey">Type of key used in the key selector for sorting.</typeparam>
+internal class SortedAggregator<TSource, TKey> : IAggregator
 {
-    /// <summary>
-    /// Aggregate that adds matching facts into a collection sorted by a given key selector and sort direction.
-    /// </summary>
-    /// <typeparam name="TSource">Type of source element.</typeparam>
-    /// <typeparam name="TKey">Type of key used in the key selector for sorting.</typeparam>
-    internal class SortedAggregator<TSource, TKey> : IAggregator
+    private readonly SortedFactCollection<TSource, TKey> _sortedFactCollection;
+    private readonly IAggregateExpression _keySelector;
+    private bool _created = false;
+
+    public SortedAggregator(IAggregateExpression keySelector, SortDirection sortDirection)
     {
-        private readonly SortedFactCollection<TSource, TKey> _sortedFactCollection;
-        private readonly IAggregateExpression _keySelector;
-        private bool _created = false;
+        _keySelector = keySelector;
+        var comparer = CreateComparer(sortDirection);
+        _sortedFactCollection = new SortedFactCollection<TSource, TKey>(comparer);
+    }
 
-        public SortedAggregator(IAggregateExpression keySelector, SortDirection sortDirection)
+    private static IComparer<TKey> CreateComparer(SortDirection sortDirection)
+    {
+        var defaultComparer = (IComparer<TKey>)Comparer<TKey>.Default;
+        var comparer = sortDirection == SortDirection.Ascending ? defaultComparer : new ReverseComparer<TKey>(defaultComparer);
+        return comparer;
+    }
+
+    public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        AddFacts(context, tuple, facts);
+        if (!_created)
         {
-            _keySelector = keySelector;
-            var comparer = CreateComparer(sortDirection);
-            _sortedFactCollection = new SortedFactCollection<TSource, TKey>(comparer);
+            _created = true;
+            return new[] { AggregationResult.Added(_sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
         }
+        return new[] { AggregationResult.Modified(_sortedFactCollection, _sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
+    }
 
-        private static IComparer<TKey> CreateComparer(SortDirection sortDirection)
+    public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        ModifyFacts(context, tuple, facts);
+        return new[] { AggregationResult.Modified(_sortedFactCollection, _sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
+    }
+
+    public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        RemoveFacts(context, tuple, facts);
+        return new[] { AggregationResult.Modified(_sortedFactCollection, _sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
+    }
+
+    private void AddFacts(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        foreach (var fact in facts)
         {
-            var defaultComparer = (IComparer<TKey>)Comparer<TKey>.Default;
-            var comparer = sortDirection == SortDirection.Ascending ? defaultComparer : new ReverseComparer<TKey>(defaultComparer);
-            return comparer;
+            var key = (TKey)_keySelector.Invoke(context, tuple, fact);
+            _sortedFactCollection.AddFact(key, fact);
         }
+    }
 
-        public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    private void ModifyFacts(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        foreach (var fact in facts)
         {
-            AddFacts(context, tuple, facts);
-            if (!_created)
-            {
-                _created = true;
-                return new[] { AggregationResult.Added(_sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
-            }
-            return new[] { AggregationResult.Modified(_sortedFactCollection, _sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
+            _sortedFactCollection.RemoveFact(fact);
+
+            var key = (TKey)_keySelector.Invoke(context, tuple, fact);
+            _sortedFactCollection.AddFact(key, fact);
         }
+    }
 
-        public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    private void RemoveFacts(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        foreach (var fact in facts)
         {
-            ModifyFacts(context, tuple, facts);
-            return new[] { AggregationResult.Modified(_sortedFactCollection, _sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
-        }
-
-        public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            RemoveFacts(context, tuple, facts);
-            return new[] { AggregationResult.Modified(_sortedFactCollection, _sortedFactCollection, _sortedFactCollection.GetFactEnumerable()) };
-        }
-
-        private void AddFacts(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            foreach (var fact in facts)
-            {
-                var key = (TKey)_keySelector.Invoke(context, tuple, fact);
-                _sortedFactCollection.AddFact(key, fact);
-            }
-        }
-
-        private void ModifyFacts(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            foreach (var fact in facts)
-            {
-                _sortedFactCollection.RemoveFact(fact);
-
-                var key = (TKey)_keySelector.Invoke(context, tuple, fact);
-                _sortedFactCollection.AddFact(key, fact);
-            }
-        }
-
-        private void RemoveFacts(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            foreach (var fact in facts)
-            {
-                _sortedFactCollection.RemoveFact(fact);
-            }
+            _sortedFactCollection.RemoveFact(fact);
         }
     }
 }

--- a/src/NRules/NRules/BatchOptions.cs
+++ b/src/NRules/NRules/BatchOptions.cs
@@ -1,22 +1,21 @@
-﻿namespace NRules
+﻿namespace NRules;
+
+/// <summary>
+/// Defines how batch insert/update/retract of facts behaves.
+/// Any fact that already exists in the session during insert is considered failed.
+/// Similarly, a fact that does not exist in the session during update or retract is also considered failed.
+/// By default, any failed fact in a batch operation fails the whole operation, and no facts are propagated.
+/// This behavior can be changed using <c>BatchOptions</c>.
+/// </summary>
+public enum BatchOptions
 {
     /// <summary>
-    /// Defines how batch insert/update/retract of facts behaves.
-    /// Any fact that already exists in the session during insert is considered failed.
-    /// Similarly, a fact that does not exist in the session during update or retract is also considered failed.
-    /// By default, any failed fact in a batch operation fails the whole operation, and no facts are propagated.
-    /// This behavior can be changed using <c>BatchOptions</c>.
+    /// Default behavior of batch operations, where the operation is either applied to all facts in the batch or none of them.
     /// </summary>
-    public enum BatchOptions
-    {
-        /// <summary>
-        /// Default behavior of batch operations, where the operation is either applied to all facts in the batch or none of them.
-        /// </summary>
-        AllOrNothing = 0,
+    AllOrNothing = 0,
 
-        /// <summary>
-        /// Changes the behavior of fact propagation, where failed facts are skipped, and the rest are propagated.
-        /// </summary>
-        SkipFailed = 1,
-    }
+    /// <summary>
+    /// Changes the behavior of fact propagation, where failed facts are skipped, and the rest are propagated.
+    /// </summary>
+    SkipFailed = 1,
 }

--- a/src/NRules/NRules/Collections/OrderedDictionary.cs
+++ b/src/NRules/NRules/Collections/OrderedDictionary.cs
@@ -1,82 +1,81 @@
 ﻿using System.Collections.Generic;
 
-namespace NRules.Collections
+namespace NRules.Collections;
+
+internal class OrderedDictionary<TKey, TValue>
 {
-    internal class OrderedDictionary<TKey, TValue>
+    private readonly IDictionary<TKey, LinkedListNode<TValue>> _dictionary;
+    private readonly LinkedList<TValue> _linkedList;
+
+    public OrderedDictionary()
+        : this(EqualityComparer<TKey>.Default)
     {
-        private readonly IDictionary<TKey, LinkedListNode<TValue>> _dictionary;
-        private readonly LinkedList<TValue> _linkedList;
+    }
 
-        public OrderedDictionary()
-            : this(EqualityComparer<TKey>.Default)
+    public OrderedDictionary(IEqualityComparer<TKey> comparer)
+    {
+        _dictionary = new Dictionary<TKey, LinkedListNode<TValue>>(comparer);
+        _linkedList = new LinkedList<TValue>();
+    }
+
+    public void Clear()
+    {
+        _linkedList.Clear();
+        _dictionary.Clear();
+    }
+
+    public int Count => _dictionary.Count;
+    public IEnumerable<TValue> Values => _linkedList;
+
+    public bool ContainsKey(TKey key)
+    {
+        return _dictionary.ContainsKey(key);
+    }
+
+    public void Add(TKey key, TValue value)
+    {
+        LinkedListNode<TValue> node = _linkedList.AddLast(value);
+        _dictionary.Add(key, node);
+    }
+
+    public bool Remove(TKey key)
+    {
+        bool found = _dictionary.TryGetValue(key, out var node);
+        if (!found) return false;
+        _dictionary.Remove(key);
+        _linkedList.Remove(node);
+        return true;
+    }
+
+    public bool TryGetValue(TKey key, out TValue value)
+    {
+        bool found = _dictionary.TryGetValue(key, out var node);
+        if (!found)
         {
+            value = default;
+            return false;
         }
+        value = node.Value;
+        return true;
+    }
 
-        public OrderedDictionary(IEqualityComparer<TKey> comparer)
+    public TValue this[TKey key]
+    {
+        get
         {
-            _dictionary = new Dictionary<TKey, LinkedListNode<TValue>>(comparer);
-            _linkedList = new LinkedList<TValue>();
+            var node = _dictionary[key];
+            return node.Value;
         }
-
-        public void Clear()
-        {
-            _linkedList.Clear();
-            _dictionary.Clear();
-        }
-
-        public int Count => _dictionary.Count;
-        public IEnumerable<TValue> Values => _linkedList;
-
-        public bool ContainsKey(TKey key)
-        {
-            return _dictionary.ContainsKey(key);
-        }
-
-        public void Add(TKey key, TValue value)
-        {
-            LinkedListNode<TValue> node = _linkedList.AddLast(value);
-            _dictionary.Add(key, node);
-        }
-
-        public bool Remove(TKey key)
-        {
-            bool found = _dictionary.TryGetValue(key, out var node);
-            if (!found) return false;
-            _dictionary.Remove(key);
-            _linkedList.Remove(node);
-            return true;
-        }
-
-        public bool TryGetValue(TKey key, out TValue value)
+        set
         {
             bool found = _dictionary.TryGetValue(key, out var node);
             if (!found)
             {
-                value = default;
-                return false;
+                Add(key, value);
             }
-            value = node.Value;
-            return true;
-        }
-
-        public TValue this[TKey key]
-        {
-            get
+            else
             {
-                var node = _dictionary[key];
-                return node.Value;
-            }
-            set
-            {
-                bool found = _dictionary.TryGetValue(key, out var node);
-                if (!found)
-                {
-                    Add(key, value);
-                }
-                else
-                {
-                    node.Value = value;
-                }
+                node.Value = value;
             }
         }
     }

--- a/src/NRules/NRules/Collections/OrderedHashSet.cs
+++ b/src/NRules/NRules/Collections/OrderedHashSet.cs
@@ -1,62 +1,61 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 
-namespace NRules.Collections
+namespace NRules.Collections;
+
+internal class OrderedHashSet<TValue> : IEnumerable<TValue>
 {
-    internal class OrderedHashSet<TValue> : IEnumerable<TValue>
+    private readonly Dictionary<TValue, LinkedListNode<TValue>> _dictionary;
+    private readonly LinkedList<TValue> _linkedList;
+
+    public OrderedHashSet()
+        : this(EqualityComparer<TValue>.Default)
     {
-        private readonly Dictionary<TValue, LinkedListNode<TValue>> _dictionary;
-        private readonly LinkedList<TValue> _linkedList;
+    }
 
-        public OrderedHashSet()
-            : this(EqualityComparer<TValue>.Default)
-        {
-        }
+    public OrderedHashSet(IEqualityComparer<TValue> comparer)
+    {
+        _dictionary = new Dictionary<TValue, LinkedListNode<TValue>>(comparer);
+        _linkedList = new LinkedList<TValue>();
+    }
 
-        public OrderedHashSet(IEqualityComparer<TValue> comparer)
-        {
-            _dictionary = new Dictionary<TValue, LinkedListNode<TValue>>(comparer);
-            _linkedList = new LinkedList<TValue>();
-        }
+    public int Count => _dictionary.Count;
 
-        public int Count => _dictionary.Count;
+    public void Clear()
+    {
+        _linkedList.Clear();
+        _dictionary.Clear();
+    }
 
-        public void Clear()
-        {
-            _linkedList.Clear();
-            _dictionary.Clear();
-        }
+    public bool Remove(TValue item)
+    {
+        bool found = _dictionary.TryGetValue(item, out var node);
+        if (!found) return false;
+        _dictionary.Remove(item);
+        _linkedList.Remove(node);
+        return true;
+    }
 
-        public bool Remove(TValue item)
-        {
-            bool found = _dictionary.TryGetValue(item, out var node);
-            if (!found) return false;
-            _dictionary.Remove(item);
-            _linkedList.Remove(node);
-            return true;
-        }
+    public IEnumerator<TValue> GetEnumerator()
+    {
+        return _linkedList.GetEnumerator();
+    }
 
-        public IEnumerator<TValue> GetEnumerator()
-        {
-            return _linkedList.GetEnumerator();
-        }
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+    public bool Contains(TValue item)
+    {
+        return _dictionary.ContainsKey(item);
+    }
 
-        public bool Contains(TValue item)
-        {
-            return _dictionary.ContainsKey(item);
-        }
-
-        public bool Add(TValue item)
-        {
-            if (_dictionary.ContainsKey(item)) return false;
-            LinkedListNode<TValue> node = _linkedList.AddLast(item);
-            _dictionary.Add(item, node);
-            return true;
-        }
+    public bool Add(TValue item)
+    {
+        if (_dictionary.ContainsKey(item)) return false;
+        LinkedListNode<TValue> node = _linkedList.AddLast(item);
+        _dictionary.Add(item, node);
+        return true;
     }
 }

--- a/src/NRules/NRules/Collections/OrderedPriorityQueue.cs
+++ b/src/NRules/NRules/Collections/OrderedPriorityQueue.cs
@@ -1,78 +1,77 @@
 ﻿using System.Collections.Generic;
 
-namespace NRules.Collections
+namespace NRules.Collections;
+
+internal class OrderedPriorityQueue<TPriority, TValue> : IPriorityQueue<TPriority, TValue>
 {
-    internal class OrderedPriorityQueue<TPriority, TValue> : IPriorityQueue<TPriority, TValue>
+    private readonly PriorityQueue<OrderedKey<TPriority>, TValue> _priorityQueue;
+    private int _insertionOrderCounter = 0;
+
+    public OrderedPriorityQueue()
+        : this(Comparer<TPriority>.Default)
     {
-        private readonly PriorityQueue<OrderedKey<TPriority>, TValue> _priorityQueue;
-        private int _insertionOrderCounter = 0;
+    }
 
-        public OrderedPriorityQueue()
-            : this(Comparer<TPriority>.Default)
+    public OrderedPriorityQueue(IComparer<TPriority> comparer)
+    {
+        var orderComparer = new OrderedKeyComparer<TPriority>(comparer);
+        _priorityQueue = new PriorityQueue<OrderedKey<TPriority>, TValue>(orderComparer);
+    }
+
+    public void Enqueue(TPriority priority, TValue value)
+    {
+        var key = new OrderedKey<TPriority>(priority, _insertionOrderCounter++);
+        _priorityQueue.Enqueue(key, value);
+    }
+
+    public TValue Dequeue()
+    {
+        return _priorityQueue.Dequeue();
+    }
+
+    public TValue Peek()
+    {
+        return _priorityQueue.Peek();
+    }
+
+    public bool IsEmpty => _priorityQueue.IsEmpty;
+
+    public void Clear()
+    {
+        _priorityQueue.Clear();
+    }
+
+    private readonly struct OrderedKey<T>
+    {
+        public T Key { get; }
+        public int Order { get; }
+
+        public OrderedKey(T key, int order)
         {
+            Key = key;
+            Order = order;
+        }
+    }
+
+    private class OrderedKeyComparer<T> : IComparer<OrderedKey<T>>
+    {
+        private readonly IComparer<T> _keyComparer;
+        private readonly IComparer<int> _orderComparer;
+
+        public OrderedKeyComparer(IComparer<T> comparer)
+        {
+            _keyComparer = comparer;
+            _orderComparer = Comparer<int>.Default;
         }
 
-        public OrderedPriorityQueue(IComparer<TPriority> comparer)
+        public int Compare(OrderedKey<T> x, OrderedKey<T> y)
         {
-            var orderComparer = new OrderedKeyComparer<TPriority>(comparer);
-            _priorityQueue = new PriorityQueue<OrderedKey<TPriority>, TValue>(orderComparer);
-        }
-
-        public void Enqueue(TPriority priority, TValue value)
-        {
-            var key = new OrderedKey<TPriority>(priority, _insertionOrderCounter++);
-            _priorityQueue.Enqueue(key, value);
-        }
-
-        public TValue Dequeue()
-        {
-            return _priorityQueue.Dequeue();
-        }
-
-        public TValue Peek()
-        {
-            return _priorityQueue.Peek();
-        }
-
-        public bool IsEmpty => _priorityQueue.IsEmpty;
-
-        public void Clear()
-        {
-            _priorityQueue.Clear();
-        }
-
-        private readonly struct OrderedKey<T>
-        {
-            public T Key { get; }
-            public int Order { get; }
-
-            public OrderedKey(T key, int order)
+            int result = _keyComparer.Compare(x.Key, y.Key);
+            if (result == 0)
             {
-                Key = key;
-                Order = order;
+                result = -1*_orderComparer.Compare(x.Order, y.Order); //min first - FIFO
             }
-        }
-
-        private class OrderedKeyComparer<T> : IComparer<OrderedKey<T>>
-        {
-            private readonly IComparer<T> _keyComparer;
-            private readonly IComparer<int> _orderComparer;
-
-            public OrderedKeyComparer(IComparer<T> comparer)
-            {
-                _keyComparer = comparer;
-                _orderComparer = Comparer<int>.Default;
-            }
-
-            public int Compare(OrderedKey<T> x, OrderedKey<T> y)
-            {
-                int result = _keyComparer.Compare(x.Key, y.Key);
-                if (result == 0)
-                {
-                    result = -1*_orderComparer.Compare(x.Order, y.Order); //min first - FIFO
-                }
-                return result;
-            }
+            return result;
         }
     }
 }

--- a/src/NRules/NRules/Collections/PriorityQueue.cs
+++ b/src/NRules/NRules/Collections/PriorityQueue.cs
@@ -1,132 +1,131 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace NRules.Collections
+namespace NRules.Collections;
+
+internal interface IPriorityQueue<in TPriority, TValue>
 {
-    internal interface IPriorityQueue<in TPriority, TValue>
+    void Enqueue(TPriority priority, TValue value);
+    TValue Dequeue();
+    TValue Peek();
+    bool IsEmpty { get; }
+    void Clear();
+}
+
+internal class PriorityQueue<TPriority, TValue> : IPriorityQueue<TPriority, TValue>
+{
+    private readonly List<KeyValuePair<TPriority, TValue>> _baseHeap;
+    private readonly IComparer<TPriority> _comparer;
+
+    public PriorityQueue()
+        : this(Comparer<TPriority>.Default)
     {
-        void Enqueue(TPriority priority, TValue value);
-        TValue Dequeue();
-        TValue Peek();
-        bool IsEmpty { get; }
-        void Clear();
     }
 
-    internal class PriorityQueue<TPriority, TValue> : IPriorityQueue<TPriority, TValue>
+    public PriorityQueue(IComparer<TPriority> comparer)
     {
-        private readonly List<KeyValuePair<TPriority, TValue>> _baseHeap;
-        private readonly IComparer<TPriority> _comparer;
+        _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+        _baseHeap = new List<KeyValuePair<TPriority, TValue>>();
+    }
 
-        public PriorityQueue()
-            : this(Comparer<TPriority>.Default)
+    public void Enqueue(TPriority priority, TValue value)
+    {
+        Insert(priority, value);
+    }
+
+    public TValue Dequeue()
+    {
+        if (!IsEmpty)
         {
+            var result = _baseHeap[0];
+            DeleteRoot();
+            return result.Value;
         }
+        throw new InvalidOperationException("Priority queue is empty");
+    }
 
-        public PriorityQueue(IComparer<TPriority> comparer)
+    public TValue Peek()
+    {
+        if (!IsEmpty)
         {
-            _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
-            _baseHeap = new List<KeyValuePair<TPriority, TValue>>();
+            return _baseHeap[0].Value;
         }
+        throw new InvalidOperationException("Priority queue is empty");
+    }
 
-        public void Enqueue(TPriority priority, TValue value)
-        {
-            Insert(priority, value);
-        }
+    public bool IsEmpty => _baseHeap.Count == 0;
 
-        public TValue Dequeue()
+    public void Clear()
+    {
+        _baseHeap.Clear();
+    }
+
+    private void ExchangeElements(int pos1, int pos2)
+    {
+        (_baseHeap[pos1], _baseHeap[pos2]) = (_baseHeap[pos2], _baseHeap[pos1]);
+    }
+
+    private void Insert(TPriority priority, TValue value)
+    {
+        var val = new KeyValuePair<TPriority, TValue>(priority, value);
+        _baseHeap.Add(val);
+
+        HeapifyUp();
+    }
+
+    private void HeapifyUp()
+    {
+        int pos = _baseHeap.Count - 1;
+
+        while (pos > 0)
         {
-            if (!IsEmpty)
+            int parentPos = (pos - 1)/2;
+            if (_comparer.Compare(_baseHeap[parentPos].Key, _baseHeap[pos].Key) < 0)
             {
-                var result = _baseHeap[0];
-                DeleteRoot();
-                return result.Value;
+                ExchangeElements(parentPos, pos);
+                pos = parentPos;
             }
-            throw new InvalidOperationException("Priority queue is empty");
+            else break;
         }
+    }
 
-        public TValue Peek()
-        {
-            if (!IsEmpty)
-            {
-                return _baseHeap[0].Value;
-            }
-            throw new InvalidOperationException("Priority queue is empty");
-        }
-
-        public bool IsEmpty => _baseHeap.Count == 0;
-
-        public void Clear()
+    private void DeleteRoot()
+    {
+        if (_baseHeap.Count <= 1)
         {
             _baseHeap.Clear();
+            return;
         }
 
-        private void ExchangeElements(int pos1, int pos2)
+        _baseHeap[0] = _baseHeap[_baseHeap.Count - 1];
+        _baseHeap.RemoveAt(_baseHeap.Count - 1);
+
+        HeapifyDown();
+    }
+
+    private void HeapifyDown()
+    {
+        int pos = 0;
+
+        // heap[i] has children heap[2*i + 1] and heap[2*i + 2] and parent heap[(i-1)/ 2];
+
+        while (true)
         {
-            (_baseHeap[pos1], _baseHeap[pos2]) = (_baseHeap[pos2], _baseHeap[pos1]);
-        }
+            //exchange element with its largest child if heap property is violated
+            int largest = pos;
+            int left = 2*pos + 1;
+            int right = 2*pos + 2;
+            if (left < _baseHeap.Count && _comparer.Compare(_baseHeap[largest].Key, _baseHeap[left].Key) < 0)
+                largest = left;
+            if (right < _baseHeap.Count && _comparer.Compare(_baseHeap[largest].Key, _baseHeap[right].Key) < 0)
+                largest = right;
 
-        private void Insert(TPriority priority, TValue value)
-        {
-            var val = new KeyValuePair<TPriority, TValue>(priority, value);
-            _baseHeap.Add(val);
-
-            HeapifyUp();
-        }
-
-        private void HeapifyUp()
-        {
-            int pos = _baseHeap.Count - 1;
-
-            while (pos > 0)
+            if (largest != pos)
             {
-                int parentPos = (pos - 1)/2;
-                if (_comparer.Compare(_baseHeap[parentPos].Key, _baseHeap[pos].Key) < 0)
-                {
-                    ExchangeElements(parentPos, pos);
-                    pos = parentPos;
-                }
-                else break;
+                ExchangeElements(largest, pos);
+                pos = largest;
             }
-        }
-
-        private void DeleteRoot()
-        {
-            if (_baseHeap.Count <= 1)
-            {
-                _baseHeap.Clear();
-                return;
-            }
-
-            _baseHeap[0] = _baseHeap[_baseHeap.Count - 1];
-            _baseHeap.RemoveAt(_baseHeap.Count - 1);
-
-            HeapifyDown();
-        }
-
-        private void HeapifyDown()
-        {
-            int pos = 0;
-
-            // heap[i] has children heap[2*i + 1] and heap[2*i + 2] and parent heap[(i-1)/ 2];
-
-            while (true)
-            {
-                //exchange element with its largest child if heap property is violated
-                int largest = pos;
-                int left = 2*pos + 1;
-                int right = 2*pos + 2;
-                if (left < _baseHeap.Count && _comparer.Compare(_baseHeap[largest].Key, _baseHeap[left].Key) < 0)
-                    largest = left;
-                if (right < _baseHeap.Count && _comparer.Compare(_baseHeap[largest].Key, _baseHeap[right].Key) < 0)
-                    largest = right;
-
-                if (largest != pos)
-                {
-                    ExchangeElements(largest, pos);
-                    pos = largest;
-                }
-                else break;
-            }
+            else break;
         }
     }
 }

--- a/src/NRules/NRules/CompiledRule.cs
+++ b/src/NRules/NRules/CompiledRule.cs
@@ -3,48 +3,47 @@ using System.Diagnostics;
 using NRules.Rete;
 using NRules.RuleModel;
 
-namespace NRules
+namespace NRules;
+
+internal interface ICompiledRule
 {
-    internal interface ICompiledRule
-    {
-        int Priority { get; }
-        RuleRepeatability Repeatability { get; }
-        IRuleDefinition Definition { get; }
-        IEnumerable<Declaration> Declarations { get; }
-        IEnumerable<IRuleAction> Actions { get; }
-        IRuleFilter Filter { get; }
-        ActionTrigger ActionTriggers { get; }
-        IndexMap FactMap { get; }
-    }
+    int Priority { get; }
+    RuleRepeatability Repeatability { get; }
+    IRuleDefinition Definition { get; }
+    IEnumerable<Declaration> Declarations { get; }
+    IEnumerable<IRuleAction> Actions { get; }
+    IRuleFilter Filter { get; }
+    ActionTrigger ActionTriggers { get; }
+    IndexMap FactMap { get; }
+}
 
-    [DebuggerDisplay("{Definition.Name}")]
-    internal class CompiledRule : ICompiledRule
-    {
-        private readonly List<Declaration> _declarations;
-        private readonly List<IRuleAction> _actions;
+[DebuggerDisplay("{Definition.Name}")]
+internal class CompiledRule : ICompiledRule
+{
+    private readonly List<Declaration> _declarations;
+    private readonly List<IRuleAction> _actions;
 
-        public CompiledRule(IRuleDefinition definition, IEnumerable<Declaration> declarations, IEnumerable<IRuleAction> actions, IRuleFilter filter, IndexMap factMap)
+    public CompiledRule(IRuleDefinition definition, IEnumerable<Declaration> declarations, IEnumerable<IRuleAction> actions, IRuleFilter filter, IndexMap factMap)
+    {
+        Definition = definition;
+        Filter = filter;
+        FactMap = factMap;
+        _declarations = new List<Declaration>(declarations);
+        _actions = new List<IRuleAction>(actions);
+
+        foreach (var ruleAction in _actions)
         {
-            Definition = definition;
-            Filter = filter;
-            FactMap = factMap;
-            _declarations = new List<Declaration>(declarations);
-            _actions = new List<IRuleAction>(actions);
-
-            foreach (var ruleAction in _actions)
-            {
-                ActionTriggers |= ruleAction.Trigger;
-            }
+            ActionTriggers |= ruleAction.Trigger;
         }
-
-        public int Priority => Definition.Priority;
-        public RuleRepeatability Repeatability => Definition.Repeatability;
-        public IRuleDefinition Definition { get; }
-        public IRuleFilter Filter { get; }
-        public ActionTrigger ActionTriggers { get; }
-        public IndexMap FactMap { get; }
-
-        public IEnumerable<Declaration> Declarations => _declarations;
-        public IEnumerable<IRuleAction> Actions => _actions;
     }
+
+    public int Priority => Definition.Priority;
+    public RuleRepeatability Repeatability => Definition.Repeatability;
+    public IRuleDefinition Definition { get; }
+    public IRuleFilter Filter { get; }
+    public ActionTrigger ActionTriggers { get; }
+    public IndexMap FactMap { get; }
+
+    public IEnumerable<Declaration> Declarations => _declarations;
+    public IEnumerable<IRuleAction> Actions => _actions;
 }

--- a/src/NRules/NRules/Diagnostics/AgendaEventArgs.cs
+++ b/src/NRules/NRules/Diagnostics/AgendaEventArgs.cs
@@ -2,35 +2,34 @@ using System;
 using System.Collections.Generic;
 using NRules.RuleModel;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Information related to agenda events.
+/// </summary>
+public class AgendaEventArgs : EventArgs
 {
     /// <summary>
-    /// Information related to agenda events.
+    /// Initializes a new instance of the <c>AgendaEventArgs</c> class.
     /// </summary>
-    public class AgendaEventArgs : EventArgs
+    /// <param name="match">Rule match related to the event.</param>
+    public AgendaEventArgs(IMatch match)
     {
-        /// <summary>
-        /// Initializes a new instance of the <c>AgendaEventArgs</c> class.
-        /// </summary>
-        /// <param name="match">Rule match related to the event.</param>
-        public AgendaEventArgs(IMatch match)
-        {
-            Match = match;
-        }
-
-        /// <summary>
-        /// Rule related to the event.
-        /// </summary>
-        public IRuleDefinition Rule => Match.Rule;
-
-        /// <summary>
-        /// Facts related to the event.
-        /// </summary>
-        public IEnumerable<IFactMatch> Facts => Match.Facts;
-
-        /// <summary>
-        /// Rule match related to the event.
-        /// </summary>
-        public IMatch Match { get; }
+        Match = match;
     }
+
+    /// <summary>
+    /// Rule related to the event.
+    /// </summary>
+    public IRuleDefinition Rule => Match.Rule;
+
+    /// <summary>
+    /// Facts related to the event.
+    /// </summary>
+    public IEnumerable<IFactMatch> Facts => Match.Facts;
+
+    /// <summary>
+    /// Rule match related to the event.
+    /// </summary>
+    public IMatch Match { get; }
 }

--- a/src/NRules/NRules/Diagnostics/AgendaExpressionErrorEventArgs.cs
+++ b/src/NRules/NRules/Diagnostics/AgendaExpressionErrorEventArgs.cs
@@ -3,31 +3,30 @@ using System.Linq.Expressions;
 using NRules.RuleModel;
 using NRules.Utilities;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Information related to error events raised during agenda expression evaluation.
+/// </summary>
+public class AgendaExpressionErrorEventArgs : AgendaExpressionEventArgs, IRecoverableError
 {
     /// <summary>
-    /// Information related to error events raised during agenda expression evaluation.
+    /// Initializes a new instance of the <c>AgendaExpressionErrorEventArgs</c> class.
     /// </summary>
-    public class AgendaExpressionErrorEventArgs : AgendaExpressionEventArgs, IRecoverableError
+    /// <param name="expression">Expression related to the event.</param>
+    /// <param name="exception">Exception related to the event.</param>
+    /// <param name="arguments">Expression arguments.</param>
+    /// <param name="match">Rule match related to the event.</param>
+    public AgendaExpressionErrorEventArgs(Expression expression, Exception exception, object[] arguments, IMatch match)
+        : base(expression, exception, arguments, null, match)
     {
-        /// <summary>
-        /// Initializes a new instance of the <c>AgendaExpressionErrorEventArgs</c> class.
-        /// </summary>
-        /// <param name="expression">Expression related to the event.</param>
-        /// <param name="exception">Exception related to the event.</param>
-        /// <param name="arguments">Expression arguments.</param>
-        /// <param name="match">Rule match related to the event.</param>
-        public AgendaExpressionErrorEventArgs(Expression expression, Exception exception, object[] arguments, IMatch match)
-            : base(expression, exception, arguments, null, match)
-        {
-        }
-        
-        internal AgendaExpressionErrorEventArgs(Expression expression, Exception exception, IArguments arguments, IMatch match)
-            : base(expression, exception, arguments, null, match)
-        {
-        }
-
-        /// <inheritdoc />
-        public bool IsHandled { get; set; }
     }
+    
+    internal AgendaExpressionErrorEventArgs(Expression expression, Exception exception, IArguments arguments, IMatch match)
+        : base(expression, exception, arguments, null, match)
+    {
+    }
+
+    /// <inheritdoc />
+    public bool IsHandled { get; set; }
 }

--- a/src/NRules/NRules/Diagnostics/AgendaExpressionEventArgs.cs
+++ b/src/NRules/NRules/Diagnostics/AgendaExpressionEventArgs.cs
@@ -4,46 +4,45 @@ using System.Linq.Expressions;
 using NRules.RuleModel;
 using NRules.Utilities;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Information related to events raised during agenda expression evaluation.
+/// </summary>
+public class AgendaExpressionEventArgs : ExpressionEventArgs
 {
     /// <summary>
-    /// Information related to events raised during agenda expression evaluation.
+    /// Initializes a new instance of the <c>AgendaExpressionEventArgs</c> class.
     /// </summary>
-    public class AgendaExpressionEventArgs : ExpressionEventArgs
+    /// <param name="expression">Expression related to the event.</param>
+    /// <param name="exception">Exception related to the event.</param>
+    /// <param name="arguments">Expression arguments.</param>
+    /// <param name="result">Expression result.</param>
+    /// <param name="match">Rule match related to the event.</param>
+    public AgendaExpressionEventArgs(Expression expression, Exception exception, object[] arguments, object result, IMatch match)
+        : base(expression, exception, arguments, result)
     {
-        /// <summary>
-        /// Initializes a new instance of the <c>AgendaExpressionEventArgs</c> class.
-        /// </summary>
-        /// <param name="expression">Expression related to the event.</param>
-        /// <param name="exception">Exception related to the event.</param>
-        /// <param name="arguments">Expression arguments.</param>
-        /// <param name="result">Expression result.</param>
-        /// <param name="match">Rule match related to the event.</param>
-        public AgendaExpressionEventArgs(Expression expression, Exception exception, object[] arguments, object result, IMatch match)
-            : base(expression, exception, arguments, result)
-        {
-            Match = match;
-        }
-        
-        internal AgendaExpressionEventArgs(Expression expression, Exception exception, IArguments arguments, object result, IMatch match)
-            : base(expression, exception, arguments, result)
-        {
-            Match = match;
-        }
-
-        /// <summary>
-        /// Rule related to the event.
-        /// </summary>
-        public IRuleDefinition Rule => Match.Rule;
-
-        /// <summary>
-        /// Facts related to the event.
-        /// </summary>
-        public IEnumerable<IFactMatch> Facts => Match.Facts;
-
-        /// <summary>
-        /// Rule match related to the event.
-        /// </summary>
-        public IMatch Match { get; }
+        Match = match;
     }
+    
+    internal AgendaExpressionEventArgs(Expression expression, Exception exception, IArguments arguments, object result, IMatch match)
+        : base(expression, exception, arguments, result)
+    {
+        Match = match;
+    }
+
+    /// <summary>
+    /// Rule related to the event.
+    /// </summary>
+    public IRuleDefinition Rule => Match.Rule;
+
+    /// <summary>
+    /// Facts related to the event.
+    /// </summary>
+    public IEnumerable<IFactMatch> Facts => Match.Facts;
+
+    /// <summary>
+    /// Rule match related to the event.
+    /// </summary>
+    public IMatch Match { get; }
 }

--- a/src/NRules/NRules/Diagnostics/Dgml/Category.cs
+++ b/src/NRules/NRules/Diagnostics/Dgml/Category.cs
@@ -1,25 +1,24 @@
 using System.Xml;
 
-namespace NRules.Diagnostics.Dgml
+namespace NRules.Diagnostics.Dgml;
+
+internal class Category
 {
-    internal class Category
+    public Category(string id)
     {
-        public Category(string id)
-        {
-            Id = id;
-        }
+        Id = id;
+    }
 
-        public string Id { get; }
-        public string Label { get; set; }
-        public string Background { get; set; }
+    public string Id { get; }
+    public string Label { get; set; }
+    public string Background { get; set; }
 
-        public void WriteXml(XmlWriter writer)
-        {
-            writer.WriteStartElement(nameof(Category));
-            writer.WriteAttributeString(nameof(Id), Id);
-            writer.WriteAttributeIfNotNull(nameof(Label), Label);
-            writer.WriteAttributeIfNotNull(nameof(Background), Background);
-            writer.WriteEndElement();
-        }
+    public void WriteXml(XmlWriter writer)
+    {
+        writer.WriteStartElement(nameof(Category));
+        writer.WriteAttributeString(nameof(Id), Id);
+        writer.WriteAttributeIfNotNull(nameof(Label), Label);
+        writer.WriteAttributeIfNotNull(nameof(Background), Background);
+        writer.WriteEndElement();
     }
 }

--- a/src/NRules/NRules/Diagnostics/Dgml/Condition.cs
+++ b/src/NRules/NRules/Diagnostics/Dgml/Condition.cs
@@ -1,16 +1,15 @@
 using System.Xml;
 
-namespace NRules.Diagnostics.Dgml
-{
-    internal class Condition
-    {
-        public string Expression { get; set; }
+namespace NRules.Diagnostics.Dgml;
 
-        public void WriteXml(XmlWriter writer)
-        {
-            writer.WriteStartElement(nameof(Condition));
-            writer.WriteAttributeString(nameof(Expression), Expression);
-            writer.WriteEndElement();
-        }
+internal class Condition
+{
+    public string Expression { get; set; }
+
+    public void WriteXml(XmlWriter writer)
+    {
+        writer.WriteStartElement(nameof(Condition));
+        writer.WriteAttributeString(nameof(Expression), Expression);
+        writer.WriteEndElement();
     }
 }

--- a/src/NRules/NRules/Diagnostics/Dgml/DgmlWriter.cs
+++ b/src/NRules/NRules/Diagnostics/Dgml/DgmlWriter.cs
@@ -5,363 +5,362 @@ using System.Linq;
 using System.Text;
 using System.Xml;
 
-namespace NRules.Diagnostics.Dgml
+namespace NRules.Diagnostics.Dgml;
+
+/// <summary>
+/// Creates a <see href="https://en.wikipedia.org/wiki/DGML">DGML</see> document writer
+/// that can be used to serialize a Rete graph for a given rules session into XML.
+/// </summary>
+public class DgmlWriter
 {
+    private readonly ReteGraph _schema;
+
+    private HashSet<string> _ruleNameFilter;
+    private IMetricsProvider _metricsProvider;
+    
     /// <summary>
-    /// Creates a <see href="https://en.wikipedia.org/wiki/DGML">DGML</see> document writer
-    /// that can be used to serialize a Rete graph for a given rules session into XML.
+    /// Sets a filter for Rete graph nodes, such that only nodes that belong to the given
+    /// set of rules is serialized, along with the connecting graph edges.
     /// </summary>
-    public class DgmlWriter
+    /// <param name="ruleNames">Set of rules to use as a filter, or <c>null</c> to remove the filter.</param>
+    public void SetRuleFilter(IEnumerable<string> ruleNames)
     {
-        private readonly ReteGraph _schema;
+        _ruleNameFilter = ruleNames == null ? null : new HashSet<string>(ruleNames);
+    }
 
-        private HashSet<string> _ruleNameFilter;
-        private IMetricsProvider _metricsProvider;
-        
-        /// <summary>
-        /// Sets a filter for Rete graph nodes, such that only nodes that belong to the given
-        /// set of rules is serialized, along with the connecting graph edges.
-        /// </summary>
-        /// <param name="ruleNames">Set of rules to use as a filter, or <c>null</c> to remove the filter.</param>
-        public void SetRuleFilter(IEnumerable<string> ruleNames)
+    /// <summary>
+    /// Sets the <see cref="IMetricsProvider"/> to retrieve performance metrics for serialized nodes,
+    /// so that performance metrics are included in the output.
+    /// </summary>
+    /// <param name="metricsProvider">Performance metrics provider or <c>null</c> to exclude performance metrics from the output.</param>
+    public void SetMetricsProvider(IMetricsProvider metricsProvider)
+    {
+        _metricsProvider = metricsProvider;
+    }
+
+    /// <summary>
+    /// Creates an instance of a <c>DgmlWriter</c> for a given session schema.
+    /// </summary>
+    /// <param name="schema">Rules session schema.</param>
+    public DgmlWriter(ReteGraph schema)
+    {
+        _schema = schema;
+    }
+
+    /// <summary>
+    /// Writes DGML graph representing a given rules session to a file.
+    /// </summary>
+    /// <param name="fileName">File to write the session to.</param>
+    public void WriteAllText(string fileName)
+    {
+        string contents = GetContents();
+        File.WriteAllText(fileName, contents);
+    }
+
+    /// <summary>
+    /// Writes DGML graph representing a given rules session to the provided
+    /// <see cref="XmlWriter"/>.
+    /// </summary>
+    /// <param name="writer"><see cref="XmlWriter"/> to write the session to.</param>
+    public void WriteXml(XmlWriter writer)
+    {
+        var graph = CreateGraph();
+        writer.WriteStartDocument();
+        graph.WriteXml(writer);
+        writer.WriteEndDocument();
+    }
+
+    /// <summary>
+    /// Retrieves a serialized DGML graph as an XML string.
+    /// </summary>
+    /// <returns>Contents of the serialized DGML graph as an XML string.</returns>
+    public string GetContents()
+    {
+        using var stringWriter = new Utf8StringWriter();
+        var xmlWriter = new XmlTextWriter(stringWriter);
+        xmlWriter.Formatting = Formatting.Indented;
+        WriteXml(xmlWriter);
+        var contents = stringWriter.ToString();
+        return contents;
+    }
+
+    private DirectedGraph CreateGraph()
+    {
+        var graph = new DirectedGraph {Title = "ReteNetwork"};
+        var reteNodes = FilterNodes(_ruleNameFilter, _schema.Nodes).ToArray();
+        var reteLinks = FilterLinks(reteNodes, _schema.Links).ToArray();
+
+        graph.Nodes.AddRange(CreateNodes(reteNodes));
+        graph.Links.AddRange(CreateLinks(reteLinks));
+        graph.Categories.AddRange(CreateNodeTypeCategories());
+
+        if (_metricsProvider != null)
+            AddPerformanceMetrics(graph);
+        else
+            graph.Styles.AddRange(CreateSchemaStyles());
+
+        return graph;
+    }
+
+    private IEnumerable<Node> CreateNodes(IEnumerable<ReteNode> reteNodes)
+    {
+        foreach (var reteNode in reteNodes)
         {
-            _ruleNameFilter = ruleNames == null ? null : new HashSet<string>(ruleNames);
-        }
-
-        /// <summary>
-        /// Sets the <see cref="IMetricsProvider"/> to retrieve performance metrics for serialized nodes,
-        /// so that performance metrics are included in the output.
-        /// </summary>
-        /// <param name="metricsProvider">Performance metrics provider or <c>null</c> to exclude performance metrics from the output.</param>
-        public void SetMetricsProvider(IMetricsProvider metricsProvider)
-        {
-            _metricsProvider = metricsProvider;
-        }
-
-        /// <summary>
-        /// Creates an instance of a <c>DgmlWriter</c> for a given session schema.
-        /// </summary>
-        /// <param name="schema">Rules session schema.</param>
-        public DgmlWriter(ReteGraph schema)
-        {
-            _schema = schema;
-        }
-
-        /// <summary>
-        /// Writes DGML graph representing a given rules session to a file.
-        /// </summary>
-        /// <param name="fileName">File to write the session to.</param>
-        public void WriteAllText(string fileName)
-        {
-            string contents = GetContents();
-            File.WriteAllText(fileName, contents);
-        }
-
-        /// <summary>
-        /// Writes DGML graph representing a given rules session to the provided
-        /// <see cref="XmlWriter"/>.
-        /// </summary>
-        /// <param name="writer"><see cref="XmlWriter"/> to write the session to.</param>
-        public void WriteXml(XmlWriter writer)
-        {
-            var graph = CreateGraph();
-            writer.WriteStartDocument();
-            graph.WriteXml(writer);
-            writer.WriteEndDocument();
-        }
-
-        /// <summary>
-        /// Retrieves a serialized DGML graph as an XML string.
-        /// </summary>
-        /// <returns>Contents of the serialized DGML graph as an XML string.</returns>
-        public string GetContents()
-        {
-            using var stringWriter = new Utf8StringWriter();
-            var xmlWriter = new XmlTextWriter(stringWriter);
-            xmlWriter.Formatting = Formatting.Indented;
-            WriteXml(xmlWriter);
-            var contents = stringWriter.ToString();
-            return contents;
-        }
-
-        private DirectedGraph CreateGraph()
-        {
-            var graph = new DirectedGraph {Title = "ReteNetwork"};
-            var reteNodes = FilterNodes(_ruleNameFilter, _schema.Nodes).ToArray();
-            var reteLinks = FilterLinks(reteNodes, _schema.Links).ToArray();
-
-            graph.Nodes.AddRange(CreateNodes(reteNodes));
-            graph.Links.AddRange(CreateLinks(reteLinks));
-            graph.Categories.AddRange(CreateNodeTypeCategories());
-
-            if (_metricsProvider != null)
-                AddPerformanceMetrics(graph);
-            else
-                graph.Styles.AddRange(CreateSchemaStyles());
-
-            return graph;
-        }
-
-        private IEnumerable<Node> CreateNodes(IEnumerable<ReteNode> reteNodes)
-        {
-            foreach (var reteNode in reteNodes)
+            var node = new Node(Id(reteNode))
             {
-                var node = new Node(Id(reteNode))
-                {
-                    Label = GetNodeLabel(reteNode),
-                    Category = reteNode.NodeType.ToString()
-                };
+                Label = GetNodeLabel(reteNode),
+                Category = reteNode.NodeType.ToString()
+            };
 
-                node.Properties.Add("OutputType", reteNode.OutputType?.ToString());
+            node.Properties.Add("OutputType", reteNode.OutputType?.ToString());
 
-                foreach (var valueGroup in reteNode.Properties.GroupBy(x => x.Key, x => x.Value))
-                {
-                    var key = valueGroup.Key;
-                    var value = string.Join("; ", valueGroup);
-                    node.Properties.Add($"{reteNode.NodeType}{key}", value);
-                }
-
-                foreach (var expressionGroup in reteNode.Expressions.GroupBy(x => x.Key, x => x.Value))
-                {
-                    var key = expressionGroup.Key;
-                    var value = string.Join("; ", expressionGroup);
-                    node.Properties.Add($"{reteNode.NodeType}{key}", value);
-                }
-
-                if (reteNode.Rules.Length > 0)
-                {
-                    var value = string.Join("; ", reteNode.Rules.Select(x => x.Name));
-                    node.Properties.Add("Rule", value);
-                }
-
-                if (reteNode.Rules.Length > 1)
-                {
-                    node.Properties.Add("Shared", true);
-                }
-
-                yield return node;
-            }
-        }
-
-        private IEnumerable<Link> CreateLinks(IEnumerable<ReteLink> reteLinks)
-        {
-            foreach (var linkInfo in reteLinks)
+            foreach (var valueGroup in reteNode.Properties.GroupBy(x => x.Key, x => x.Value))
             {
-                yield return new Link(Id(linkInfo.Source), Id(linkInfo.Target));
-            }
-        }
-
-        private static IEnumerable<Category> CreateNodeTypeCategories()
-        {
-            foreach (var nodeType in Enum.GetValues(typeof(NodeType)))
-            {
-                yield return new Category($"{nodeType}");
-            }
-        }
-        
-        private static string GetNodeLabel(ReteNode reteNode)
-        {
-            var labelParts = new List<object>();
-            labelParts.Add(reteNode.NodeType.ToString());
-            switch (reteNode.NodeType)
-            {
-                case NodeType.Type:
-                    labelParts.Add(reteNode.OutputType.Name);
-                    break;
-                case NodeType.Selection:
-                    labelParts.AddRange(reteNode.Expressions.Select(x => $"{x.Value.Body}"));
-                    break;
-                case NodeType.Join:
-                    labelParts.AddRange(reteNode.Expressions.Select(x => $"{x.Value.Body}"));
-                    break;
-                case NodeType.Aggregate:
-                    labelParts.Add(reteNode.Properties.Single(x => x.Key == "Name").Value);
-                    labelParts.AddRange(reteNode.Expressions.Select(x => $"{x.Key}={x.Value.Body}"));
-                    break;
-                case NodeType.Binding:
-                    labelParts.AddRange(reteNode.Expressions.Select(x => $"{x.Value.Body}"));
-                    break;
-                case NodeType.Rule:
-                    labelParts.Add(reteNode.Rules.Single().Name);
-                    labelParts.AddRange(reteNode.Expressions.Select(x => $"{x.Key}={x.Value.Body}"));
-                    break;
+                var key = valueGroup.Key;
+                var value = string.Join("; ", valueGroup);
+                node.Properties.Add($"{reteNode.NodeType}{key}", value);
             }
 
-            var label = string.Join("\n", labelParts);
-            return label;
-        }
-
-        private void AddPerformanceMetrics(DirectedGraph graph)
-        {
-            long maxDuration = 0;
-            long minDuration = Int64.MaxValue;
-            var reteNodeLookup = _schema.Nodes.ToDictionary(Id);
-            foreach (var node in graph.Nodes)
+            foreach (var expressionGroup in reteNode.Expressions.GroupBy(x => x.Key, x => x.Value))
             {
-                var reteNode = reteNodeLookup[node.Id];
-                INodeMetrics nodeMetrics = _metricsProvider?.FindByNodeId(reteNode.Id);
-                if (nodeMetrics == null) continue;
-
-                var totalDuration = nodeMetrics.InsertDurationMilliseconds +
-                                    nodeMetrics.UpdateDurationMilliseconds +
-                                    nodeMetrics.RetractDurationMilliseconds;
-                maxDuration = Math.Max(maxDuration, totalDuration);
-                minDuration = Math.Min(minDuration, totalDuration);
-                AddPerformanceMetrics(node, nodeMetrics);
+                var key = expressionGroup.Key;
+                var value = string.Join("; ", expressionGroup);
+                node.Properties.Add($"{reteNode.NodeType}{key}", value);
             }
 
-            minDuration = Math.Min(minDuration, maxDuration);
-
-            graph.Properties.AddRange(
-                CreatePerformanceProperties());
-            graph.Styles.AddRange(
-                CreatePerformanceStyles(minDuration, maxDuration));
-        }
-
-        private IEnumerable<Property> CreatePerformanceProperties()
-        {
-            yield return new Property("PerfElementCount") {DataType = "System.Int32"};
-            yield return new Property("PerfInsertInputCount") {DataType = "System.Int32"};
-            yield return new Property("PerfInsertOutputCount") {DataType = "System.Int32"};
-            yield return new Property("PerfUpdateInputCount") {DataType = "System.Int32"};
-            yield return new Property("PerfUpdateOutputCount") {DataType = "System.Int32"};
-            yield return new Property("PerfRetractInputCount") {DataType = "System.Int32"};
-            yield return new Property("PerfRetractOutputCount") {DataType = "System.Int32"};
-            yield return new Property("PerfInsertDurationMilliseconds") {DataType = "System.Int64"};
-            yield return new Property("PerfUpdateDurationMilliseconds") {DataType = "System.Int64"};
-            yield return new Property("PerfRetractDurationMilliseconds") {DataType = "System.Int64"};
-            yield return new Property("PerfTotalInputCount") {DataType = "System.Int32"};
-            yield return new Property("PerfTotalOutputCount") {DataType = "System.Int32"};
-            yield return new Property("PerfTotalDurationMilliseconds") {DataType = "System.Int64"};
-        }
-
-        private void AddPerformanceMetrics(Node node, INodeMetrics nodeMetrics)
-        {
-            if (nodeMetrics.ElementCount.HasValue)
-                node.Properties.Add("PerfElementCount", nodeMetrics.ElementCount.Value);
-            node.Properties.Add("PerfInsertInputCount", nodeMetrics.InsertInputCount);
-            node.Properties.Add("PerfInsertOutputCount", nodeMetrics.InsertOutputCount);
-            node.Properties.Add("PerfUpdateInputCount", nodeMetrics.UpdateInputCount);
-            node.Properties.Add("PerfUpdateOutputCount", nodeMetrics.UpdateOutputCount);
-            node.Properties.Add("PerfRetractInputCount", nodeMetrics.RetractInputCount);
-            node.Properties.Add("PerfRetractOutputCount", nodeMetrics.RetractOutputCount);
-            node.Properties.Add("PerfInsertDurationMilliseconds", nodeMetrics.InsertDurationMilliseconds);
-            node.Properties.Add("PerfUpdateDurationMilliseconds", nodeMetrics.UpdateDurationMilliseconds);
-            node.Properties.Add("PerfRetractDurationMilliseconds", nodeMetrics.RetractDurationMilliseconds);
-            node.Properties.Add("PerfTotalInputCount",
-                nodeMetrics.InsertInputCount + nodeMetrics.UpdateInputCount + nodeMetrics.RetractInputCount);
-            node.Properties.Add("PerfTotalOutputCount",
-                nodeMetrics.InsertOutputCount + nodeMetrics.UpdateOutputCount + nodeMetrics.RetractOutputCount);
-            node.Properties.Add("PerfTotalDurationMilliseconds",
-                nodeMetrics.InsertDurationMilliseconds + nodeMetrics.UpdateDurationMilliseconds + nodeMetrics.RetractDurationMilliseconds);
-        }
-        
-        private IEnumerable<Style> CreatePerformanceStyles(long minDuration, long maxDuration)
-        {
-            var flowProperty = "Source.PerfTotalOutputCount";
-            yield return new Style("Link")
-                .Condition($"{flowProperty} > 0")
-                .Setter(nameof(Link.StrokeThickness),
-                    expression: $"Math.Min(25,Math.Max(1,Math.Log({flowProperty},2)))");
-
-            var countProperty = "PerfElementCount";
-            yield return new Style("Node")
-                .Condition($"HasCategory('{NodeType.AlphaMemory}') or HasCategory('{NodeType.BetaMemory}')")
-                .Condition($"{countProperty} > 0")
-                .Setter(nameof(Node.FontSize),
-                    expression: $"Math.Min(72,Math.Max(8,8+4*Math.Log({countProperty},2)))");
-
-            var durationProperty = "PerfTotalDurationMilliseconds";
-            maxDuration = Math.Max(50, maxDuration);
-            long basis = maxDuration - minDuration;
-            int maxRed = 200;
-            int maxGreen = 200;
-            int maxBlue = 200;
-            yield return new Style("Node")
-                .Condition($"{durationProperty} > 0")
-                .Setter(nameof(Node.Foreground), value: "Black")
-                .Setter(nameof(Node.Background), 
-                    expression: $"Color.FromRgb({maxRed},({maxGreen}*({maxDuration}-{durationProperty}))/{basis},({maxBlue}*({maxDuration}-{durationProperty}))/{basis})");
-            yield return new Style("Node")
-                .Setter(nameof(Node.Foreground), value: "Black")
-                .Setter(nameof(Node.Background),
-                    expression: $"Color.FromRgb({maxRed},{maxGreen},{maxBlue})");
-        }
-        
-        private IEnumerable<Style> CreateSchemaStyles()
-        {
-            yield return new Style(nameof(Node))
-                .HasCategory($"{NodeType.Root}")
-                .Setter(nameof(Node.Background), value: "Black");
-            yield return new Style(nameof(Node))
-                .HasCategory($"{NodeType.Dummy}")
-                .Setter(nameof(Node.Background), value: "Silver");
-            yield return new Style(nameof(Node))
-                .HasCategory($"{NodeType.Type}")
-                .Setter(nameof(Node.Background), value: "Orange");
-            yield return new Style(nameof(Node))
-                .HasCategory($"{NodeType.Selection}")
-                .Setter(nameof(Node.Background), value: "Blue");
-            yield return new Style(nameof(Node))
-                .HasCategory($"{NodeType.AlphaMemory}")
-                .Setter(nameof(Node.Background), value: "Red");
-            yield return new Style(nameof(Node))
-                .HasCategory($"{NodeType.Join}")
-                .Setter(nameof(Node.Background), value: "Blue");
-            yield return new Style(nameof(Node))
-                .HasCategory($"{NodeType.Not}")
-                .Setter(nameof(Node.Background), value: "Brown");
-            yield return new Style(nameof(Node))
-                .HasCategory($"{NodeType.Exists}")
-                .Setter(nameof(Node.Background), value: "Brown");
-            yield return new Style(nameof(Node))
-                .HasCategory($"{NodeType.Aggregate}")
-                .Setter(nameof(Node.Background), value: "Brown");
-            yield return new Style(nameof(Node))
-                .HasCategory($"{NodeType.Adapter}")
-                .Setter(nameof(Node.Background), value: "Silver");
-            yield return new Style(nameof(Node))
-                .HasCategory($"{NodeType.BetaMemory}")
-                .Setter(nameof(Node.Background), value: "Green");
-            yield return new Style(nameof(Node))
-                .HasCategory($"{NodeType.Binding}")
-                .Setter(nameof(Node.Background), value: "LightBlue");
-            yield return new Style(nameof(Node))
-                .HasCategory($"{NodeType.Rule}")
-                .Setter(nameof(Node.Background), value: "Purple");
-        }
-        
-        private static IEnumerable<ReteNode> FilterNodes(HashSet<string> ruleNameFilter, ReteNode[] reteNodes)
-        {
-            foreach (var reteNode in reteNodes)
+            if (reteNode.Rules.Length > 0)
             {
-                if (ruleNameFilter == null ||
-                    reteNode.NodeType == NodeType.Root ||
-                    reteNode.NodeType == NodeType.Dummy ||
-                    reteNode.Rules.Any(r => ruleNameFilter.Contains(r.Name)))
-                    yield return reteNode;
+                var value = string.Join("; ", reteNode.Rules.Select(x => x.Name));
+                node.Properties.Add("Rule", value);
             }
-        }
 
-        private static IEnumerable<ReteLink> FilterLinks(ReteNode[] reteNodes, ReteLink[] reteLinks)
-        {
-            var reteNodeIds = new HashSet<int>(reteNodes.Select(x => x.Id));
-            foreach (var reteLink in reteLinks)
+            if (reteNode.Rules.Length > 1)
             {
-                if (reteNodeIds.Contains(reteLink.Source.Id) &&
-                    reteNodeIds.Contains(reteLink.Target.Id))
-                    yield return reteLink;
+                node.Properties.Add("Shared", true);
             }
+
+            yield return node;
+        }
+    }
+
+    private IEnumerable<Link> CreateLinks(IEnumerable<ReteLink> reteLinks)
+    {
+        foreach (var linkInfo in reteLinks)
+        {
+            yield return new Link(Id(linkInfo.Source), Id(linkInfo.Target));
+        }
+    }
+
+    private static IEnumerable<Category> CreateNodeTypeCategories()
+    {
+        foreach (var nodeType in Enum.GetValues(typeof(NodeType)))
+        {
+            yield return new Category($"{nodeType}");
+        }
+    }
+    
+    private static string GetNodeLabel(ReteNode reteNode)
+    {
+        var labelParts = new List<object>();
+        labelParts.Add(reteNode.NodeType.ToString());
+        switch (reteNode.NodeType)
+        {
+            case NodeType.Type:
+                labelParts.Add(reteNode.OutputType.Name);
+                break;
+            case NodeType.Selection:
+                labelParts.AddRange(reteNode.Expressions.Select(x => $"{x.Value.Body}"));
+                break;
+            case NodeType.Join:
+                labelParts.AddRange(reteNode.Expressions.Select(x => $"{x.Value.Body}"));
+                break;
+            case NodeType.Aggregate:
+                labelParts.Add(reteNode.Properties.Single(x => x.Key == "Name").Value);
+                labelParts.AddRange(reteNode.Expressions.Select(x => $"{x.Key}={x.Value.Body}"));
+                break;
+            case NodeType.Binding:
+                labelParts.AddRange(reteNode.Expressions.Select(x => $"{x.Value.Body}"));
+                break;
+            case NodeType.Rule:
+                labelParts.Add(reteNode.Rules.Single().Name);
+                labelParts.AddRange(reteNode.Expressions.Select(x => $"{x.Key}={x.Value.Body}"));
+                break;
         }
 
-        private string Id(ReteNode reteNode)
+        var label = string.Join("\n", labelParts);
+        return label;
+    }
+
+    private void AddPerformanceMetrics(DirectedGraph graph)
+    {
+        long maxDuration = 0;
+        long minDuration = Int64.MaxValue;
+        var reteNodeLookup = _schema.Nodes.ToDictionary(Id);
+        foreach (var node in graph.Nodes)
         {
-            return $"{reteNode.Id}";
+            var reteNode = reteNodeLookup[node.Id];
+            INodeMetrics nodeMetrics = _metricsProvider?.FindByNodeId(reteNode.Id);
+            if (nodeMetrics == null) continue;
+
+            var totalDuration = nodeMetrics.InsertDurationMilliseconds +
+                                nodeMetrics.UpdateDurationMilliseconds +
+                                nodeMetrics.RetractDurationMilliseconds;
+            maxDuration = Math.Max(maxDuration, totalDuration);
+            minDuration = Math.Min(minDuration, totalDuration);
+            AddPerformanceMetrics(node, nodeMetrics);
         }
 
-        private class Utf8StringWriter : StringWriter
+        minDuration = Math.Min(minDuration, maxDuration);
+
+        graph.Properties.AddRange(
+            CreatePerformanceProperties());
+        graph.Styles.AddRange(
+            CreatePerformanceStyles(minDuration, maxDuration));
+    }
+
+    private IEnumerable<Property> CreatePerformanceProperties()
+    {
+        yield return new Property("PerfElementCount") {DataType = "System.Int32"};
+        yield return new Property("PerfInsertInputCount") {DataType = "System.Int32"};
+        yield return new Property("PerfInsertOutputCount") {DataType = "System.Int32"};
+        yield return new Property("PerfUpdateInputCount") {DataType = "System.Int32"};
+        yield return new Property("PerfUpdateOutputCount") {DataType = "System.Int32"};
+        yield return new Property("PerfRetractInputCount") {DataType = "System.Int32"};
+        yield return new Property("PerfRetractOutputCount") {DataType = "System.Int32"};
+        yield return new Property("PerfInsertDurationMilliseconds") {DataType = "System.Int64"};
+        yield return new Property("PerfUpdateDurationMilliseconds") {DataType = "System.Int64"};
+        yield return new Property("PerfRetractDurationMilliseconds") {DataType = "System.Int64"};
+        yield return new Property("PerfTotalInputCount") {DataType = "System.Int32"};
+        yield return new Property("PerfTotalOutputCount") {DataType = "System.Int32"};
+        yield return new Property("PerfTotalDurationMilliseconds") {DataType = "System.Int64"};
+    }
+
+    private void AddPerformanceMetrics(Node node, INodeMetrics nodeMetrics)
+    {
+        if (nodeMetrics.ElementCount.HasValue)
+            node.Properties.Add("PerfElementCount", nodeMetrics.ElementCount.Value);
+        node.Properties.Add("PerfInsertInputCount", nodeMetrics.InsertInputCount);
+        node.Properties.Add("PerfInsertOutputCount", nodeMetrics.InsertOutputCount);
+        node.Properties.Add("PerfUpdateInputCount", nodeMetrics.UpdateInputCount);
+        node.Properties.Add("PerfUpdateOutputCount", nodeMetrics.UpdateOutputCount);
+        node.Properties.Add("PerfRetractInputCount", nodeMetrics.RetractInputCount);
+        node.Properties.Add("PerfRetractOutputCount", nodeMetrics.RetractOutputCount);
+        node.Properties.Add("PerfInsertDurationMilliseconds", nodeMetrics.InsertDurationMilliseconds);
+        node.Properties.Add("PerfUpdateDurationMilliseconds", nodeMetrics.UpdateDurationMilliseconds);
+        node.Properties.Add("PerfRetractDurationMilliseconds", nodeMetrics.RetractDurationMilliseconds);
+        node.Properties.Add("PerfTotalInputCount",
+            nodeMetrics.InsertInputCount + nodeMetrics.UpdateInputCount + nodeMetrics.RetractInputCount);
+        node.Properties.Add("PerfTotalOutputCount",
+            nodeMetrics.InsertOutputCount + nodeMetrics.UpdateOutputCount + nodeMetrics.RetractOutputCount);
+        node.Properties.Add("PerfTotalDurationMilliseconds",
+            nodeMetrics.InsertDurationMilliseconds + nodeMetrics.UpdateDurationMilliseconds + nodeMetrics.RetractDurationMilliseconds);
+    }
+    
+    private IEnumerable<Style> CreatePerformanceStyles(long minDuration, long maxDuration)
+    {
+        var flowProperty = "Source.PerfTotalOutputCount";
+        yield return new Style("Link")
+            .Condition($"{flowProperty} > 0")
+            .Setter(nameof(Link.StrokeThickness),
+                expression: $"Math.Min(25,Math.Max(1,Math.Log({flowProperty},2)))");
+
+        var countProperty = "PerfElementCount";
+        yield return new Style("Node")
+            .Condition($"HasCategory('{NodeType.AlphaMemory}') or HasCategory('{NodeType.BetaMemory}')")
+            .Condition($"{countProperty} > 0")
+            .Setter(nameof(Node.FontSize),
+                expression: $"Math.Min(72,Math.Max(8,8+4*Math.Log({countProperty},2)))");
+
+        var durationProperty = "PerfTotalDurationMilliseconds";
+        maxDuration = Math.Max(50, maxDuration);
+        long basis = maxDuration - minDuration;
+        int maxRed = 200;
+        int maxGreen = 200;
+        int maxBlue = 200;
+        yield return new Style("Node")
+            .Condition($"{durationProperty} > 0")
+            .Setter(nameof(Node.Foreground), value: "Black")
+            .Setter(nameof(Node.Background), 
+                expression: $"Color.FromRgb({maxRed},({maxGreen}*({maxDuration}-{durationProperty}))/{basis},({maxBlue}*({maxDuration}-{durationProperty}))/{basis})");
+        yield return new Style("Node")
+            .Setter(nameof(Node.Foreground), value: "Black")
+            .Setter(nameof(Node.Background),
+                expression: $"Color.FromRgb({maxRed},{maxGreen},{maxBlue})");
+    }
+    
+    private IEnumerable<Style> CreateSchemaStyles()
+    {
+        yield return new Style(nameof(Node))
+            .HasCategory($"{NodeType.Root}")
+            .Setter(nameof(Node.Background), value: "Black");
+        yield return new Style(nameof(Node))
+            .HasCategory($"{NodeType.Dummy}")
+            .Setter(nameof(Node.Background), value: "Silver");
+        yield return new Style(nameof(Node))
+            .HasCategory($"{NodeType.Type}")
+            .Setter(nameof(Node.Background), value: "Orange");
+        yield return new Style(nameof(Node))
+            .HasCategory($"{NodeType.Selection}")
+            .Setter(nameof(Node.Background), value: "Blue");
+        yield return new Style(nameof(Node))
+            .HasCategory($"{NodeType.AlphaMemory}")
+            .Setter(nameof(Node.Background), value: "Red");
+        yield return new Style(nameof(Node))
+            .HasCategory($"{NodeType.Join}")
+            .Setter(nameof(Node.Background), value: "Blue");
+        yield return new Style(nameof(Node))
+            .HasCategory($"{NodeType.Not}")
+            .Setter(nameof(Node.Background), value: "Brown");
+        yield return new Style(nameof(Node))
+            .HasCategory($"{NodeType.Exists}")
+            .Setter(nameof(Node.Background), value: "Brown");
+        yield return new Style(nameof(Node))
+            .HasCategory($"{NodeType.Aggregate}")
+            .Setter(nameof(Node.Background), value: "Brown");
+        yield return new Style(nameof(Node))
+            .HasCategory($"{NodeType.Adapter}")
+            .Setter(nameof(Node.Background), value: "Silver");
+        yield return new Style(nameof(Node))
+            .HasCategory($"{NodeType.BetaMemory}")
+            .Setter(nameof(Node.Background), value: "Green");
+        yield return new Style(nameof(Node))
+            .HasCategory($"{NodeType.Binding}")
+            .Setter(nameof(Node.Background), value: "LightBlue");
+        yield return new Style(nameof(Node))
+            .HasCategory($"{NodeType.Rule}")
+            .Setter(nameof(Node.Background), value: "Purple");
+    }
+    
+    private static IEnumerable<ReteNode> FilterNodes(HashSet<string> ruleNameFilter, ReteNode[] reteNodes)
+    {
+        foreach (var reteNode in reteNodes)
         {
-            public override Encoding Encoding => Encoding.UTF8;
+            if (ruleNameFilter == null ||
+                reteNode.NodeType == NodeType.Root ||
+                reteNode.NodeType == NodeType.Dummy ||
+                reteNode.Rules.Any(r => ruleNameFilter.Contains(r.Name)))
+                yield return reteNode;
         }
+    }
+
+    private static IEnumerable<ReteLink> FilterLinks(ReteNode[] reteNodes, ReteLink[] reteLinks)
+    {
+        var reteNodeIds = new HashSet<int>(reteNodes.Select(x => x.Id));
+        foreach (var reteLink in reteLinks)
+        {
+            if (reteNodeIds.Contains(reteLink.Source.Id) &&
+                reteNodeIds.Contains(reteLink.Target.Id))
+                yield return reteLink;
+        }
+    }
+
+    private string Id(ReteNode reteNode)
+    {
+        return $"{reteNode.Id}";
+    }
+
+    private class Utf8StringWriter : StringWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
     }
 }

--- a/src/NRules/NRules/Diagnostics/Dgml/DirectedGraph.cs
+++ b/src/NRules/NRules/Diagnostics/Dgml/DirectedGraph.cs
@@ -2,62 +2,61 @@
 using System.Linq;
 using System.Xml;
 
-namespace NRules.Diagnostics.Dgml
+namespace NRules.Diagnostics.Dgml;
+
+internal class DirectedGraph
 {
-    internal class DirectedGraph
+    private const string Namespace = "http://schemas.microsoft.com/vs/2009/dgml";
+
+    public string Title { get; set; }
+    public string Background { get; set; }
+
+    public List<Node> Nodes { get; set; } = new();
+    public List<Link> Links { get; set; } = new();
+    public List<Category> Categories { get; set; } = new();
+    public List<Style> Styles { get; set; } = new();
+    public List<Property> Properties { get; set; } = new();
+
+    public void WriteXml(XmlWriter writer)
     {
-        private const string Namespace = "http://schemas.microsoft.com/vs/2009/dgml";
+        writer.WriteStartElement(nameof(DirectedGraph), Namespace);
+        writer.WriteAttributeIfNotNull(nameof(Title), Title);
+        writer.WriteAttributeIfNotNull(nameof(Background), Background);
 
-        public string Title { get; set; }
-        public string Background { get; set; }
+        writer.WriteStartElement(nameof(Nodes));
+        foreach (var node in Nodes)
+            node.WriteXml(writer);
+        writer.WriteEndElement();
 
-        public List<Node> Nodes { get; set; } = new();
-        public List<Link> Links { get; set; } = new();
-        public List<Category> Categories { get; set; } = new();
-        public List<Style> Styles { get; set; } = new();
-        public List<Property> Properties { get; set; } = new();
+        writer.WriteStartElement(nameof(Links));
+        foreach (var link in Links)
+            link.WriteXml(writer);
+        writer.WriteEndElement();
 
-        public void WriteXml(XmlWriter writer)
+        if (Categories.Any())
         {
-            writer.WriteStartElement(nameof(DirectedGraph), Namespace);
-            writer.WriteAttributeIfNotNull(nameof(Title), Title);
-            writer.WriteAttributeIfNotNull(nameof(Background), Background);
-
-            writer.WriteStartElement(nameof(Nodes));
-            foreach (var node in Nodes)
-                node.WriteXml(writer);
-            writer.WriteEndElement();
-
-            writer.WriteStartElement(nameof(Links));
-            foreach (var link in Links)
-                link.WriteXml(writer);
-            writer.WriteEndElement();
-
-            if (Categories.Any())
-            {
-                writer.WriteStartElement(nameof(Categories));
-                foreach (var category in Categories)
-                    category.WriteXml(writer);
-                writer.WriteEndElement();
-            }
-
-            if (Styles.Any())
-            {
-                writer.WriteStartElement(nameof(Styles));
-                foreach (var style in Styles)
-                    style.WriteXml(writer);
-                writer.WriteEndElement();
-            }
-
-            if (Properties.Any())
-            {
-                writer.WriteStartElement(nameof(Properties));
-                foreach (var property in Properties)
-                    property.WriteXml(writer);
-                writer.WriteEndElement();
-            }
-
+            writer.WriteStartElement(nameof(Categories));
+            foreach (var category in Categories)
+                category.WriteXml(writer);
             writer.WriteEndElement();
         }
+
+        if (Styles.Any())
+        {
+            writer.WriteStartElement(nameof(Styles));
+            foreach (var style in Styles)
+                style.WriteXml(writer);
+            writer.WriteEndElement();
+        }
+
+        if (Properties.Any())
+        {
+            writer.WriteStartElement(nameof(Properties));
+            foreach (var property in Properties)
+                property.WriteXml(writer);
+            writer.WriteEndElement();
+        }
+
+        writer.WriteEndElement();
     }
 }

--- a/src/NRules/NRules/Diagnostics/Dgml/Link.cs
+++ b/src/NRules/NRules/Diagnostics/Dgml/Link.cs
@@ -1,35 +1,34 @@
 using System.Collections.Generic;
 using System.Xml;
 
-namespace NRules.Diagnostics.Dgml
+namespace NRules.Diagnostics.Dgml;
+
+internal class Link
 {
-    internal class Link
+    public Link(string source, string target)
     {
-        public Link(string source, string target)
-        {
-            Source = source;
-            Target = target;
-        }
+        Source = source;
+        Target = target;
+    }
 
-        public string Source { get; }
-        public string Target { get; }
-        public string Category { get; set; }
-        public string Label { get; set; }
-        public string Description { get; set; }
-        public string StrokeThickness { get; set; }
-        public Dictionary<string, object> Properties { get; } = new();
+    public string Source { get; }
+    public string Target { get; }
+    public string Category { get; set; }
+    public string Label { get; set; }
+    public string Description { get; set; }
+    public string StrokeThickness { get; set; }
+    public Dictionary<string, object> Properties { get; } = new();
 
-        public void WriteXml(XmlWriter writer)
-        {
-            writer.WriteStartElement(nameof(Link));
-            writer.WriteAttributeString(nameof(Source), Source);
-            writer.WriteAttributeString(nameof(Target), Target);
-            writer.WriteAttributeIfNotNull(nameof(Category), Category);
-            writer.WriteAttributeIfNotNull(nameof(Label), Label);
-            writer.WriteAttributeIfNotNull(nameof(Description), Description);
-            writer.WriteAttributeIfNotNull(nameof(StrokeThickness), StrokeThickness);
-            writer.WriteProperties(Properties);
-            writer.WriteEndElement();
-        }
+    public void WriteXml(XmlWriter writer)
+    {
+        writer.WriteStartElement(nameof(Link));
+        writer.WriteAttributeString(nameof(Source), Source);
+        writer.WriteAttributeString(nameof(Target), Target);
+        writer.WriteAttributeIfNotNull(nameof(Category), Category);
+        writer.WriteAttributeIfNotNull(nameof(Label), Label);
+        writer.WriteAttributeIfNotNull(nameof(Description), Description);
+        writer.WriteAttributeIfNotNull(nameof(StrokeThickness), StrokeThickness);
+        writer.WriteProperties(Properties);
+        writer.WriteEndElement();
     }
 }

--- a/src/NRules/NRules/Diagnostics/Dgml/Node.cs
+++ b/src/NRules/NRules/Diagnostics/Dgml/Node.cs
@@ -1,40 +1,39 @@
 using System.Collections.Generic;
 using System.Xml;
 
-namespace NRules.Diagnostics.Dgml
+namespace NRules.Diagnostics.Dgml;
+
+internal class Node
 {
-    internal class Node
+    public Node(string id)
     {
-        public Node(string id)
-        {
-            Id = id;
-        }
+        Id = id;
+    }
 
-        public string Id { get; }
-        public string Label { get; set; }
-        public string Category { get; set; }
-        public string Group { get; set; }
-        public string Description { get; set; }
-        public string Reference { get; set; }
-        public string Background { get; set; }
-        public string Foreground { get; set; }
-        public string FontSize { get; set; }
-        public Dictionary<string, object> Properties { get; } = new();
+    public string Id { get; }
+    public string Label { get; set; }
+    public string Category { get; set; }
+    public string Group { get; set; }
+    public string Description { get; set; }
+    public string Reference { get; set; }
+    public string Background { get; set; }
+    public string Foreground { get; set; }
+    public string FontSize { get; set; }
+    public Dictionary<string, object> Properties { get; } = new();
 
-        public void WriteXml(XmlWriter writer)
-        {
-            writer.WriteStartElement(nameof(Node));
-            writer.WriteAttributeString(nameof(Id), Id);
-            writer.WriteAttributeIfNotNull(nameof(Label), Label);
-            writer.WriteAttributeIfNotNull(nameof(Category), Category);
-            writer.WriteAttributeIfNotNull(nameof(Group), Group);
-            writer.WriteAttributeIfNotNull(nameof(Description), Description);
-            writer.WriteAttributeIfNotNull(nameof(Reference), Reference);
-            writer.WriteAttributeIfNotNull(nameof(Background), Background);
-            writer.WriteAttributeIfNotNull(nameof(Foreground), Foreground);
-            writer.WriteAttributeIfNotNull(nameof(FontSize), FontSize);
-            writer.WriteProperties(Properties);
-            writer.WriteEndElement();
-        }
+    public void WriteXml(XmlWriter writer)
+    {
+        writer.WriteStartElement(nameof(Node));
+        writer.WriteAttributeString(nameof(Id), Id);
+        writer.WriteAttributeIfNotNull(nameof(Label), Label);
+        writer.WriteAttributeIfNotNull(nameof(Category), Category);
+        writer.WriteAttributeIfNotNull(nameof(Group), Group);
+        writer.WriteAttributeIfNotNull(nameof(Description), Description);
+        writer.WriteAttributeIfNotNull(nameof(Reference), Reference);
+        writer.WriteAttributeIfNotNull(nameof(Background), Background);
+        writer.WriteAttributeIfNotNull(nameof(Foreground), Foreground);
+        writer.WriteAttributeIfNotNull(nameof(FontSize), FontSize);
+        writer.WriteProperties(Properties);
+        writer.WriteEndElement();
     }
 }

--- a/src/NRules/NRules/Diagnostics/Dgml/Property.cs
+++ b/src/NRules/NRules/Diagnostics/Dgml/Property.cs
@@ -1,27 +1,26 @@
 using System.Xml;
 
-namespace NRules.Diagnostics.Dgml
+namespace NRules.Diagnostics.Dgml;
+
+internal class Property
 {
-    internal class Property
+    public Property(string id)
     {
-        public Property(string id)
-        {
-            Id = id;
-        }
+        Id = id;
+    }
 
-        public string Id { get; }
-        public string DataType { get; set; }
-        public string Label { get; set; }
-        public string Description { get; set; }
+    public string Id { get; }
+    public string DataType { get; set; }
+    public string Label { get; set; }
+    public string Description { get; set; }
 
-        public void WriteXml(XmlWriter writer)
-        {
-            writer.WriteStartElement(nameof(Property));
-            writer.WriteAttributeString(nameof(Id), Id);
-            writer.WriteAttributeString(nameof(DataType), DataType);
-            writer.WriteAttributeIfNotNull(nameof(Label), Label);
-            writer.WriteAttributeIfNotNull(nameof(Description), Description);
-            writer.WriteEndElement();
-        }
+    public void WriteXml(XmlWriter writer)
+    {
+        writer.WriteStartElement(nameof(Property));
+        writer.WriteAttributeString(nameof(Id), Id);
+        writer.WriteAttributeString(nameof(DataType), DataType);
+        writer.WriteAttributeIfNotNull(nameof(Label), Label);
+        writer.WriteAttributeIfNotNull(nameof(Description), Description);
+        writer.WriteEndElement();
     }
 }

--- a/src/NRules/NRules/Diagnostics/Dgml/Setter.cs
+++ b/src/NRules/NRules/Diagnostics/Dgml/Setter.cs
@@ -1,20 +1,19 @@
 using System.Xml;
 
-namespace NRules.Diagnostics.Dgml
-{
-    internal class Setter
-    {
-        public string Property { get; set; }
-        public string Value { get; set; }
-        public string Expression{ get; set; }
+namespace NRules.Diagnostics.Dgml;
 
-        public void WriteXml(XmlWriter writer)
-        {
-            writer.WriteStartElement(nameof(Setter));
-            writer.WriteAttributeString(nameof(Property), Property);
-            writer.WriteAttributeIfNotNull(nameof(Value), Value);
-            writer.WriteAttributeIfNotNull(nameof(Expression), Expression);
-            writer.WriteEndElement();
-        }
+internal class Setter
+{
+    public string Property { get; set; }
+    public string Value { get; set; }
+    public string Expression{ get; set; }
+
+    public void WriteXml(XmlWriter writer)
+    {
+        writer.WriteStartElement(nameof(Setter));
+        writer.WriteAttributeString(nameof(Property), Property);
+        writer.WriteAttributeIfNotNull(nameof(Value), Value);
+        writer.WriteAttributeIfNotNull(nameof(Expression), Expression);
+        writer.WriteEndElement();
     }
 }

--- a/src/NRules/NRules/Diagnostics/Dgml/Style.cs
+++ b/src/NRules/NRules/Diagnostics/Dgml/Style.cs
@@ -1,54 +1,53 @@
 using System.Collections.Generic;
 using System.Xml;
 
-namespace NRules.Diagnostics.Dgml
+namespace NRules.Diagnostics.Dgml;
+
+internal class Style
 {
-    internal class Style
+    public Style(string targetType)
     {
-        public Style(string targetType)
-        {
-            TargetType = targetType;
-        }
+        TargetType = targetType;
+    }
 
-        public string TargetType { get; }
-        public string GroupLabel { get; set; }
-        public string ValueLabel { get; set; }
-        public List<Condition> Conditions { get; set; } = new();
-        public List<Setter> Setters { get; set; } = new();
+    public string TargetType { get; }
+    public string GroupLabel { get; set; }
+    public string ValueLabel { get; set; }
+    public List<Condition> Conditions { get; set; } = new();
+    public List<Setter> Setters { get; set; } = new();
 
-        public Style HasCategory(string category)
-        {
-            return Condition($"HasCategory('{category}')");
-        }
+    public Style HasCategory(string category)
+    {
+        return Condition($"HasCategory('{category}')");
+    }
 
-        public Style Condition(string expression)
-        {
-            var condition = new Condition {Expression = expression};
-            Conditions.Add(condition);
-            return this;
-        }
+    public Style Condition(string expression)
+    {
+        var condition = new Condition {Expression = expression};
+        Conditions.Add(condition);
+        return this;
+    }
 
-        public Style Setter(string property, string value = null, string expression = null)
-        {
-            var setter = new Setter {Property = property, Value = value, Expression = expression};
-            Setters.Add(setter);
-            return this;
-        }
+    public Style Setter(string property, string value = null, string expression = null)
+    {
+        var setter = new Setter {Property = property, Value = value, Expression = expression};
+        Setters.Add(setter);
+        return this;
+    }
 
-        public void WriteXml(XmlWriter writer)
-        {
-            writer.WriteStartElement(nameof(Style));
-            writer.WriteAttributeString(nameof(TargetType), TargetType);
-            writer.WriteAttributeIfNotNull(nameof(GroupLabel), GroupLabel);
-            writer.WriteAttributeIfNotNull(nameof(ValueLabel), ValueLabel);
+    public void WriteXml(XmlWriter writer)
+    {
+        writer.WriteStartElement(nameof(Style));
+        writer.WriteAttributeString(nameof(TargetType), TargetType);
+        writer.WriteAttributeIfNotNull(nameof(GroupLabel), GroupLabel);
+        writer.WriteAttributeIfNotNull(nameof(ValueLabel), ValueLabel);
 
-            foreach (var condition in Conditions)
-                condition.WriteXml(writer);
+        foreach (var condition in Conditions)
+            condition.WriteXml(writer);
 
-            foreach (var setter in Setters)
-                setter.WriteXml(writer);
+        foreach (var setter in Setters)
+            setter.WriteXml(writer);
 
-            writer.WriteEndElement();
-        }
+        writer.WriteEndElement();
     }
 }

--- a/src/NRules/NRules/Diagnostics/Dgml/XmlWriterExtensions.cs
+++ b/src/NRules/NRules/Diagnostics/Dgml/XmlWriterExtensions.cs
@@ -1,23 +1,22 @@
 ﻿using System.Collections.Generic;
 using System.Xml;
 
-namespace NRules.Diagnostics.Dgml
-{
-    internal static class XmlWriterExtensions
-    {
-        public static void WriteAttributeIfNotNull(this XmlWriter writer, string localName, object value)
-        {
-            if (value != null)
-                writer.WriteAttributeString(localName, value.ToString());
-        }
+namespace NRules.Diagnostics.Dgml;
 
-        public static void WriteProperties(this XmlWriter writer, Dictionary<string, object> properties)
+internal static class XmlWriterExtensions
+{
+    public static void WriteAttributeIfNotNull(this XmlWriter writer, string localName, object value)
+    {
+        if (value != null)
+            writer.WriteAttributeString(localName, value.ToString());
+    }
+
+    public static void WriteProperties(this XmlWriter writer, Dictionary<string, object> properties)
+    {
+        foreach (var property in properties)
         {
-            foreach (var property in properties)
-            {
-                if (property.Value != null)
-                    writer.WriteAttributeString(property.Key, property.Value.ToString());
-            }
+            if (property.Value != null)
+                writer.WriteAttributeString(property.Key, property.Value.ToString());
         }
     }
 }

--- a/src/NRules/NRules/Diagnostics/EventAggregator.cs
+++ b/src/NRules/NRules/Diagnostics/EventAggregator.cs
@@ -7,410 +7,409 @@ using NRules.Rete;
 using NRules.Utilities;
 using Tuple = NRules.Rete.Tuple;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Provider of rules session events.
+/// </summary>
+public interface IEventProvider
 {
     /// <summary>
-    /// Provider of rules session events.
+    /// Raised when a new rule activation is created.
+    /// A new activation is created when a new set of facts (tuple) matches a rule.
+    /// The activation is placed on the agenda and becomes a candidate for firing.
     /// </summary>
-    public interface IEventProvider
+    event EventHandler<AgendaEventArgs> ActivationCreatedEvent;
+
+    /// <summary>
+    /// Raised when an existing activation is updated.
+    /// An activation is updated when a previously matching set of facts (tuple) is updated 
+    /// and it still matches the rule.
+    /// The activation is updated in the agenda and remains a candidate for firing.
+    /// </summary>
+    event EventHandler<AgendaEventArgs> ActivationUpdatedEvent;
+
+    /// <summary>
+    /// Raised when an existing activation is deleted.
+    /// An activation is deleted when a previously matching set of facts (tuple) no longer 
+    /// matches the rule due to updated or retracted facts.
+    /// The activation is removed from the agenda and is no longer a candidate for firing.
+    /// </summary>
+    event EventHandler<AgendaEventArgs> ActivationDeletedEvent;
+
+    /// <summary>
+    /// Raised before a rule is about to fire.
+    /// </summary>
+    event EventHandler<AgendaEventArgs> RuleFiringEvent;
+
+    /// <summary>
+    /// Raised after a rule has fired and all its actions executed.
+    /// </summary>
+    event EventHandler<AgendaEventArgs> RuleFiredEvent;
+
+    /// <summary>
+    /// Raised before a new fact is inserted into working memory.
+    /// </summary>
+    event EventHandler<WorkingMemoryEventArgs> FactInsertingEvent;
+
+    /// <summary>
+    /// Raised after a new fact is inserted into working memory.
+    /// </summary>
+    event EventHandler<WorkingMemoryEventArgs> FactInsertedEvent;
+
+    /// <summary>
+    /// Raised before an existing fact is updated in the working memory.
+    /// </summary>
+    event EventHandler<WorkingMemoryEventArgs> FactUpdatingEvent;
+
+    /// <summary>
+    /// Raised after an existing fact is updated in the working memory.
+    /// </summary>
+    event EventHandler<WorkingMemoryEventArgs> FactUpdatedEvent;
+
+    /// <summary>
+    /// Raised before an existing fact is retracted from the working memory.
+    /// </summary>
+    event EventHandler<WorkingMemoryEventArgs> FactRetractingEvent;
+
+    /// <summary>
+    /// Raised after an existing fact is retracted from the working memory.
+    /// </summary>
+    event EventHandler<WorkingMemoryEventArgs> FactRetractedEvent;
+
+    /// <summary>
+    /// Raised when left-hand side expression is evaluated.
+    /// This event is raised on both, successful expression evaluations, and on exceptions.
+    /// </summary>
+    event EventHandler<LhsExpressionEventArgs> LhsExpressionEvaluatedEvent;
+
+    /// <summary>
+    /// Raised when left-hand side expression evaluation threw an exception.
+    /// Gives observer of the event control over handling of the exception.
+    /// </summary>
+    event EventHandler<LhsExpressionErrorEventArgs> LhsExpressionFailedEvent;
+
+    /// <summary>
+    /// Raised when agenda expression is evaluated.
+    /// This event is raised on both, successful expression evaluations, and on exceptions.
+    /// </summary>
+    /// <seealso cref="IAgendaFilter"/>
+    event EventHandler<AgendaExpressionEventArgs> AgendaExpressionEvaluatedEvent;
+
+    /// <summary>
+    /// Raised when agenda expression evaluation threw an exception.
+    /// Gives observer of the event control over handling of the exception.
+    /// </summary>
+    /// <seealso cref="IAgendaFilter"/>
+    event EventHandler<AgendaExpressionErrorEventArgs> AgendaExpressionFailedEvent;
+
+    /// <summary>
+    /// Raised when right-hand side expression is evaluated.
+    /// This event is raised on both, successful expression evaluations, and on exceptions.
+    /// </summary>
+    /// <seealso cref="IActionInterceptor"/>
+    event EventHandler<RhsExpressionEventArgs> RhsExpressionEvaluatedEvent;
+
+    /// <summary>
+    /// Raised when right-hand side expression evaluation threw an exception.
+    /// Gives observer of the event control over handling of the exception.
+    /// </summary>
+    /// <seealso cref="IActionInterceptor"/>
+    event EventHandler<RhsExpressionErrorEventArgs> RhsExpressionFailedEvent;
+}
+
+internal interface IEventAggregator : IEventProvider
+{
+    bool TraceEnabled { get; }
+    void RaiseActivationCreated(ISession session, Activation activation);
+    void RaiseActivationUpdated(ISession session, Activation activation);
+    void RaiseActivationDeleted(ISession session, Activation activation);
+    void RaiseRuleFiring(ISession session, Activation activation);
+    void RaiseRuleFired(ISession session, Activation activation);
+    void RaiseFactInserting(ISession session, Fact fact);
+    void RaiseFactInserted(ISession session, Fact fact);
+    void RaiseFactUpdating(ISession session, Fact fact);
+    void RaiseFactUpdated(ISession session, Fact fact);
+    void RaiseFactRetracting(ISession session, Fact fact);
+    void RaiseFactRetracted(ISession session, Fact fact);
+    void RaiseLhsExpressionFailed(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Tuple tuple, Fact fact, NodeInfo nodeInfo, ref bool isHandled);
+    void RaiseLhsExpressionEvaluated(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, object result, Tuple tuple, Fact fact, NodeInfo nodeInfo);
+    void RaiseAgendaExpressionFailed(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Activation activation, ref bool isHandled);
+    void RaiseAgendaExpressionEvaluated(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, object result, Activation activation);
+    void RaiseRhsExpressionFailed(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Activation activation, ref bool isHandled);
+    void RaiseRhsExpressionEvaluated(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Activation activation);
+}
+
+internal class EventAggregator : IEventAggregator
+{
+    private readonly IEventAggregator _parent;
+    private volatile int _traceSubscriberCount = 0;
+
+    private event EventHandler<LhsExpressionEventArgs> LhsExpressionEvaluatedEvent;
+    private event EventHandler<AgendaExpressionEventArgs> AgendaExpressionEvaluatedEvent;
+    private event EventHandler<RhsExpressionEventArgs> RhsExpressionEvaluatedEvent;
+
+    public event EventHandler<AgendaEventArgs> ActivationCreatedEvent;
+    public event EventHandler<AgendaEventArgs> ActivationUpdatedEvent;
+    public event EventHandler<AgendaEventArgs> ActivationDeletedEvent;
+    public event EventHandler<AgendaEventArgs> RuleFiringEvent;
+    public event EventHandler<AgendaEventArgs> RuleFiredEvent;
+    public event EventHandler<WorkingMemoryEventArgs> FactInsertingEvent;
+    public event EventHandler<WorkingMemoryEventArgs> FactInsertedEvent;
+    public event EventHandler<WorkingMemoryEventArgs> FactUpdatingEvent;
+    public event EventHandler<WorkingMemoryEventArgs> FactUpdatedEvent;
+    public event EventHandler<WorkingMemoryEventArgs> FactRetractingEvent;
+    public event EventHandler<WorkingMemoryEventArgs> FactRetractedEvent;
+    public event EventHandler<LhsExpressionErrorEventArgs> LhsExpressionFailedEvent;
+    public event EventHandler<AgendaExpressionErrorEventArgs> AgendaExpressionFailedEvent;
+    public event EventHandler<RhsExpressionErrorEventArgs> RhsExpressionFailedEvent;
+
+    event EventHandler<LhsExpressionEventArgs> IEventProvider.LhsExpressionEvaluatedEvent
     {
-        /// <summary>
-        /// Raised when a new rule activation is created.
-        /// A new activation is created when a new set of facts (tuple) matches a rule.
-        /// The activation is placed on the agenda and becomes a candidate for firing.
-        /// </summary>
-        event EventHandler<AgendaEventArgs> ActivationCreatedEvent;
-
-        /// <summary>
-        /// Raised when an existing activation is updated.
-        /// An activation is updated when a previously matching set of facts (tuple) is updated 
-        /// and it still matches the rule.
-        /// The activation is updated in the agenda and remains a candidate for firing.
-        /// </summary>
-        event EventHandler<AgendaEventArgs> ActivationUpdatedEvent;
-
-        /// <summary>
-        /// Raised when an existing activation is deleted.
-        /// An activation is deleted when a previously matching set of facts (tuple) no longer 
-        /// matches the rule due to updated or retracted facts.
-        /// The activation is removed from the agenda and is no longer a candidate for firing.
-        /// </summary>
-        event EventHandler<AgendaEventArgs> ActivationDeletedEvent;
-
-        /// <summary>
-        /// Raised before a rule is about to fire.
-        /// </summary>
-        event EventHandler<AgendaEventArgs> RuleFiringEvent;
-
-        /// <summary>
-        /// Raised after a rule has fired and all its actions executed.
-        /// </summary>
-        event EventHandler<AgendaEventArgs> RuleFiredEvent;
-
-        /// <summary>
-        /// Raised before a new fact is inserted into working memory.
-        /// </summary>
-        event EventHandler<WorkingMemoryEventArgs> FactInsertingEvent;
-
-        /// <summary>
-        /// Raised after a new fact is inserted into working memory.
-        /// </summary>
-        event EventHandler<WorkingMemoryEventArgs> FactInsertedEvent;
-
-        /// <summary>
-        /// Raised before an existing fact is updated in the working memory.
-        /// </summary>
-        event EventHandler<WorkingMemoryEventArgs> FactUpdatingEvent;
-
-        /// <summary>
-        /// Raised after an existing fact is updated in the working memory.
-        /// </summary>
-        event EventHandler<WorkingMemoryEventArgs> FactUpdatedEvent;
-
-        /// <summary>
-        /// Raised before an existing fact is retracted from the working memory.
-        /// </summary>
-        event EventHandler<WorkingMemoryEventArgs> FactRetractingEvent;
-
-        /// <summary>
-        /// Raised after an existing fact is retracted from the working memory.
-        /// </summary>
-        event EventHandler<WorkingMemoryEventArgs> FactRetractedEvent;
-
-        /// <summary>
-        /// Raised when left-hand side expression is evaluated.
-        /// This event is raised on both, successful expression evaluations, and on exceptions.
-        /// </summary>
-        event EventHandler<LhsExpressionEventArgs> LhsExpressionEvaluatedEvent;
-
-        /// <summary>
-        /// Raised when left-hand side expression evaluation threw an exception.
-        /// Gives observer of the event control over handling of the exception.
-        /// </summary>
-        event EventHandler<LhsExpressionErrorEventArgs> LhsExpressionFailedEvent;
-
-        /// <summary>
-        /// Raised when agenda expression is evaluated.
-        /// This event is raised on both, successful expression evaluations, and on exceptions.
-        /// </summary>
-        /// <seealso cref="IAgendaFilter"/>
-        event EventHandler<AgendaExpressionEventArgs> AgendaExpressionEvaluatedEvent;
-
-        /// <summary>
-        /// Raised when agenda expression evaluation threw an exception.
-        /// Gives observer of the event control over handling of the exception.
-        /// </summary>
-        /// <seealso cref="IAgendaFilter"/>
-        event EventHandler<AgendaExpressionErrorEventArgs> AgendaExpressionFailedEvent;
-
-        /// <summary>
-        /// Raised when right-hand side expression is evaluated.
-        /// This event is raised on both, successful expression evaluations, and on exceptions.
-        /// </summary>
-        /// <seealso cref="IActionInterceptor"/>
-        event EventHandler<RhsExpressionEventArgs> RhsExpressionEvaluatedEvent;
-
-        /// <summary>
-        /// Raised when right-hand side expression evaluation threw an exception.
-        /// Gives observer of the event control over handling of the exception.
-        /// </summary>
-        /// <seealso cref="IActionInterceptor"/>
-        event EventHandler<RhsExpressionErrorEventArgs> RhsExpressionFailedEvent;
+        add
+        {
+            Interlocked.Increment(ref _traceSubscriberCount);
+            LhsExpressionEvaluatedEvent += value;
+        }
+        remove
+        {
+            LhsExpressionEvaluatedEvent -= value;
+            Interlocked.Decrement(ref _traceSubscriberCount);
+        }
     }
 
-    internal interface IEventAggregator : IEventProvider
+    event EventHandler<AgendaExpressionEventArgs> IEventProvider.AgendaExpressionEvaluatedEvent
     {
-        bool TraceEnabled { get; }
-        void RaiseActivationCreated(ISession session, Activation activation);
-        void RaiseActivationUpdated(ISession session, Activation activation);
-        void RaiseActivationDeleted(ISession session, Activation activation);
-        void RaiseRuleFiring(ISession session, Activation activation);
-        void RaiseRuleFired(ISession session, Activation activation);
-        void RaiseFactInserting(ISession session, Fact fact);
-        void RaiseFactInserted(ISession session, Fact fact);
-        void RaiseFactUpdating(ISession session, Fact fact);
-        void RaiseFactUpdated(ISession session, Fact fact);
-        void RaiseFactRetracting(ISession session, Fact fact);
-        void RaiseFactRetracted(ISession session, Fact fact);
-        void RaiseLhsExpressionFailed(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Tuple tuple, Fact fact, NodeInfo nodeInfo, ref bool isHandled);
-        void RaiseLhsExpressionEvaluated(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, object result, Tuple tuple, Fact fact, NodeInfo nodeInfo);
-        void RaiseAgendaExpressionFailed(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Activation activation, ref bool isHandled);
-        void RaiseAgendaExpressionEvaluated(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, object result, Activation activation);
-        void RaiseRhsExpressionFailed(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Activation activation, ref bool isHandled);
-        void RaiseRhsExpressionEvaluated(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Activation activation);
+        add
+        {
+            Interlocked.Increment(ref _traceSubscriberCount);
+            AgendaExpressionEvaluatedEvent += value;
+        }
+        remove
+        {
+            AgendaExpressionEvaluatedEvent -= value;
+            Interlocked.Decrement(ref _traceSubscriberCount);
+        }
     }
 
-    internal class EventAggregator : IEventAggregator
+    event EventHandler<RhsExpressionEventArgs> IEventProvider.RhsExpressionEvaluatedEvent
     {
-        private readonly IEventAggregator _parent;
-        private volatile int _traceSubscriberCount = 0;
-
-        private event EventHandler<LhsExpressionEventArgs> LhsExpressionEvaluatedEvent;
-        private event EventHandler<AgendaExpressionEventArgs> AgendaExpressionEvaluatedEvent;
-        private event EventHandler<RhsExpressionEventArgs> RhsExpressionEvaluatedEvent;
-
-        public event EventHandler<AgendaEventArgs> ActivationCreatedEvent;
-        public event EventHandler<AgendaEventArgs> ActivationUpdatedEvent;
-        public event EventHandler<AgendaEventArgs> ActivationDeletedEvent;
-        public event EventHandler<AgendaEventArgs> RuleFiringEvent;
-        public event EventHandler<AgendaEventArgs> RuleFiredEvent;
-        public event EventHandler<WorkingMemoryEventArgs> FactInsertingEvent;
-        public event EventHandler<WorkingMemoryEventArgs> FactInsertedEvent;
-        public event EventHandler<WorkingMemoryEventArgs> FactUpdatingEvent;
-        public event EventHandler<WorkingMemoryEventArgs> FactUpdatedEvent;
-        public event EventHandler<WorkingMemoryEventArgs> FactRetractingEvent;
-        public event EventHandler<WorkingMemoryEventArgs> FactRetractedEvent;
-        public event EventHandler<LhsExpressionErrorEventArgs> LhsExpressionFailedEvent;
-        public event EventHandler<AgendaExpressionErrorEventArgs> AgendaExpressionFailedEvent;
-        public event EventHandler<RhsExpressionErrorEventArgs> RhsExpressionFailedEvent;
-
-        event EventHandler<LhsExpressionEventArgs> IEventProvider.LhsExpressionEvaluatedEvent
+        add
         {
-            add
-            {
-                Interlocked.Increment(ref _traceSubscriberCount);
-                LhsExpressionEvaluatedEvent += value;
-            }
-            remove
-            {
-                LhsExpressionEvaluatedEvent -= value;
-                Interlocked.Decrement(ref _traceSubscriberCount);
-            }
+            Interlocked.Increment(ref _traceSubscriberCount);
+            RhsExpressionEvaluatedEvent += value;
         }
-
-        event EventHandler<AgendaExpressionEventArgs> IEventProvider.AgendaExpressionEvaluatedEvent
+        remove
         {
-            add
-            {
-                Interlocked.Increment(ref _traceSubscriberCount);
-                AgendaExpressionEvaluatedEvent += value;
-            }
-            remove
-            {
-                AgendaExpressionEvaluatedEvent -= value;
-                Interlocked.Decrement(ref _traceSubscriberCount);
-            }
+            RhsExpressionEvaluatedEvent -= value;
+            Interlocked.Decrement(ref _traceSubscriberCount);
         }
+    }
 
-        event EventHandler<RhsExpressionEventArgs> IEventProvider.RhsExpressionEvaluatedEvent
-        {
-            add
-            {
-                Interlocked.Increment(ref _traceSubscriberCount);
-                RhsExpressionEvaluatedEvent += value;
-            }
-            remove
-            {
-                RhsExpressionEvaluatedEvent -= value;
-                Interlocked.Decrement(ref _traceSubscriberCount);
-            }
-        }
+    public EventAggregator()
+    {
+    }
 
-        public EventAggregator()
-        {
-        }
+    public EventAggregator(IEventAggregator eventAggregator)
+    {
+        _parent = eventAggregator;
+    }
 
-        public EventAggregator(IEventAggregator eventAggregator)
-        {
-            _parent = eventAggregator;
-        }
+    public bool TraceEnabled => _traceSubscriberCount > 0 || (_parent != null && _parent.TraceEnabled);
 
-        public bool TraceEnabled => _traceSubscriberCount > 0 || (_parent != null && _parent.TraceEnabled);
+    public void RaiseActivationCreated(ISession session, Activation activation)
+    {
+        var handler = ActivationCreatedEvent;
+        if (handler != null)
+        {
+            var @event = new AgendaEventArgs(activation);
+            handler(session, @event);
+        }
+        _parent?.RaiseActivationCreated(session, activation);
+    }
 
-        public void RaiseActivationCreated(ISession session, Activation activation)
+    public void RaiseActivationUpdated(ISession session, Activation activation)
+    {
+        var handler = ActivationUpdatedEvent;
+        if (handler != null)
         {
-            var handler = ActivationCreatedEvent;
-            if (handler != null)
-            {
-                var @event = new AgendaEventArgs(activation);
-                handler(session, @event);
-            }
-            _parent?.RaiseActivationCreated(session, activation);
+            var @event = new AgendaEventArgs(activation);
+            handler(session, @event);
         }
+        _parent?.RaiseActivationUpdated(session, activation);
+    }
 
-        public void RaiseActivationUpdated(ISession session, Activation activation)
+    public void RaiseActivationDeleted(ISession session, Activation activation)
+    {
+        var handler = ActivationDeletedEvent;
+        if (handler != null)
         {
-            var handler = ActivationUpdatedEvent;
-            if (handler != null)
-            {
-                var @event = new AgendaEventArgs(activation);
-                handler(session, @event);
-            }
-            _parent?.RaiseActivationUpdated(session, activation);
+            var @event = new AgendaEventArgs(activation);
+            handler(session, @event);
         }
+        _parent?.RaiseActivationDeleted(session, activation);
+    }
 
-        public void RaiseActivationDeleted(ISession session, Activation activation)
+    public void RaiseRuleFiring(ISession session, Activation activation)
+    {
+        var handler = RuleFiringEvent;
+        if (handler != null)
         {
-            var handler = ActivationDeletedEvent;
-            if (handler != null)
-            {
-                var @event = new AgendaEventArgs(activation);
-                handler(session, @event);
-            }
-            _parent?.RaiseActivationDeleted(session, activation);
+            var @event = new AgendaEventArgs(activation);
+            handler(session, @event);
         }
+        _parent?.RaiseRuleFiring(session, activation);
+    }
 
-        public void RaiseRuleFiring(ISession session, Activation activation)
+    public void RaiseRuleFired(ISession session, Activation activation)
+    {
+        var handler = RuleFiredEvent;
+        if (handler != null)
         {
-            var handler = RuleFiringEvent;
-            if (handler != null)
-            {
-                var @event = new AgendaEventArgs(activation);
-                handler(session, @event);
-            }
-            _parent?.RaiseRuleFiring(session, activation);
+            var @event = new AgendaEventArgs(activation);
+            handler(session, @event);
         }
+        _parent?.RaiseRuleFired(session, activation);
+    }
 
-        public void RaiseRuleFired(ISession session, Activation activation)
+    public void RaiseFactInserting(ISession session, Fact fact)
+    {
+        var handler = FactInsertingEvent;
+        if (handler != null)
         {
-            var handler = RuleFiredEvent;
-            if (handler != null)
-            {
-                var @event = new AgendaEventArgs(activation);
-                handler(session, @event);
-            }
-            _parent?.RaiseRuleFired(session, activation);
+            var @event = new WorkingMemoryEventArgs(fact);
+            handler(session, @event);
         }
+        _parent?.RaiseFactInserting(session, fact);
+    }
 
-        public void RaiseFactInserting(ISession session, Fact fact)
+    public void RaiseFactInserted(ISession session, Fact fact)
+    {
+        var handler = FactInsertedEvent;
+        if (handler != null)
         {
-            var handler = FactInsertingEvent;
-            if (handler != null)
-            {
-                var @event = new WorkingMemoryEventArgs(fact);
-                handler(session, @event);
-            }
-            _parent?.RaiseFactInserting(session, fact);
+            var @event = new WorkingMemoryEventArgs(fact);
+            handler(session, @event);
         }
+        _parent?.RaiseFactInserted(session, fact);
+    }
 
-        public void RaiseFactInserted(ISession session, Fact fact)
+    public void RaiseFactUpdating(ISession session, Fact fact)
+    {
+        var handler = FactUpdatingEvent;
+        if (handler != null)
         {
-            var handler = FactInsertedEvent;
-            if (handler != null)
-            {
-                var @event = new WorkingMemoryEventArgs(fact);
-                handler(session, @event);
-            }
-            _parent?.RaiseFactInserted(session, fact);
+            var @event = new WorkingMemoryEventArgs(fact);
+            handler(session, @event);
         }
+        _parent?.RaiseFactUpdating(session, fact);
+    }
 
-        public void RaiseFactUpdating(ISession session, Fact fact)
+    public void RaiseFactUpdated(ISession session, Fact fact)
+    {
+        var handler = FactUpdatedEvent;
+        if (handler != null)
         {
-            var handler = FactUpdatingEvent;
-            if (handler != null)
-            {
-                var @event = new WorkingMemoryEventArgs(fact);
-                handler(session, @event);
-            }
-            _parent?.RaiseFactUpdating(session, fact);
+            var @event = new WorkingMemoryEventArgs(fact);
+            handler(session, @event);
         }
+        _parent?.RaiseFactUpdated(session, fact);
+    }
 
-        public void RaiseFactUpdated(ISession session, Fact fact)
+    public void RaiseFactRetracting(ISession session, Fact fact)
+    {
+        var handler = FactRetractingEvent;
+        if (handler != null)
         {
-            var handler = FactUpdatedEvent;
-            if (handler != null)
-            {
-                var @event = new WorkingMemoryEventArgs(fact);
-                handler(session, @event);
-            }
-            _parent?.RaiseFactUpdated(session, fact);
+            var @event = new WorkingMemoryEventArgs(fact);
+            handler(session, @event);
         }
+        _parent?.RaiseFactRetracting(session, fact);
+    }
 
-        public void RaiseFactRetracting(ISession session, Fact fact)
+    public void RaiseFactRetracted(ISession session, Fact fact)
+    {
+        var handler = FactRetractedEvent;
+        if (handler != null)
         {
-            var handler = FactRetractingEvent;
-            if (handler != null)
-            {
-                var @event = new WorkingMemoryEventArgs(fact);
-                handler(session, @event);
-            }
-            _parent?.RaiseFactRetracting(session, fact);
+            var @event = new WorkingMemoryEventArgs(fact);
+            handler(session, @event);
         }
+        _parent?.RaiseFactRetracted(session, fact);
+    }
 
-        public void RaiseFactRetracted(ISession session, Fact fact)
+    public void RaiseLhsExpressionEvaluated(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, object result, Tuple tuple, Fact fact, NodeInfo nodeInfo)
+    {
+        var handler = LhsExpressionEvaluatedEvent;
+        if (handler != null)
         {
-            var handler = FactRetractedEvent;
-            if (handler != null)
-            {
-                var @event = new WorkingMemoryEventArgs(fact);
-                handler(session, @event);
-            }
-            _parent?.RaiseFactRetracted(session, fact);
+            var arguments = new LhsExpressionArguments(argumentMap, tuple, fact);
+            var @event = new LhsExpressionEventArgs(expression, exception, arguments, result, tuple, fact, nodeInfo.Rules);
+            handler(session, @event);
         }
+        _parent?.RaiseLhsExpressionEvaluated(session, exception, expression, argumentMap, result, tuple, fact, nodeInfo);
+    }
 
-        public void RaiseLhsExpressionEvaluated(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, object result, Tuple tuple, Fact fact, NodeInfo nodeInfo)
+    public void RaiseLhsExpressionFailed(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Tuple tuple, Fact fact, NodeInfo nodeInfo, ref bool isHandled)
+    {
+        var handler = LhsExpressionFailedEvent;
+        if (handler != null)
         {
-            var handler = LhsExpressionEvaluatedEvent;
-            if (handler != null)
-            {
-                var arguments = new LhsExpressionArguments(argumentMap, tuple, fact);
-                var @event = new LhsExpressionEventArgs(expression, exception, arguments, result, tuple, fact, nodeInfo.Rules);
-                handler(session, @event);
-            }
-            _parent?.RaiseLhsExpressionEvaluated(session, exception, expression, argumentMap, result, tuple, fact, nodeInfo);
+            var arguments = new LhsExpressionArguments(argumentMap, tuple, fact);
+            var @event = new LhsExpressionErrorEventArgs(expression, exception, arguments, tuple, fact, nodeInfo.Rules);
+            handler(session, @event);
+            isHandled |= @event.IsHandled;
         }
+        _parent?.RaiseLhsExpressionFailed(session, exception, expression, argumentMap, tuple, fact, nodeInfo, ref isHandled);
+    }
 
-        public void RaiseLhsExpressionFailed(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Tuple tuple, Fact fact, NodeInfo nodeInfo, ref bool isHandled)
+    public void RaiseAgendaExpressionEvaluated(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, object result, Activation activation)
+    {
+        var handler = AgendaExpressionEvaluatedEvent;
+        if (handler != null)
         {
-            var handler = LhsExpressionFailedEvent;
-            if (handler != null)
-            {
-                var arguments = new LhsExpressionArguments(argumentMap, tuple, fact);
-                var @event = new LhsExpressionErrorEventArgs(expression, exception, arguments, tuple, fact, nodeInfo.Rules);
-                handler(session, @event);
-                isHandled |= @event.IsHandled;
-            }
-            _parent?.RaiseLhsExpressionFailed(session, exception, expression, argumentMap, tuple, fact, nodeInfo, ref isHandled);
+            var arguments = new ActivationExpressionArguments(argumentMap, activation);
+            var @event = new AgendaExpressionEventArgs(expression, exception, arguments, result, activation);
+            handler(session, @event);
         }
+        _parent?.RaiseAgendaExpressionEvaluated(session, exception, expression, argumentMap, result, activation);
+    }
 
-        public void RaiseAgendaExpressionEvaluated(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, object result, Activation activation)
+    public void RaiseAgendaExpressionFailed(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Activation activation, ref bool isHandled)
+    {
+        var handler = AgendaExpressionFailedEvent;
+        if (handler != null)
         {
-            var handler = AgendaExpressionEvaluatedEvent;
-            if (handler != null)
-            {
-                var arguments = new ActivationExpressionArguments(argumentMap, activation);
-                var @event = new AgendaExpressionEventArgs(expression, exception, arguments, result, activation);
-                handler(session, @event);
-            }
-            _parent?.RaiseAgendaExpressionEvaluated(session, exception, expression, argumentMap, result, activation);
+            var arguments = new ActivationExpressionArguments(argumentMap, activation);
+            var @event = new AgendaExpressionErrorEventArgs(expression, exception, arguments, activation);
+            handler(session, @event);
+            isHandled |= @event.IsHandled;
         }
+        _parent?.RaiseAgendaExpressionFailed(session, exception, expression, argumentMap, activation, ref isHandled);
+    }
+    
+    public void RaiseRhsExpressionEvaluated(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Activation activation)
+    {
+        var handler = RhsExpressionEvaluatedEvent;
+        if (handler != null)
+        {
+            var arguments = new ActivationExpressionArguments(argumentMap, activation);
+            var @event = new RhsExpressionEventArgs(expression, exception, arguments, activation);
+            handler(session, @event);
+        }
+        _parent?.RaiseRhsExpressionEvaluated(session, exception, expression, argumentMap, activation);
+    }
 
-        public void RaiseAgendaExpressionFailed(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Activation activation, ref bool isHandled)
+    public void RaiseRhsExpressionFailed(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Activation activation, ref bool isHandled)
+    {
+        var handler = RhsExpressionFailedEvent;
+        if (handler != null)
         {
-            var handler = AgendaExpressionFailedEvent;
-            if (handler != null)
-            {
-                var arguments = new ActivationExpressionArguments(argumentMap, activation);
-                var @event = new AgendaExpressionErrorEventArgs(expression, exception, arguments, activation);
-                handler(session, @event);
-                isHandled |= @event.IsHandled;
-            }
-            _parent?.RaiseAgendaExpressionFailed(session, exception, expression, argumentMap, activation, ref isHandled);
+            var arguments = new ActivationExpressionArguments(argumentMap, activation);
+            var @event = new RhsExpressionErrorEventArgs(expression, exception, arguments, activation);
+            handler(session, @event);
+            isHandled |= @event.IsHandled;
         }
-        
-        public void RaiseRhsExpressionEvaluated(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Activation activation)
-        {
-            var handler = RhsExpressionEvaluatedEvent;
-            if (handler != null)
-            {
-                var arguments = new ActivationExpressionArguments(argumentMap, activation);
-                var @event = new RhsExpressionEventArgs(expression, exception, arguments, activation);
-                handler(session, @event);
-            }
-            _parent?.RaiseRhsExpressionEvaluated(session, exception, expression, argumentMap, activation);
-        }
-
-        public void RaiseRhsExpressionFailed(ISession session, Exception exception, Expression expression, IArgumentMap argumentMap, Activation activation, ref bool isHandled)
-        {
-            var handler = RhsExpressionFailedEvent;
-            if (handler != null)
-            {
-                var arguments = new ActivationExpressionArguments(argumentMap, activation);
-                var @event = new RhsExpressionErrorEventArgs(expression, exception, arguments, activation);
-                handler(session, @event);
-                isHandled |= @event.IsHandled;
-            }
-            _parent?.RaiseRhsExpressionFailed(session, exception, expression, argumentMap, activation, ref isHandled);
-        }
+        _parent?.RaiseRhsExpressionFailed(session, exception, expression, argumentMap, activation, ref isHandled);
     }
 }

--- a/src/NRules/NRules/Diagnostics/ExpressionEventArgs.cs
+++ b/src/NRules/NRules/Diagnostics/ExpressionEventArgs.cs
@@ -3,57 +3,56 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using NRules.Utilities;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Information related to expression evaluation events.
+/// </summary>
+public class ExpressionEventArgs : EventArgs
 {
+    private readonly object[] _arguments;
+    private readonly IArguments _lazyArguments;
+
     /// <summary>
-    /// Information related to expression evaluation events.
+    /// Initializes a new instance of the <c>ExpressionEventArgs</c> class.
     /// </summary>
-    public class ExpressionEventArgs : EventArgs
+    /// <param name="expression">Expression that caused the event.</param>
+    /// <param name="exception">Exception thrown during expression evaluation.</param>
+    /// <param name="arguments">Arguments passed to expression during evaluation.</param>
+    /// <param name="result">Result of expression evaluation.</param>
+    public ExpressionEventArgs(Expression expression, Exception exception, object[] arguments, object result)
     {
-        private readonly object[] _arguments;
-        private readonly IArguments _lazyArguments;
-
-        /// <summary>
-        /// Initializes a new instance of the <c>ExpressionEventArgs</c> class.
-        /// </summary>
-        /// <param name="expression">Expression that caused the event.</param>
-        /// <param name="exception">Exception thrown during expression evaluation.</param>
-        /// <param name="arguments">Arguments passed to expression during evaluation.</param>
-        /// <param name="result">Result of expression evaluation.</param>
-        public ExpressionEventArgs(Expression expression, Exception exception, object[] arguments, object result)
-        {
-            _arguments = arguments;
-            Expression = expression;
-            Exception = exception;
-            Result = result;
-        }
-        
-        internal ExpressionEventArgs(Expression expression, Exception exception, IArguments arguments, object result)
-        {
-            _lazyArguments = arguments;
-            Expression = expression;
-            Exception = exception;
-            Result = result;
-        }
-
-        /// <summary>
-        /// Expression that caused the event;
-        /// </summary>
-        public Expression Expression { get; }
-
-        /// <summary>
-        /// Exception thrown during expression evaluation.
-        /// </summary>
-        public Exception Exception { get; }
-
-        /// <summary>
-        /// Arguments passed to the expression during evaluation.
-        /// </summary>
-        public virtual IEnumerable<object> Arguments => _lazyArguments?.GetValues() ?? _arguments;
-
-        /// <summary>
-        /// Result of expression evaluation.
-        /// </summary>
-        public object Result { get; }
+        _arguments = arguments;
+        Expression = expression;
+        Exception = exception;
+        Result = result;
     }
+    
+    internal ExpressionEventArgs(Expression expression, Exception exception, IArguments arguments, object result)
+    {
+        _lazyArguments = arguments;
+        Expression = expression;
+        Exception = exception;
+        Result = result;
+    }
+
+    /// <summary>
+    /// Expression that caused the event;
+    /// </summary>
+    public Expression Expression { get; }
+
+    /// <summary>
+    /// Exception thrown during expression evaluation.
+    /// </summary>
+    public Exception Exception { get; }
+
+    /// <summary>
+    /// Arguments passed to the expression during evaluation.
+    /// </summary>
+    public virtual IEnumerable<object> Arguments => _lazyArguments?.GetValues() ?? _arguments;
+
+    /// <summary>
+    /// Result of expression evaluation.
+    /// </summary>
+    public object Result { get; }
 }

--- a/src/NRules/NRules/Diagnostics/IRecoverableError.cs
+++ b/src/NRules/NRules/Diagnostics/IRecoverableError.cs
@@ -1,22 +1,21 @@
 using System;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Error event that can be handled by the consumer.
+/// </summary>
+public interface IRecoverableError
 {
     /// <summary>
-    /// Error event that can be handled by the consumer.
+    /// Flag that indicates whether the exception was handled.
+    /// If handler sets this to <c>true</c> then engine continues execution,
+    /// otherwise exception is rethrown and terminates engine's execution.
     /// </summary>
-    public interface IRecoverableError
-    {
-        /// <summary>
-        /// Flag that indicates whether the exception was handled.
-        /// If handler sets this to <c>true</c> then engine continues execution,
-        /// otherwise exception is rethrown and terminates engine's execution.
-        /// </summary>
-        bool IsHandled { get; set; }
+    bool IsHandled { get; set; }
 
-        /// <summary>
-        /// Exception that caused the error.
-        /// </summary>
-        Exception Exception { get; }
-    }
+    /// <summary>
+    /// Exception that caused the error.
+    /// </summary>
+    Exception Exception { get; }
 }

--- a/src/NRules/NRules/Diagnostics/ISessionSchemaProvider.cs
+++ b/src/NRules/NRules/Diagnostics/ISessionSchemaProvider.cs
@@ -1,14 +1,13 @@
-﻿namespace NRules.Diagnostics
+﻿namespace NRules.Diagnostics;
+
+/// <summary>
+/// Provides the rules schema in a form of a Rete network graph, for diagnostics.
+/// </summary>
+public interface ISessionSchemaProvider
 {
     /// <summary>
-    /// Provides the rules schema in a form of a Rete network graph, for diagnostics.
+    /// Returns the rules schema as a graph representing the structure of the underlying Rete network.
     /// </summary>
-    public interface ISessionSchemaProvider
-    {
-        /// <summary>
-        /// Returns the rules schema as a graph representing the structure of the underlying Rete network.
-        /// </summary>
-        /// <returns>Session schema as a Rete graph.</returns>
-        ReteGraph GetSchema();
-    }
+    /// <returns>Session schema as a Rete graph.</returns>
+    ReteGraph GetSchema();
 }

--- a/src/NRules/NRules/Diagnostics/LhsExpressionErrorEventArgs.cs
+++ b/src/NRules/NRules/Diagnostics/LhsExpressionErrorEventArgs.cs
@@ -4,33 +4,32 @@ using System.Linq.Expressions;
 using NRules.RuleModel;
 using NRules.Utilities;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Information related to error events raised during left-hand side expression evaluation.
+/// </summary>
+public class LhsExpressionErrorEventArgs : LhsExpressionEventArgs, IRecoverableError
 {
     /// <summary>
-    /// Information related to error events raised during left-hand side expression evaluation.
+    /// Initializes a new instance of the <c>LhsExpressionErrorEventArgs</c> class.
     /// </summary>
-    public class LhsExpressionErrorEventArgs : LhsExpressionEventArgs, IRecoverableError
+    /// <param name="expression">Expression related to the event.</param>
+    /// <param name="exception">Exception related to the event.</param>
+    /// <param name="arguments">Expression arguments.</param>
+    /// <param name="tuple">Tuple related to the event.</param>
+    /// <param name="fact">Fact related to the event.</param>
+    /// <param name="rules">Rules that contain the expression that generated the event.</param>
+    public LhsExpressionErrorEventArgs(Expression expression, Exception exception, object[] arguments, ITuple tuple, IFact fact, IEnumerable<IRuleDefinition> rules)
+        : base(expression, exception, arguments, null, tuple, fact, rules)
     {
-        /// <summary>
-        /// Initializes a new instance of the <c>LhsExpressionErrorEventArgs</c> class.
-        /// </summary>
-        /// <param name="expression">Expression related to the event.</param>
-        /// <param name="exception">Exception related to the event.</param>
-        /// <param name="arguments">Expression arguments.</param>
-        /// <param name="tuple">Tuple related to the event.</param>
-        /// <param name="fact">Fact related to the event.</param>
-        /// <param name="rules">Rules that contain the expression that generated the event.</param>
-        public LhsExpressionErrorEventArgs(Expression expression, Exception exception, object[] arguments, ITuple tuple, IFact fact, IEnumerable<IRuleDefinition> rules)
-            : base(expression, exception, arguments, null, tuple, fact, rules)
-        {
-        }
-        
-        internal LhsExpressionErrorEventArgs(Expression expression, Exception exception, IArguments arguments, ITuple tuple, IFact fact, IEnumerable<IRuleDefinition> rules)
-            : base(expression, exception, arguments, null, tuple, fact, rules)
-        {
-        }
-
-        /// <inheritdoc />
-        public bool IsHandled { get; set; }
     }
+    
+    internal LhsExpressionErrorEventArgs(Expression expression, Exception exception, IArguments arguments, ITuple tuple, IFact fact, IEnumerable<IRuleDefinition> rules)
+        : base(expression, exception, arguments, null, tuple, fact, rules)
+    {
+    }
+
+    /// <inheritdoc />
+    public bool IsHandled { get; set; }
 }

--- a/src/NRules/NRules/Diagnostics/LhsExpressionEventArgs.cs
+++ b/src/NRules/NRules/Diagnostics/LhsExpressionEventArgs.cs
@@ -5,67 +5,66 @@ using NRules.Rete;
 using NRules.RuleModel;
 using NRules.Utilities;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Information related to events raised during left-hand side expression evaluation.
+/// </summary>
+public class LhsExpressionEventArgs : ExpressionEventArgs
 {
+    private readonly ITuple _tuple;
+    private readonly IFact _fact;
+
     /// <summary>
-    /// Information related to events raised during left-hand side expression evaluation.
+    /// Initializes a new instance of the <c>LhsExpressionEventArgs</c> class.
     /// </summary>
-    public class LhsExpressionEventArgs : ExpressionEventArgs
+    /// <param name="expression">Expression related to the event.</param>
+    /// <param name="exception">Exception related to the event.</param>
+    /// <param name="arguments">Expression arguments.</param>
+    /// <param name="result">Expression result.</param>
+    /// <param name="tuple">Tuple related to the event.</param>
+    /// <param name="fact">Fact related to the event.</param>
+    /// <param name="rules">Rules that contain the expression that generated the event.</param>
+    public LhsExpressionEventArgs(Expression expression, Exception exception, object[] arguments, object result, ITuple tuple, IFact fact, IEnumerable<IRuleDefinition> rules)
+        : base(expression, exception, arguments, result)
     {
-        private readonly ITuple _tuple;
-        private readonly IFact _fact;
+        _tuple = tuple;
+        _fact = fact;
+        Rules = rules;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <c>LhsExpressionEventArgs</c> class.
-        /// </summary>
-        /// <param name="expression">Expression related to the event.</param>
-        /// <param name="exception">Exception related to the event.</param>
-        /// <param name="arguments">Expression arguments.</param>
-        /// <param name="result">Expression result.</param>
-        /// <param name="tuple">Tuple related to the event.</param>
-        /// <param name="fact">Fact related to the event.</param>
-        /// <param name="rules">Rules that contain the expression that generated the event.</param>
-        public LhsExpressionEventArgs(Expression expression, Exception exception, object[] arguments, object result, ITuple tuple, IFact fact, IEnumerable<IRuleDefinition> rules)
-            : base(expression, exception, arguments, result)
-        {
-            _tuple = tuple;
-            _fact = fact;
-            Rules = rules;
-        }
+    internal LhsExpressionEventArgs(Expression expression, Exception exception, IArguments arguments, object result, ITuple tuple, IFact fact, IEnumerable<IRuleDefinition> rules)
+        : base(expression, exception, arguments, result)
+    {
+        _tuple = tuple;
+        _fact = fact;
+        Rules = rules;
+    }
 
-        internal LhsExpressionEventArgs(Expression expression, Exception exception, IArguments arguments, object result, ITuple tuple, IFact fact, IEnumerable<IRuleDefinition> rules)
-            : base(expression, exception, arguments, result)
+    /// <summary>
+    /// Facts related to the event.
+    /// </summary>
+    public IEnumerable<IFact> Facts
+    {
+        get
         {
-            _tuple = tuple;
-            _fact = fact;
-            Rules = rules;
-        }
-
-        /// <summary>
-        /// Facts related to the event.
-        /// </summary>
-        public IEnumerable<IFact> Facts
-        {
-            get
+            if (_tuple != null)
             {
-                if (_tuple != null)
+                foreach (var tupleFact in _tuple.OrderedFacts())
                 {
-                    foreach (var tupleFact in _tuple.OrderedFacts())
-                    {
-                        yield return tupleFact;
-                    }
-                }
-
-                if (_fact != null)
-                {
-                    yield return _fact;
+                    yield return tupleFact;
                 }
             }
-        }
 
-        /// <summary>
-        /// Rules that contain the expression that generated the event.
-        /// </summary>
-        public IEnumerable<IRuleDefinition> Rules { get; }
+            if (_fact != null)
+            {
+                yield return _fact;
+            }
+        }
     }
+
+    /// <summary>
+    /// Rules that contain the expression that generated the event.
+    /// </summary>
+    public IEnumerable<IRuleDefinition> Rules { get; }
 }

--- a/src/NRules/NRules/Diagnostics/NodeInfo.cs
+++ b/src/NRules/NRules/Diagnostics/NodeInfo.cs
@@ -2,18 +2,17 @@
 using System.Collections.Generic;
 using NRules.RuleModel;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+internal class NodeInfo
 {
-    internal class NodeInfo
+    private readonly List<IRuleDefinition> _rules = new();
+
+    public Type OutputType { get; set; }
+    public IEnumerable<IRuleDefinition> Rules => _rules;
+
+    public void Add(IRuleDefinition rule)
     {
-        private readonly List<IRuleDefinition> _rules = new();
-
-        public Type OutputType { get; set; }
-        public IEnumerable<IRuleDefinition> Rules => _rules;
-
-        public void Add(IRuleDefinition rule)
-        {
-            _rules.Add(rule);
-        }
+        _rules.Add(rule);
     }
 }

--- a/src/NRules/NRules/Diagnostics/NodeMetrics.cs
+++ b/src/NRules/NRules/Diagnostics/NodeMetrics.cs
@@ -1,117 +1,116 @@
-﻿namespace NRules.Diagnostics
+﻿namespace NRules.Diagnostics;
+
+/// <summary>
+/// Performance metrics associated with a given node in the Rete network.
+/// </summary>
+public interface INodeMetrics
 {
     /// <summary>
-    /// Performance metrics associated with a given node in the Rete network.
+    /// Id of the node with which these metrics are associated.
     /// </summary>
-    public interface INodeMetrics
+    int NodeId { get; }
+
+    /// <summary>
+    /// Number of elements stored in the node.
+    /// If a node does not store elements, this value is <c>null</c>.
+    /// </summary>
+    int? ElementCount { get; }
+
+    /// <summary>
+    /// Cumulative number of elements that entered this node during the propagation of inserted facts.
+    /// This number is counted since the last reset or since the creation of the session.
+    /// </summary>
+    int InsertInputCount { get; }
+
+    /// <summary>
+    /// Cumulative number of elements that entered this node during the propagation of updated facts.
+    /// This number is counted since the last reset or since the creation of the session.
+    /// </summary>
+    int UpdateInputCount { get; }
+
+    /// <summary>
+    /// Cumulative number of elements that entered this node during the propagation of retracted facts.
+    /// This number is counted since the last reset or since the creation of the session.
+    /// </summary>
+    int RetractInputCount { get; }
+
+    /// <summary>
+    /// Cumulative number of elements that exited this node during the propagation of inserted facts.
+    /// This number is counted since the last reset or since the creation of the session.
+    /// </summary>
+    int InsertOutputCount { get; }
+
+    /// <summary>
+    /// Cumulative number of elements that exited this node during the propagation of updated facts.
+    /// This number is counted since the last reset or since the creation of the session.
+    /// </summary>
+    int UpdateOutputCount { get; }
+
+    /// <summary>
+    /// Cumulative number of elements that exited this node during the propagation of retracted facts.
+    /// This number is counted since the last reset or since the creation of the session.
+    /// </summary>
+    int RetractOutputCount { get; }
+
+    /// <summary>
+    /// Cumulative number of milliseconds spent in this node handling the elements passed through it
+    /// during the propagation of inserted facts.
+    /// This time is counted since the last reset or since the creation of the session.
+    /// This duration is exclusive of any time spent propagating facts through the downstream nodes.
+    /// </summary>
+    long InsertDurationMilliseconds { get; }
+
+    /// <summary>
+    /// Cumulative number of milliseconds spent in this node handling the elements passed through it
+    /// during the propagation of updated facts.
+    /// This time is counted since the last reset or since the creation of the session.
+    /// This duration is exclusive of any time spent propagating facts through the downstream nodes.
+    /// </summary>
+    long UpdateDurationMilliseconds { get; }
+
+    /// <summary>
+    /// Cumulative number of milliseconds spent in this node handling the elements passed through it
+    /// during the propagation of retracted facts.
+    /// This time is counted since the last reset or since the creation of the session.
+    /// This duration is exclusive of any time spent propagating facts through the downstream nodes.
+    /// </summary>
+    long RetractDurationMilliseconds { get; }
+
+    /// <summary>
+    /// Resets cumulative metrics associated with this node.
+    /// </summary>
+    void Reset();
+}
+
+internal class NodeMetrics : INodeMetrics
+{
+    public int NodeId { get; }
+    public int? ElementCount { get; set; }
+    public int InsertInputCount { get; set; }
+    public int UpdateInputCount { get; set; }
+    public int RetractInputCount { get; set; }
+    public int InsertOutputCount { get; set; }
+    public int UpdateOutputCount { get; set; }
+    public int RetractOutputCount { get; set; }
+    public long InsertDurationMilliseconds { get; set; }
+    public long UpdateDurationMilliseconds { get; set; }
+    public long RetractDurationMilliseconds { get; set; }
+
+    public NodeMetrics(int nodeId)
     {
-        /// <summary>
-        /// Id of the node with which these metrics are associated.
-        /// </summary>
-        int NodeId { get; }
-
-        /// <summary>
-        /// Number of elements stored in the node.
-        /// If a node does not store elements, this value is <c>null</c>.
-        /// </summary>
-        int? ElementCount { get; }
-
-        /// <summary>
-        /// Cumulative number of elements that entered this node during the propagation of inserted facts.
-        /// This number is counted since the last reset or since the creation of the session.
-        /// </summary>
-        int InsertInputCount { get; }
-
-        /// <summary>
-        /// Cumulative number of elements that entered this node during the propagation of updated facts.
-        /// This number is counted since the last reset or since the creation of the session.
-        /// </summary>
-        int UpdateInputCount { get; }
-
-        /// <summary>
-        /// Cumulative number of elements that entered this node during the propagation of retracted facts.
-        /// This number is counted since the last reset or since the creation of the session.
-        /// </summary>
-        int RetractInputCount { get; }
-
-        /// <summary>
-        /// Cumulative number of elements that exited this node during the propagation of inserted facts.
-        /// This number is counted since the last reset or since the creation of the session.
-        /// </summary>
-        int InsertOutputCount { get; }
-
-        /// <summary>
-        /// Cumulative number of elements that exited this node during the propagation of updated facts.
-        /// This number is counted since the last reset or since the creation of the session.
-        /// </summary>
-        int UpdateOutputCount { get; }
-
-        /// <summary>
-        /// Cumulative number of elements that exited this node during the propagation of retracted facts.
-        /// This number is counted since the last reset or since the creation of the session.
-        /// </summary>
-        int RetractOutputCount { get; }
-
-        /// <summary>
-        /// Cumulative number of milliseconds spent in this node handling the elements passed through it
-        /// during the propagation of inserted facts.
-        /// This time is counted since the last reset or since the creation of the session.
-        /// This duration is exclusive of any time spent propagating facts through the downstream nodes.
-        /// </summary>
-        long InsertDurationMilliseconds { get; }
-
-        /// <summary>
-        /// Cumulative number of milliseconds spent in this node handling the elements passed through it
-        /// during the propagation of updated facts.
-        /// This time is counted since the last reset or since the creation of the session.
-        /// This duration is exclusive of any time spent propagating facts through the downstream nodes.
-        /// </summary>
-        long UpdateDurationMilliseconds { get; }
-
-        /// <summary>
-        /// Cumulative number of milliseconds spent in this node handling the elements passed through it
-        /// during the propagation of retracted facts.
-        /// This time is counted since the last reset or since the creation of the session.
-        /// This duration is exclusive of any time spent propagating facts through the downstream nodes.
-        /// </summary>
-        long RetractDurationMilliseconds { get; }
-
-        /// <summary>
-        /// Resets cumulative metrics associated with this node.
-        /// </summary>
-        void Reset();
+        NodeId = nodeId;
     }
 
-    internal class NodeMetrics : INodeMetrics
+    public void Reset()
     {
-        public int NodeId { get; }
-        public int? ElementCount { get; set; }
-        public int InsertInputCount { get; set; }
-        public int UpdateInputCount { get; set; }
-        public int RetractInputCount { get; set; }
-        public int InsertOutputCount { get; set; }
-        public int UpdateOutputCount { get; set; }
-        public int RetractOutputCount { get; set; }
-        public long InsertDurationMilliseconds { get; set; }
-        public long UpdateDurationMilliseconds { get; set; }
-        public long RetractDurationMilliseconds { get; set; }
-
-        public NodeMetrics(int nodeId)
-        {
-            NodeId = nodeId;
-        }
-
-        public void Reset()
-        {
-            InsertInputCount = 0;
-            InsertOutputCount = 0;
-            InsertDurationMilliseconds = 0;
-            UpdateInputCount = 0;
-            UpdateOutputCount = 0;
-            UpdateDurationMilliseconds = 0;
-            RetractInputCount = 0;
-            RetractOutputCount = 0;
-            RetractDurationMilliseconds = 0;
-        }
+        InsertInputCount = 0;
+        InsertOutputCount = 0;
+        InsertDurationMilliseconds = 0;
+        UpdateInputCount = 0;
+        UpdateOutputCount = 0;
+        UpdateDurationMilliseconds = 0;
+        RetractInputCount = 0;
+        RetractOutputCount = 0;
+        RetractDurationMilliseconds = 0;
     }
 }

--- a/src/NRules/NRules/Diagnostics/PerfCounter.cs
+++ b/src/NRules/NRules/Diagnostics/PerfCounter.cs
@@ -1,107 +1,106 @@
 ﻿using System;
 using NRules.Rete;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+internal static class PerfCounter
 {
-    internal static class PerfCounter
+    public static AssertPerfCounter Assert(IExecutionContext context, INode node)
     {
-        public static AssertPerfCounter Assert(IExecutionContext context, INode node)
-        {
-            var nodeMetrics = context.MetricsAggregator.GetMetrics(node);
-            return new AssertPerfCounter(nodeMetrics);
-        }
-        
-        public static UpdatePerfCounter Update(IExecutionContext context, INode node)
-        {
-            var nodeMetrics = context.MetricsAggregator.GetMetrics(node);
-            return new UpdatePerfCounter(nodeMetrics);
-        }
-        
-        public static RetractPerfCounter Retract(IExecutionContext context, INode node)
-        {
-            var nodeMetrics = context.MetricsAggregator.GetMetrics(node);
-            return new RetractPerfCounter(nodeMetrics);
-        }
+        var nodeMetrics = context.MetricsAggregator.GetMetrics(node);
+        return new AssertPerfCounter(nodeMetrics);
+    }
+    
+    public static UpdatePerfCounter Update(IExecutionContext context, INode node)
+    {
+        var nodeMetrics = context.MetricsAggregator.GetMetrics(node);
+        return new UpdatePerfCounter(nodeMetrics);
+    }
+    
+    public static RetractPerfCounter Retract(IExecutionContext context, INode node)
+    {
+        var nodeMetrics = context.MetricsAggregator.GetMetrics(node);
+        return new RetractPerfCounter(nodeMetrics);
+    }
+}
+
+internal readonly struct AssertPerfCounter : IDisposable
+{
+    private readonly NodeMetrics _nodeMetrics;
+    private readonly long _startTicks;
+
+    public AssertPerfCounter(NodeMetrics nodeMetrics)
+    {
+        _nodeMetrics = nodeMetrics;
+        _startTicks = Environment.TickCount;
     }
 
-    internal readonly struct AssertPerfCounter : IDisposable
+    public void Dispose()
     {
-        private readonly NodeMetrics _nodeMetrics;
-        private readonly long _startTicks;
-
-        public AssertPerfCounter(NodeMetrics nodeMetrics)
-        {
-            _nodeMetrics = nodeMetrics;
-            _startTicks = Environment.TickCount;
-        }
-
-        public void Dispose()
-        {
-            _nodeMetrics.InsertDurationMilliseconds += unchecked(Environment.TickCount - _startTicks);
-        }
-
-        public void AddItems(int count)
-        {
-            AddInputs(count);
-            AddOutputs(count);
-        }
-
-        public void AddInputs(int count) => _nodeMetrics.InsertInputCount += count;
-        public void AddOutputs(int count) => _nodeMetrics.InsertOutputCount += count;
-        public void SetCount(int count) => _nodeMetrics.ElementCount = count;
+        _nodeMetrics.InsertDurationMilliseconds += unchecked(Environment.TickCount - _startTicks);
     }
 
-    internal readonly struct UpdatePerfCounter : IDisposable
+    public void AddItems(int count)
     {
-        private readonly NodeMetrics _nodeMetrics;
-        private readonly long _startTicks;
-
-        public UpdatePerfCounter(NodeMetrics nodeMetrics)
-        {
-            _nodeMetrics = nodeMetrics;
-            _startTicks = Environment.TickCount;
-        }
-
-        public void Dispose()
-        {
-            _nodeMetrics.UpdateDurationMilliseconds += unchecked(Environment.TickCount - _startTicks);
-        }
-
-        public void AddItems(int count)
-        {
-            AddInputs(count);
-            AddOutputs(count);
-        }
-
-        public void AddInputs(int count) => _nodeMetrics.UpdateInputCount += count;
-        public void AddOutputs(int count) => _nodeMetrics.UpdateOutputCount += count;
-        public void SetCount(int count) => _nodeMetrics.ElementCount = count;
+        AddInputs(count);
+        AddOutputs(count);
     }
 
-    internal readonly struct RetractPerfCounter : IDisposable
+    public void AddInputs(int count) => _nodeMetrics.InsertInputCount += count;
+    public void AddOutputs(int count) => _nodeMetrics.InsertOutputCount += count;
+    public void SetCount(int count) => _nodeMetrics.ElementCount = count;
+}
+
+internal readonly struct UpdatePerfCounter : IDisposable
+{
+    private readonly NodeMetrics _nodeMetrics;
+    private readonly long _startTicks;
+
+    public UpdatePerfCounter(NodeMetrics nodeMetrics)
     {
-        private readonly NodeMetrics _nodeMetrics;
-        private readonly long _startTicks;
-
-        public RetractPerfCounter(NodeMetrics nodeMetrics)
-        {
-            _nodeMetrics = nodeMetrics;
-            _startTicks = Environment.TickCount;
-        }
-
-        public void Dispose()
-        {
-            _nodeMetrics.RetractDurationMilliseconds += unchecked(Environment.TickCount - _startTicks);
-        }
-
-        public void AddItems(int count)
-        {
-            AddInputs(count);
-            AddOutputs(count);
-        }
-
-        public void AddInputs(int count) => _nodeMetrics.RetractInputCount += count;
-        public void AddOutputs(int count) => _nodeMetrics.RetractOutputCount += count;
-        public void SetCount(int count) => _nodeMetrics.ElementCount = count;
+        _nodeMetrics = nodeMetrics;
+        _startTicks = Environment.TickCount;
     }
+
+    public void Dispose()
+    {
+        _nodeMetrics.UpdateDurationMilliseconds += unchecked(Environment.TickCount - _startTicks);
+    }
+
+    public void AddItems(int count)
+    {
+        AddInputs(count);
+        AddOutputs(count);
+    }
+
+    public void AddInputs(int count) => _nodeMetrics.UpdateInputCount += count;
+    public void AddOutputs(int count) => _nodeMetrics.UpdateOutputCount += count;
+    public void SetCount(int count) => _nodeMetrics.ElementCount = count;
+}
+
+internal readonly struct RetractPerfCounter : IDisposable
+{
+    private readonly NodeMetrics _nodeMetrics;
+    private readonly long _startTicks;
+
+    public RetractPerfCounter(NodeMetrics nodeMetrics)
+    {
+        _nodeMetrics = nodeMetrics;
+        _startTicks = Environment.TickCount;
+    }
+
+    public void Dispose()
+    {
+        _nodeMetrics.RetractDurationMilliseconds += unchecked(Environment.TickCount - _startTicks);
+    }
+
+    public void AddItems(int count)
+    {
+        AddInputs(count);
+        AddOutputs(count);
+    }
+
+    public void AddInputs(int count) => _nodeMetrics.RetractInputCount += count;
+    public void AddOutputs(int count) => _nodeMetrics.RetractOutputCount += count;
+    public void SetCount(int count) => _nodeMetrics.ElementCount = count;
 }

--- a/src/NRules/NRules/Diagnostics/ReteGraph.cs
+++ b/src/NRules/NRules/Diagnostics/ReteGraph.cs
@@ -1,32 +1,31 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Rete network graph that corresponds to the compiled rules.
+/// </summary>
+public class ReteGraph
 {
     /// <summary>
-    /// Rete network graph that corresponds to the compiled rules.
+    /// Creates an instance of a Rete network graph as a collection of nodes and links between them.
     /// </summary>
-    public class ReteGraph
+    /// <param name="nodes">Rete network graph nodes.</param>
+    /// <param name="links">Links between Rete network nodes.</param>
+    public ReteGraph(IEnumerable<ReteNode> nodes, IEnumerable<ReteLink> links)
     {
-        /// <summary>
-        /// Creates an instance of a Rete network graph as a collection of nodes and links between them.
-        /// </summary>
-        /// <param name="nodes">Rete network graph nodes.</param>
-        /// <param name="links">Links between Rete network nodes.</param>
-        public ReteGraph(IEnumerable<ReteNode> nodes, IEnumerable<ReteLink> links)
-        {
-            Nodes = nodes.ToArray();
-            Links = links.ToArray();
-        }
-
-        /// <summary>
-        /// Nodes of the Rete network graph.
-        /// </summary>
-        public ReteNode[] Nodes { get; }
-
-        /// <summary>
-        /// Links between nodes of the Rete network graph.
-        /// </summary>
-        public ReteLink[] Links { get; }
+        Nodes = nodes.ToArray();
+        Links = links.ToArray();
     }
+
+    /// <summary>
+    /// Nodes of the Rete network graph.
+    /// </summary>
+    public ReteNode[] Nodes { get; }
+
+    /// <summary>
+    /// Links between nodes of the Rete network graph.
+    /// </summary>
+    public ReteLink[] Links { get; }
 }

--- a/src/NRules/NRules/Diagnostics/ReteLink.cs
+++ b/src/NRules/NRules/Diagnostics/ReteLink.cs
@@ -1,24 +1,23 @@
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Link between nodes in the rete network graph.
+/// </summary>
+public class ReteLink
 {
     /// <summary>
-    /// Link between nodes in the rete network graph.
+    /// Source node.
     /// </summary>
-    public class ReteLink
+    public ReteNode Source { get; }
+
+    /// <summary>
+    /// Target node.
+    /// </summary>
+    public ReteNode Target { get; }
+
+    internal ReteLink(ReteNode source, ReteNode target)
     {
-        /// <summary>
-        /// Source node.
-        /// </summary>
-        public ReteNode Source { get; }
-
-        /// <summary>
-        /// Target node.
-        /// </summary>
-        public ReteNode Target { get; }
-
-        internal ReteLink(ReteNode source, ReteNode target)
-        {
-            Source = source;
-            Target = target;
-        }
+        Source = source;
+        Target = target;
     }
 }

--- a/src/NRules/NRules/Diagnostics/ReteNode.cs
+++ b/src/NRules/NRules/Diagnostics/ReteNode.cs
@@ -5,165 +5,164 @@ using System.Linq.Expressions;
 using NRules.Rete;
 using NRules.RuleModel;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Types of nodes in the Rete network.
+/// </summary>
+public enum NodeType
+{
+    Root,
+    Type,
+    Selection,
+    AlphaMemory,
+    Dummy,
+    Join,
+    Adapter,
+    Exists,
+    Aggregate,
+    Not,
+    Binding,
+    BetaMemory,
+    Rule,
+}
+
+/// <summary>
+/// Node in the Rete network graph.
+/// </summary>
+public class ReteNode
 {
     /// <summary>
-    /// Types of nodes in the Rete network.
+    /// Node id, unique within a given instance of <see cref="ISessionFactory"/>.
+    /// This id is stable for a given set of rules (same rules will get compiled
+    /// into the same Rete network, and produce nodes with the same ids).
     /// </summary>
-    public enum NodeType
-    {
-        Root,
-        Type,
-        Selection,
-        AlphaMemory,
-        Dummy,
-        Join,
-        Adapter,
-        Exists,
-        Aggregate,
-        Not,
-        Binding,
-        BetaMemory,
-        Rule,
-    }
+    public int Id { get; }
 
     /// <summary>
-    /// Node in the Rete network graph.
+    /// Type of the node in the Rete network.
     /// </summary>
-    public class ReteNode
+    public NodeType NodeType { get; }
+
+    /// <summary>
+    /// Type of elements the node produces as output.
+    /// </summary>
+    public Type OutputType { get; }
+
+    /// <summary>
+    /// Properties associated with the node.
+    /// </summary>
+    public KeyValuePair<string, object>[] Properties { get; }
+
+    /// <summary>
+    /// Expressions associated with the node.
+    /// </summary>
+    public KeyValuePair<string, LambdaExpression>[] Expressions { get; }
+
+    /// <summary>
+    /// Rules that this node participates in.
+    /// </summary>
+    public IRuleDefinition[] Rules { get; }
+
+    internal static ReteNode Create(RootNode node)
     {
-        /// <summary>
-        /// Node id, unique within a given instance of <see cref="ISessionFactory"/>.
-        /// This id is stable for a given set of rules (same rules will get compiled
-        /// into the same Rete network, and produce nodes with the same ids).
-        /// </summary>
-        public int Id { get; }
-
-        /// <summary>
-        /// Type of the node in the Rete network.
-        /// </summary>
-        public NodeType NodeType { get; }
-
-        /// <summary>
-        /// Type of elements the node produces as output.
-        /// </summary>
-        public Type OutputType { get; }
-
-        /// <summary>
-        /// Properties associated with the node.
-        /// </summary>
-        public KeyValuePair<string, object>[] Properties { get; }
-
-        /// <summary>
-        /// Expressions associated with the node.
-        /// </summary>
-        public KeyValuePair<string, LambdaExpression>[] Expressions { get; }
-
-        /// <summary>
-        /// Rules that this node participates in.
-        /// </summary>
-        public IRuleDefinition[] Rules { get; }
-
-        internal static ReteNode Create(RootNode node)
+        return new ReteNode(node.Id, NodeType.Root);
+    }
+    
+    internal static ReteNode Create(TypeNode node)
+    {
+        return new ReteNode(node.Id, NodeType.Type, outputType: node.FilterType, 
+            rules: node.NodeInfo.Rules);
+    }
+    
+    internal static ReteNode Create(SelectionNode node)
+    {
+        var conditions = new[]
         {
-            return new ReteNode(node.Id, NodeType.Root);
-        }
-        
-        internal static ReteNode Create(TypeNode node)
-        {
-            return new ReteNode(node.Id, NodeType.Type, outputType: node.FilterType, 
-                rules: node.NodeInfo.Rules);
-        }
-        
-        internal static ReteNode Create(SelectionNode node)
-        {
-            var conditions = new[]
-            {
-                new KeyValuePair<string, LambdaExpression>("Condition", node.ExpressionElement.Expression)
-            };
-            return new ReteNode(node.Id, NodeType.Selection, outputType: node.NodeInfo.OutputType, 
-                expressions: conditions, rules: node.NodeInfo.Rules);
-        }
+            new KeyValuePair<string, LambdaExpression>("Condition", node.ExpressionElement.Expression)
+        };
+        return new ReteNode(node.Id, NodeType.Selection, outputType: node.NodeInfo.OutputType, 
+            expressions: conditions, rules: node.NodeInfo.Rules);
+    }
 
-        internal static ReteNode Create(AlphaMemoryNode node)
-        {
-            return new ReteNode(node.Id, NodeType.AlphaMemory, outputType: node.NodeInfo.OutputType,
-                rules: node.NodeInfo.Rules);
-        }
+    internal static ReteNode Create(AlphaMemoryNode node)
+    {
+        return new ReteNode(node.Id, NodeType.AlphaMemory, outputType: node.NodeInfo.OutputType,
+            rules: node.NodeInfo.Rules);
+    }
 
-        internal static ReteNode Create(JoinNode node)
-        {
-            var conditions = node.ExpressionElements.Select(c => 
-                new KeyValuePair<string, LambdaExpression>("Condition", c.Expression));
-            return new ReteNode(node.Id, NodeType.Join, expressions: conditions,
-                rules: node.NodeInfo.Rules);
-        }
+    internal static ReteNode Create(JoinNode node)
+    {
+        var conditions = node.ExpressionElements.Select(c => 
+            new KeyValuePair<string, LambdaExpression>("Condition", c.Expression));
+        return new ReteNode(node.Id, NodeType.Join, expressions: conditions,
+            rules: node.NodeInfo.Rules);
+    }
 
-        internal static ReteNode Create(NotNode node)
-        {
-            return new ReteNode(node.Id, NodeType.Not, rules: node.NodeInfo.Rules);
-        }
+    internal static ReteNode Create(NotNode node)
+    {
+        return new ReteNode(node.Id, NodeType.Not, rules: node.NodeInfo.Rules);
+    }
 
-        internal static ReteNode Create(ExistsNode node)
-        {
-            return new ReteNode(node.Id, NodeType.Exists, rules: node.NodeInfo.Rules);
-        }
+    internal static ReteNode Create(ExistsNode node)
+    {
+        return new ReteNode(node.Id, NodeType.Exists, rules: node.NodeInfo.Rules);
+    }
 
-        internal static ReteNode Create(AggregateNode node)
-        {
-            var values = new[] {new KeyValuePair<string, object>("Name", node.Name)};
-            var expressions = node.Expressions.Select(e =>
-                new KeyValuePair<string, LambdaExpression>(e.Name, e.Expression));
-            return new ReteNode(node.Id, NodeType.Aggregate, outputType: node.NodeInfo.OutputType,
-                values: values, expressions: expressions, rules: node.NodeInfo.Rules);
-        }
+    internal static ReteNode Create(AggregateNode node)
+    {
+        var values = new[] {new KeyValuePair<string, object>("Name", node.Name)};
+        var expressions = node.Expressions.Select(e =>
+            new KeyValuePair<string, LambdaExpression>(e.Name, e.Expression));
+        return new ReteNode(node.Id, NodeType.Aggregate, outputType: node.NodeInfo.OutputType,
+            values: values, expressions: expressions, rules: node.NodeInfo.Rules);
+    }
 
-        internal static ReteNode Create(ObjectInputAdapter node)
-        {
-            return new ReteNode(node.Id, NodeType.Adapter, rules: node.NodeInfo.Rules);
-        }
+    internal static ReteNode Create(ObjectInputAdapter node)
+    {
+        return new ReteNode(node.Id, NodeType.Adapter, rules: node.NodeInfo.Rules);
+    }
 
-        internal static ReteNode Create(BindingNode node)
+    internal static ReteNode Create(BindingNode node)
+    {
+        var expressions = new[]
         {
-            var expressions = new[]
-            {
-                new KeyValuePair<string, LambdaExpression>("Expression", node.ExpressionElement.Expression)
-            };
-            return new ReteNode(node.Id, NodeType.Binding, outputType: node.ResultType, 
-                expressions: expressions, rules: node.NodeInfo.Rules);
-        }
+            new KeyValuePair<string, LambdaExpression>("Expression", node.ExpressionElement.Expression)
+        };
+        return new ReteNode(node.Id, NodeType.Binding, outputType: node.ResultType, 
+            expressions: expressions, rules: node.NodeInfo.Rules);
+    }
 
-        internal static ReteNode Create(BetaMemoryNode node)
-        {
-            return new ReteNode(node.Id, NodeType.BetaMemory, rules: node.NodeInfo.Rules);
-        }
+    internal static ReteNode Create(BetaMemoryNode node)
+    {
+        return new ReteNode(node.Id, NodeType.BetaMemory, rules: node.NodeInfo.Rules);
+    }
 
-        internal static ReteNode Create(RuleNode node)
-        {
-            var expressions = node.CompiledRule.Definition.FilterGroup.Filters.Select(e =>
-                new KeyValuePair<string, LambdaExpression>($"Filter{e.FilterType}", e.Expression));
-            return new ReteNode(node.Id, NodeType.Rule, expressions: expressions,
-                rules: node.NodeInfo.Rules);
-        }
+    internal static ReteNode Create(RuleNode node)
+    {
+        var expressions = node.CompiledRule.Definition.FilterGroup.Filters.Select(e =>
+            new KeyValuePair<string, LambdaExpression>($"Filter{e.FilterType}", e.Expression));
+        return new ReteNode(node.Id, NodeType.Rule, expressions: expressions,
+            rules: node.NodeInfo.Rules);
+    }
 
-        internal static ReteNode Create(DummyNode node)
-        {
-            return new ReteNode(node.Id, NodeType.Dummy);
-        }
+    internal static ReteNode Create(DummyNode node)
+    {
+        return new ReteNode(node.Id, NodeType.Dummy);
+    }
 
-        internal ReteNode(int id, 
-            NodeType nodeType, 
-            Type outputType = null, 
-            IEnumerable<KeyValuePair<string, object>> values = null,
-            IEnumerable<KeyValuePair<string, LambdaExpression>> expressions = null, 
-            IEnumerable<IRuleDefinition> rules = null)
-        {
-            Id = id;
-            NodeType = nodeType;
-            OutputType = outputType;
-            Properties = values?.ToArray() ?? Array.Empty<KeyValuePair<string, object>>();
-            Expressions = expressions?.ToArray() ?? Array.Empty<KeyValuePair<string, LambdaExpression>>();
-            Rules = rules?.ToArray() ?? Array.Empty<IRuleDefinition>();
-        }
+    internal ReteNode(int id, 
+        NodeType nodeType, 
+        Type outputType = null, 
+        IEnumerable<KeyValuePair<string, object>> values = null,
+        IEnumerable<KeyValuePair<string, LambdaExpression>> expressions = null, 
+        IEnumerable<IRuleDefinition> rules = null)
+    {
+        Id = id;
+        NodeType = nodeType;
+        OutputType = outputType;
+        Properties = values?.ToArray() ?? Array.Empty<KeyValuePair<string, object>>();
+        Expressions = expressions?.ToArray() ?? Array.Empty<KeyValuePair<string, LambdaExpression>>();
+        Rules = rules?.ToArray() ?? Array.Empty<IRuleDefinition>();
     }
 }

--- a/src/NRules/NRules/Diagnostics/RhsExpressionErrorEventArgs.cs
+++ b/src/NRules/NRules/Diagnostics/RhsExpressionErrorEventArgs.cs
@@ -3,31 +3,30 @@ using System.Linq.Expressions;
 using NRules.RuleModel;
 using NRules.Utilities;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Information related to error events raised during right-hand side expression evaluation.
+/// </summary>
+public class RhsExpressionErrorEventArgs : RhsExpressionEventArgs, IRecoverableError
 {
     /// <summary>
-    /// Information related to error events raised during right-hand side expression evaluation.
+    /// Initializes a new instance of the <c>RhsExpressionErrorEventArgs</c> class.
     /// </summary>
-    public class RhsExpressionErrorEventArgs : RhsExpressionEventArgs, IRecoverableError
+    /// <param name="expression">Expression related to the event.</param>
+    /// <param name="exception">Exception related to the event.</param>
+    /// <param name="arguments">Expression arguments.</param>
+    /// <param name="match">Rule match related to the event.</param>
+    public RhsExpressionErrorEventArgs(Expression expression, Exception exception, object[] arguments, IMatch match)
+        : base(expression, exception, arguments, match)
     {
-        /// <summary>
-        /// Initializes a new instance of the <c>RhsExpressionErrorEventArgs</c> class.
-        /// </summary>
-        /// <param name="expression">Expression related to the event.</param>
-        /// <param name="exception">Exception related to the event.</param>
-        /// <param name="arguments">Expression arguments.</param>
-        /// <param name="match">Rule match related to the event.</param>
-        public RhsExpressionErrorEventArgs(Expression expression, Exception exception, object[] arguments, IMatch match)
-            : base(expression, exception, arguments, match)
-        {
-        }
-        
-        internal RhsExpressionErrorEventArgs(Expression expression, Exception exception, IArguments arguments, IMatch match)
-            : base(expression, exception, arguments, match)
-        {
-        }
-
-        /// <inheritdoc />
-        public bool IsHandled { get; set; }
     }
+    
+    internal RhsExpressionErrorEventArgs(Expression expression, Exception exception, IArguments arguments, IMatch match)
+        : base(expression, exception, arguments, match)
+    {
+    }
+
+    /// <inheritdoc />
+    public bool IsHandled { get; set; }
 }

--- a/src/NRules/NRules/Diagnostics/RhsExpressionEventArgs.cs
+++ b/src/NRules/NRules/Diagnostics/RhsExpressionEventArgs.cs
@@ -3,35 +3,34 @@ using System.Linq.Expressions;
 using NRules.RuleModel;
 using NRules.Utilities;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Information related to events raised during right-hand side expression evaluation.
+/// </summary>
+public class RhsExpressionEventArgs : ExpressionEventArgs
 {
     /// <summary>
-    /// Information related to events raised during right-hand side expression evaluation.
+    /// Initializes a new instance of the <c>RhsExpressionEventArgs</c> class.
     /// </summary>
-    public class RhsExpressionEventArgs : ExpressionEventArgs
+    /// <param name="expression">Expression related to the event.</param>
+    /// <param name="exception">Exception related to the event.</param>
+    /// <param name="arguments">Expression arguments.</param>
+    /// <param name="match">Rule match related to the event.</param>
+    public RhsExpressionEventArgs(Expression expression, Exception exception, object[] arguments, IMatch match)
+        : base(expression, exception, arguments, null)
     {
-        /// <summary>
-        /// Initializes a new instance of the <c>RhsExpressionEventArgs</c> class.
-        /// </summary>
-        /// <param name="expression">Expression related to the event.</param>
-        /// <param name="exception">Exception related to the event.</param>
-        /// <param name="arguments">Expression arguments.</param>
-        /// <param name="match">Rule match related to the event.</param>
-        public RhsExpressionEventArgs(Expression expression, Exception exception, object[] arguments, IMatch match)
-            : base(expression, exception, arguments, null)
-        {
-            Match = match;
-        }
-        
-        internal RhsExpressionEventArgs(Expression expression, Exception exception, IArguments arguments, IMatch match)
-            : base(expression, exception, arguments, null)
-        {
-            Match = match;
-        }
-
-        /// <summary>
-        /// Rule match related to the event.
-        /// </summary>
-        public IMatch Match { get; }
+        Match = match;
     }
+    
+    internal RhsExpressionEventArgs(Expression expression, Exception exception, IArguments arguments, IMatch match)
+        : base(expression, exception, arguments, null)
+    {
+        Match = match;
+    }
+
+    /// <summary>
+    /// Rule match related to the event.
+    /// </summary>
+    public IMatch Match { get; }
 }

--- a/src/NRules/NRules/Diagnostics/SchemaBuilder.cs
+++ b/src/NRules/NRules/Diagnostics/SchemaBuilder.cs
@@ -3,42 +3,41 @@ using System.Collections.Generic;
 using System.Linq;
 using NRules.Rete;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+internal class SchemaBuilder
 {
-    internal class SchemaBuilder
+    private readonly List<(INode source, INode target)> _links = new();
+    private readonly Dictionary<INode, ReteNode> _nodeMap = new(); 
+
+    public bool IsVisited(INode node)
     {
-        private readonly List<(INode source, INode target)> _links = new();
-        private readonly Dictionary<INode, ReteNode> _nodeMap = new(); 
+        return _nodeMap.ContainsKey(node);
+    }
 
-        public bool IsVisited(INode node)
-        {
-            return _nodeMap.ContainsKey(node);
-        }
+    public void AddNode<TNode>(TNode node, Func<TNode, ReteNode> ctor) where TNode : INode
+    {
+        var nodeInfo = ctor(node);
+        _nodeMap.Add(node, nodeInfo);
+    }
 
-        public void AddNode<TNode>(TNode node, Func<TNode, ReteNode> ctor) where TNode : INode
-        {
-            var nodeInfo = ctor(node);
-            _nodeMap.Add(node, nodeInfo);
-        }
+    public void AddLink(INode source, INode target)
+    {
+        _links.Add((source, target));
+    }
 
-        public void AddLink(INode source, INode target)
+    public void AddLinks(INode source, IEnumerable<INode> targets)
+    {
+        foreach (var target in targets)
         {
-            _links.Add((source, target));
+            AddLink(source, target);
         }
+    }
 
-        public void AddLinks(INode source, IEnumerable<INode> targets)
-        {
-            foreach (var target in targets)
-            {
-                AddLink(source, target);
-            }
-        }
-
-        public ReteGraph Build()
-        {
-            var nodes = _nodeMap.Values;
-            var links = _links.Select(x => new ReteLink(_nodeMap[x.source], _nodeMap[x.target]));
-            return new ReteGraph(nodes, links);
-        }
+    public ReteGraph Build()
+    {
+        var nodes = _nodeMap.Values;
+        var links = _links.Select(x => new ReteLink(_nodeMap[x.source], _nodeMap[x.target]));
+        return new ReteGraph(nodes, links);
     }
 }

--- a/src/NRules/NRules/Diagnostics/SchemaReteVisitor.cs
+++ b/src/NRules/NRules/Diagnostics/SchemaReteVisitor.cs
@@ -1,122 +1,121 @@
 using NRules.Rete;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+internal class SchemaReteVisitor : ReteNodeVisitor<SchemaBuilder>
 {
-    internal class SchemaReteVisitor : ReteNodeVisitor<SchemaBuilder>
+    protected internal override void VisitRootNode(SchemaBuilder builder, RootNode node)
     {
-        protected internal override void VisitRootNode(SchemaBuilder builder, RootNode node)
-        {
-            if (builder.IsVisited(node)) return;
-            builder.AddNode(node, ReteNode.Create);
-            base.VisitRootNode(builder, node);
-        }
+        if (builder.IsVisited(node)) return;
+        builder.AddNode(node, ReteNode.Create);
+        base.VisitRootNode(builder, node);
+    }
 
-        protected internal override void VisitTypeNode(SchemaBuilder builder, TypeNode node)
-        {
-            if (builder.IsVisited(node)) return;
-            builder.AddNode(node, ReteNode.Create);
-            base.VisitTypeNode(builder, node);
-        }
+    protected internal override void VisitTypeNode(SchemaBuilder builder, TypeNode node)
+    {
+        if (builder.IsVisited(node)) return;
+        builder.AddNode(node, ReteNode.Create);
+        base.VisitTypeNode(builder, node);
+    }
 
-        protected internal override void VisitSelectionNode(SchemaBuilder builder, SelectionNode node)
-        {
-            if (builder.IsVisited(node)) return;
-            builder.AddNode(node, ReteNode.Create);
-            base.VisitSelectionNode(builder, node);
-        }
+    protected internal override void VisitSelectionNode(SchemaBuilder builder, SelectionNode node)
+    {
+        if (builder.IsVisited(node)) return;
+        builder.AddNode(node, ReteNode.Create);
+        base.VisitSelectionNode(builder, node);
+    }
 
-        protected internal override void VisitAlphaMemoryNode(SchemaBuilder builder, AlphaMemoryNode node)
-        {
-            if (builder.IsVisited(node)) return;
-            builder.AddNode(node, ReteNode.Create);
-            builder.AddLinks(node, node.Sinks);
-            base.VisitAlphaMemoryNode(builder, node);
-        }
+    protected internal override void VisitAlphaMemoryNode(SchemaBuilder builder, AlphaMemoryNode node)
+    {
+        if (builder.IsVisited(node)) return;
+        builder.AddNode(node, ReteNode.Create);
+        builder.AddLinks(node, node.Sinks);
+        base.VisitAlphaMemoryNode(builder, node);
+    }
 
-        protected override void VisitAlphaNode(SchemaBuilder builder, AlphaNode node)
-        {
-            builder.AddLinks(node, node.ChildNodes);
-            if (node.MemoryNode != null)
-            {
-                builder.AddLink(node, node.MemoryNode);
-            }
-            base.VisitAlphaNode(builder, node);
-        }
-
-        protected internal override void VisitJoinNode(SchemaBuilder builder, JoinNode node)
-        {
-            if (builder.IsVisited(node)) return;
-            builder.AddNode(node, ReteNode.Create);
-            base.VisitJoinNode(builder, node);
-        }
-
-        protected internal override void VisitNotNode(SchemaBuilder builder, NotNode node)
-        {
-            if (builder.IsVisited(node)) return;
-            builder.AddNode(node, ReteNode.Create);
-            base.VisitNotNode(builder, node);
-        }
-
-        protected internal override void VisitExistsNode(SchemaBuilder builder, ExistsNode node)
-        {
-            if (builder.IsVisited(node)) return;
-            builder.AddNode(node, ReteNode.Create);
-            base.VisitExistsNode(builder, node);
-        }
-
-        protected internal override void VisitAggregateNode(SchemaBuilder builder, AggregateNode node)
-        {
-            if (builder.IsVisited(node)) return;
-            builder.AddNode(node, ReteNode.Create);
-            base.VisitAggregateNode(builder, node);
-        }
-
-        protected internal override void VisitObjectInputAdapter(SchemaBuilder builder, ObjectInputAdapter node)
-        {
-            if (builder.IsVisited(node)) return;
-            builder.AddNode(node, ReteNode.Create);
-            builder.AddLinks(node, node.Sinks);
-            base.VisitObjectInputAdapter(builder, node);
-        }
-
-        protected internal override void VisitBindingNode(SchemaBuilder builder, BindingNode node)
-        {
-            if (builder.IsVisited(node)) return;
-            builder.AddNode(node, ReteNode.Create);
-            base.VisitBindingNode(builder, node);
-        }
-
-        protected internal override void VisitBetaMemoryNode(SchemaBuilder builder, BetaMemoryNode node)
-        {
-            if (builder.IsVisited(node)) return;
-            builder.AddNode(node, ReteNode.Create);
-            builder.AddLinks(node, node.Sinks);
-            base.VisitBetaMemoryNode(builder, node);
-        }
-
-        protected override void VisitBetaNode(SchemaBuilder builder, BetaNode node)
+    protected override void VisitAlphaNode(SchemaBuilder builder, AlphaNode node)
+    {
+        builder.AddLinks(node, node.ChildNodes);
+        if (node.MemoryNode != null)
         {
             builder.AddLink(node, node.MemoryNode);
-            base.VisitBetaNode(builder, node);
         }
+        base.VisitAlphaNode(builder, node);
+    }
 
-        protected internal override void VisitRuleNode(SchemaBuilder builder, RuleNode node)
-        {
-            if (builder.IsVisited(node)) return;
-            builder.AddNode(node, ReteNode.Create);
-            base.VisitRuleNode(builder, node);
-        }
+    protected internal override void VisitJoinNode(SchemaBuilder builder, JoinNode node)
+    {
+        if (builder.IsVisited(node)) return;
+        builder.AddNode(node, ReteNode.Create);
+        base.VisitJoinNode(builder, node);
+    }
 
-        protected internal override void VisitDummyNode(SchemaBuilder builder, DummyNode node)
+    protected internal override void VisitNotNode(SchemaBuilder builder, NotNode node)
+    {
+        if (builder.IsVisited(node)) return;
+        builder.AddNode(node, ReteNode.Create);
+        base.VisitNotNode(builder, node);
+    }
+
+    protected internal override void VisitExistsNode(SchemaBuilder builder, ExistsNode node)
+    {
+        if (builder.IsVisited(node)) return;
+        builder.AddNode(node, ReteNode.Create);
+        base.VisitExistsNode(builder, node);
+    }
+
+    protected internal override void VisitAggregateNode(SchemaBuilder builder, AggregateNode node)
+    {
+        if (builder.IsVisited(node)) return;
+        builder.AddNode(node, ReteNode.Create);
+        base.VisitAggregateNode(builder, node);
+    }
+
+    protected internal override void VisitObjectInputAdapter(SchemaBuilder builder, ObjectInputAdapter node)
+    {
+        if (builder.IsVisited(node)) return;
+        builder.AddNode(node, ReteNode.Create);
+        builder.AddLinks(node, node.Sinks);
+        base.VisitObjectInputAdapter(builder, node);
+    }
+
+    protected internal override void VisitBindingNode(SchemaBuilder builder, BindingNode node)
+    {
+        if (builder.IsVisited(node)) return;
+        builder.AddNode(node, ReteNode.Create);
+        base.VisitBindingNode(builder, node);
+    }
+
+    protected internal override void VisitBetaMemoryNode(SchemaBuilder builder, BetaMemoryNode node)
+    {
+        if (builder.IsVisited(node)) return;
+        builder.AddNode(node, ReteNode.Create);
+        builder.AddLinks(node, node.Sinks);
+        base.VisitBetaMemoryNode(builder, node);
+    }
+
+    protected override void VisitBetaNode(SchemaBuilder builder, BetaNode node)
+    {
+        builder.AddLink(node, node.MemoryNode);
+        base.VisitBetaNode(builder, node);
+    }
+
+    protected internal override void VisitRuleNode(SchemaBuilder builder, RuleNode node)
+    {
+        if (builder.IsVisited(node)) return;
+        builder.AddNode(node, ReteNode.Create);
+        base.VisitRuleNode(builder, node);
+    }
+
+    protected internal override void VisitDummyNode(SchemaBuilder builder, DummyNode node)
+    {
+        if (builder.IsVisited(node)) return;
+        builder.AddNode(node, ReteNode.Create);
+        foreach (var sink in node.Sinks)
         {
-            if (builder.IsVisited(node)) return;
-            builder.AddNode(node, ReteNode.Create);
-            foreach (var sink in node.Sinks)
-            {
-                if (!builder.IsVisited(sink))
-                    builder.AddLink(node, sink);
-            }
-            base.VisitDummyNode(builder, node);
+            if (!builder.IsVisited(sink))
+                builder.AddLink(node, sink);
         }
+        base.VisitDummyNode(builder, node);
     }
 }

--- a/src/NRules/NRules/Diagnostics/WorkingMemoryEventArgs.cs
+++ b/src/NRules/NRules/Diagnostics/WorkingMemoryEventArgs.cs
@@ -1,25 +1,24 @@
 using System;
 using NRules.RuleModel;
 
-namespace NRules.Diagnostics
+namespace NRules.Diagnostics;
+
+/// <summary>
+/// Information related to working memory events.
+/// </summary>
+public class WorkingMemoryEventArgs : EventArgs
 {
     /// <summary>
-    /// Information related to working memory events.
+    /// Initializes a new instance of the <c>WorkingMemoryEventArgs</c> class.
     /// </summary>
-    public class WorkingMemoryEventArgs : EventArgs
+    /// <param name="fact">Fact related to the event.</param>
+    public WorkingMemoryEventArgs(IFact fact)
     {
-        /// <summary>
-        /// Initializes a new instance of the <c>WorkingMemoryEventArgs</c> class.
-        /// </summary>
-        /// <param name="fact">Fact related to the event.</param>
-        public WorkingMemoryEventArgs(IFact fact)
-        {
-            Fact = fact;
-        }
-
-        /// <summary>
-        /// Fact related to the event.
-        /// </summary>
-        public IFact Fact { get; }
+        Fact = fact;
     }
+
+    /// <summary>
+    /// Fact related to the event.
+    /// </summary>
+    public IFact Fact { get; }
 }

--- a/src/NRules/NRules/ExecutionContext.cs
+++ b/src/NRules/NRules/ExecutionContext.cs
@@ -1,42 +1,41 @@
 ﻿using System.Collections.Generic;
 using NRules.Diagnostics;
 
-namespace NRules
+namespace NRules;
+
+internal interface IExecutionContext
 {
-    internal interface IExecutionContext
+    ISessionInternal Session { get; }
+    IWorkingMemory WorkingMemory { get; }
+    IAgendaInternal Agenda { get; }
+    IEventAggregator EventAggregator { get; }
+    IMetricsAggregator MetricsAggregator { get; }
+    IIdGenerator IdGenerator { get; }
+}
+
+internal class ExecutionContext : IExecutionContext
+{
+    public ExecutionContext(ISessionInternal session, 
+        IWorkingMemory workingMemory, 
+        IAgendaInternal agenda, 
+        IEventAggregator eventAggregator, 
+        IMetricsAggregator metricsAggregator, 
+        IIdGenerator idGenerator)
     {
-        ISessionInternal Session { get; }
-        IWorkingMemory WorkingMemory { get; }
-        IAgendaInternal Agenda { get; }
-        IEventAggregator EventAggregator { get; }
-        IMetricsAggregator MetricsAggregator { get; }
-        IIdGenerator IdGenerator { get; }
+        Session = session;
+        WorkingMemory = workingMemory;
+        Agenda = agenda;
+        EventAggregator = eventAggregator;
+        MetricsAggregator = metricsAggregator;
+        IdGenerator = idGenerator;
+        UnlinkQueue = new Queue<Activation>();
     }
 
-    internal class ExecutionContext : IExecutionContext
-    {
-        public ExecutionContext(ISessionInternal session, 
-            IWorkingMemory workingMemory, 
-            IAgendaInternal agenda, 
-            IEventAggregator eventAggregator, 
-            IMetricsAggregator metricsAggregator, 
-            IIdGenerator idGenerator)
-        {
-            Session = session;
-            WorkingMemory = workingMemory;
-            Agenda = agenda;
-            EventAggregator = eventAggregator;
-            MetricsAggregator = metricsAggregator;
-            IdGenerator = idGenerator;
-            UnlinkQueue = new Queue<Activation>();
-        }
-
-        public ISessionInternal Session { get; }
-        public IWorkingMemory WorkingMemory { get; }
-        public IAgendaInternal Agenda { get; }
-        public IEventAggregator EventAggregator { get; }
-        public IMetricsAggregator MetricsAggregator { get; }
-        public IIdGenerator IdGenerator { get; }
-        public Queue<Activation> UnlinkQueue { get; }
-    }
+    public ISessionInternal Session { get; }
+    public IWorkingMemory WorkingMemory { get; }
+    public IAgendaInternal Agenda { get; }
+    public IEventAggregator EventAggregator { get; }
+    public IMetricsAggregator MetricsAggregator { get; }
+    public IIdGenerator IdGenerator { get; }
+    public Queue<Activation> UnlinkQueue { get; }
 }

--- a/src/NRules/NRules/ExpressionEvaluationException.cs
+++ b/src/NRules/NRules/ExpressionEvaluationException.cs
@@ -1,29 +1,28 @@
 ﻿using System;
 using System.Linq.Expressions;
 
-namespace NRules
+namespace NRules;
+
+/// <summary>
+/// Exception raised if evaluation of the expression failed.
+/// Inner exception contains the details of the failure.
+/// </summary>
+internal class ExpressionEvaluationException : Exception
 {
     /// <summary>
-    /// Exception raised if evaluation of the expression failed.
-    /// Inner exception contains the details of the failure.
+    /// Expression that failed to evaluate.
     /// </summary>
-    internal class ExpressionEvaluationException : Exception
+    public Expression Expression { get; }
+
+    /// <summary>
+    /// Indicates whether exception was handled via event handler.
+    /// </summary>
+    public bool IsHandled { get; }
+
+    internal ExpressionEvaluationException(Exception inner, Expression expression, bool isHandled)
+        : base("Expression evaluation failed", inner)
     {
-        /// <summary>
-        /// Expression that failed to evaluate.
-        /// </summary>
-        public Expression Expression { get; }
-
-        /// <summary>
-        /// Indicates whether exception was handled via event handler.
-        /// </summary>
-        public bool IsHandled { get; }
-
-        internal ExpressionEvaluationException(Exception inner, Expression expression, bool isHandled)
-            : base("Expression evaluation failed", inner)
-        {
-            Expression = expression;
-            IsHandled = isHandled;
-        }
+        Expression = expression;
+        IsHandled = isHandled;
     }
 }

--- a/src/NRules/NRules/Extensibility/DependencyResolver.cs
+++ b/src/NRules/NRules/Extensibility/DependencyResolver.cs
@@ -1,31 +1,30 @@
 using System;
 
-namespace NRules.Extensibility
+namespace NRules.Extensibility;
+
+/// <summary>
+/// Defines a mechanism to resolve rule dependencies at runtime.
+/// An instance of <c>IDependencyResolver</c> can be assigned to <see cref="ISessionFactory.DependencyResolver"/> or
+/// <see cref="ISession.DependencyResolver"/>, so that all requests for rule dependencies resolution are fulfilled by that resolver.
+/// </summary>
+/// <remarks>If dependency resolver is not configured, any attempt to resolve rule dependencies will result in exception.</remarks>
+public interface IDependencyResolver
 {
     /// <summary>
-    /// Defines a mechanism to resolve rule dependencies at runtime.
-    /// An instance of <c>IDependencyResolver</c> can be assigned to <see cref="ISessionFactory.DependencyResolver"/> or
-    /// <see cref="ISession.DependencyResolver"/>, so that all requests for rule dependencies resolution are fulfilled by that resolver.
+    /// Resolves a registered service (normally via an IoC container).
     /// </summary>
-    /// <remarks>If dependency resolver is not configured, any attempt to resolve rule dependencies will result in exception.</remarks>
-    public interface IDependencyResolver
-    {
-        /// <summary>
-        /// Resolves a registered service (normally via an IoC container).
-        /// </summary>
-        /// <param name="context">Information about the context at which the resolution call is made.</param>
-        /// <param name="serviceType">The type of requested service.</param>
-        /// <returns>Requested service.</returns>
-        object Resolve(IResolutionContext context, Type serviceType);
-    }
+    /// <param name="context">Information about the context at which the resolution call is made.</param>
+    /// <param name="serviceType">The type of requested service.</param>
+    /// <returns>Requested service.</returns>
+    object Resolve(IResolutionContext context, Type serviceType);
+}
 
-    internal class DependencyResolver : IDependencyResolver
+internal class DependencyResolver : IDependencyResolver
+{
+    public object Resolve(IResolutionContext context, Type serviceType)
     {
-        public object Resolve(IResolutionContext context, Type serviceType)
-        {
-            const string message = "Dependency resolver not provided. " 
-                + "To use rule dependencies set a dependency resolver on the rules session.";
-            throw new InvalidOperationException(message);
-        }
+        const string message = "Dependency resolver not provided. " 
+            + "To use rule dependencies set a dependency resolver on the rules session.";
+        throw new InvalidOperationException(message);
     }
 }

--- a/src/NRules/NRules/Extensibility/ExpressionCompiler.cs
+++ b/src/NRules/NRules/Extensibility/ExpressionCompiler.cs
@@ -1,29 +1,28 @@
 ﻿using System;
 using System.Linq.Expressions;
 
-namespace NRules.Extensibility
+namespace NRules.Extensibility;
+
+/// <summary>
+/// Compiles expressions used in rules conditions and actions in a form of expression trees
+/// into executable delegates.
+/// The default implementation uses built-in .NET expression compiler.
+/// </summary>
+public interface IExpressionCompiler
 {
     /// <summary>
-    /// Compiles expressions used in rules conditions and actions in a form of expression trees
-    /// into executable delegates.
-    /// The default implementation uses built-in .NET expression compiler.
+    /// Compiles an expression tree into an executable delegate.
     /// </summary>
-    public interface IExpressionCompiler
-    {
-        /// <summary>
-        /// Compiles an expression tree into an executable delegate.
-        /// </summary>
-        /// <typeparam name="TDelegate">Type of the underlying expression delegate.</typeparam>
-        /// <param name="expression">Expression tree to compile.</param>
-        /// <returns>The compiled delegate.</returns>
-        TDelegate Compile<TDelegate>(Expression<TDelegate> expression) where TDelegate : Delegate;
-    }
+    /// <typeparam name="TDelegate">Type of the underlying expression delegate.</typeparam>
+    /// <param name="expression">Expression tree to compile.</param>
+    /// <returns>The compiled delegate.</returns>
+    TDelegate Compile<TDelegate>(Expression<TDelegate> expression) where TDelegate : Delegate;
+}
 
-    internal class ExpressionCompiler : IExpressionCompiler
+internal class ExpressionCompiler : IExpressionCompiler
+{
+    public TDelegate Compile<TDelegate>(Expression<TDelegate> expression) where TDelegate : Delegate
     {
-        public TDelegate Compile<TDelegate>(Expression<TDelegate> expression) where TDelegate : Delegate
-        {
-            return expression.Compile();
-        }
+        return expression.Compile();
     }
 }

--- a/src/NRules/NRules/Extensibility/IActionInterceptor.cs
+++ b/src/NRules/NRules/Extensibility/IActionInterceptor.cs
@@ -1,29 +1,28 @@
 ﻿using System.Collections.Generic;
 using NRules.RuleModel;
 
-namespace NRules.Extensibility
+namespace NRules.Extensibility;
+
+/// <summary>
+/// Extension point for rule actions interception.
+/// An instance of <c>IActionInterceptor</c> can be assigned to <see cref="ISessionFactory.ActionInterceptor"/> or
+/// <see cref="ISession.ActionInterceptor"/>, so that invocation of all rule actions is delegated to the interceptor.
+/// The interceptor is free to add pre- or post-processing to action invocations, error handling, or decide not to invoke
+/// the actions.
+/// </summary>
+/// <remarks>
+/// When actions are invoked via <c>IActionInterceptor</c>, exceptions thrown by actions
+/// are not wrapped into <see cref="RuleRhsExpressionEvaluationException"/>. It is the responsibility
+/// of the interceptor to handle the exceptions.
+/// Exceptions thrown from the interceptor are not handled by the engine and just propagate up the stack.
+/// </remarks>
+public interface IActionInterceptor
 {
     /// <summary>
-    /// Extension point for rule actions interception.
-    /// An instance of <c>IActionInterceptor</c> can be assigned to <see cref="ISessionFactory.ActionInterceptor"/> or
-    /// <see cref="ISession.ActionInterceptor"/>, so that invocation of all rule actions is delegated to the interceptor.
-    /// The interceptor is free to add pre- or post-processing to action invocations, error handling, or decide not to invoke
-    /// the actions.
+    /// Called by the rules engine in place of the action invocations when a rule fires.
+    /// The interceptor can add behavior to action invocation and choose to either proceed with the invocations or not.
     /// </summary>
-    /// <remarks>
-    /// When actions are invoked via <c>IActionInterceptor</c>, exceptions thrown by actions
-    /// are not wrapped into <see cref="RuleRhsExpressionEvaluationException"/>. It is the responsibility
-    /// of the interceptor to handle the exceptions.
-    /// Exceptions thrown from the interceptor are not handled by the engine and just propagate up the stack.
-    /// </remarks>
-    public interface IActionInterceptor
-    {
-        /// <summary>
-        /// Called by the rules engine in place of the action invocations when a rule fires.
-        /// The interceptor can add behavior to action invocation and choose to either proceed with the invocations or not.
-        /// </summary>
-        /// <param name="context">Action context, containing information about the firing rule and matched facts.</param>
-        /// <param name="actions">Action invocations for rule actions being intercepted.</param>
-        void Intercept(IContext context, IEnumerable<IActionInvocation> actions);
-    }
+    /// <param name="context">Action context, containing information about the firing rule and matched facts.</param>
+    /// <param name="actions">Action invocations for rule actions being intercepted.</param>
+    void Intercept(IContext context, IEnumerable<IActionInvocation> actions);
 }

--- a/src/NRules/NRules/Extensibility/IActionInvocation.cs
+++ b/src/NRules/NRules/Extensibility/IActionInvocation.cs
@@ -1,29 +1,28 @@
 using NRules.RuleModel;
 
-namespace NRules.Extensibility
+namespace NRules.Extensibility;
+
+/// <summary>
+/// Represents invocation of the proxied rule action.
+/// </summary>
+public interface IActionInvocation
 {
     /// <summary>
-    /// Represents invocation of the proxied rule action.
+    /// Action arguments.
+    /// To get more information about the matched facts, whether they are passed to a given action or not,
+    /// use <see cref="IContext"/> passed to the <see cref="IActionInterceptor.Intercept"/> method.
     /// </summary>
-    public interface IActionInvocation
-    {
-        /// <summary>
-        /// Action arguments.
-        /// To get more information about the matched facts, whether they are passed to a given action or not,
-        /// use <see cref="IContext"/> passed to the <see cref="IActionInterceptor.Intercept"/> method.
-        /// </summary>
-        /// <remarks>Action arguments also include dependencies that are passed to the action method.</remarks>
-        /// <remarks>Action arguments don't include <c>IContext</c>.</remarks>
-        object[] Arguments { get; }
+    /// <remarks>Action arguments also include dependencies that are passed to the action method.</remarks>
+    /// <remarks>Action arguments don't include <c>IContext</c>.</remarks>
+    object[] Arguments { get; }
 
-        /// <summary>
-        /// Invokes the action.
-        /// </summary>
-        void Invoke();
+    /// <summary>
+    /// Invokes the action.
+    /// </summary>
+    void Invoke();
 
-        /// <summary>
-        /// Activation events that trigger this action.
-        /// </summary>
-        ActionTrigger Trigger { get; }
-    }
+    /// <summary>
+    /// Activation events that trigger this action.
+    /// </summary>
+    ActionTrigger Trigger { get; }
 }

--- a/src/NRules/NRules/Extensibility/ResolutionContext.cs
+++ b/src/NRules/NRules/Extensibility/ResolutionContext.cs
@@ -1,32 +1,31 @@
 using NRules.RuleModel;
 
-namespace NRules.Extensibility
+namespace NRules.Extensibility;
+
+/// <summary>
+/// Context for dependency resolution.
+/// </summary>
+public interface IResolutionContext
 {
     /// <summary>
-    /// Context for dependency resolution.
+    /// Rules engine session that requested dependency resolution.
     /// </summary>
-    public interface IResolutionContext
-    {
-        /// <summary>
-        /// Rules engine session that requested dependency resolution.
-        /// </summary>
-        ISession Session { get; }
+    ISession Session { get; }
 
-        /// <summary>
-        /// Rule that requested dependency resolution.
-        /// </summary>
-        IRuleDefinition Rule { get; }
+    /// <summary>
+    /// Rule that requested dependency resolution.
+    /// </summary>
+    IRuleDefinition Rule { get; }
+}
+
+internal class ResolutionContext : IResolutionContext
+{
+    public ResolutionContext(ISession session, IRuleDefinition rule)
+    {
+        Session = session;
+        Rule = rule;
     }
 
-    internal class ResolutionContext : IResolutionContext
-    {
-        public ResolutionContext(ISession session, IRuleDefinition rule)
-        {
-            Session = session;
-            Rule = rule;
-        }
-
-        public ISession Session { get; }
-        public IRuleDefinition Rule { get; }
-    }
+    public ISession Session { get; }
+    public IRuleDefinition Rule { get; }
 }

--- a/src/NRules/NRules/FactResult.cs
+++ b/src/NRules/NRules/FactResult.cs
@@ -1,33 +1,32 @@
 ﻿using System.Collections.Generic;
 
-namespace NRules
+namespace NRules;
+
+/// <summary>
+/// Result of an operation on a set of facts.
+/// </summary>
+public interface IFactResult
 {
     /// <summary>
-    /// Result of an operation on a set of facts.
+    /// Number of facts on which the operation failed.
     /// </summary>
-    public interface IFactResult
-    {
-        /// <summary>
-        /// Number of facts on which the operation failed.
-        /// </summary>
-        int FailedCount { get; }
+    int FailedCount { get; }
 
-        /// <summary>
-        /// Facts on which the operation failed.
-        /// </summary>
-        IEnumerable<object> Failed { get; }
+    /// <summary>
+    /// Facts on which the operation failed.
+    /// </summary>
+    IEnumerable<object> Failed { get; }
+}
+
+internal class FactResult : IFactResult
+{
+    private readonly List<object> _failed;
+
+    internal FactResult(List<object> failed)
+    {
+        _failed = failed;
     }
 
-    internal class FactResult : IFactResult
-    {
-        private readonly List<object> _failed;
-
-        internal FactResult(List<object> failed)
-        {
-            _failed = failed;
-        }
-
-        public int FailedCount => _failed.Count;
-        public IEnumerable<object> Failed => _failed;
-    }
+    public int FailedCount => _failed.Count;
+    public IEnumerable<object> Failed => _failed;
 }

--- a/src/NRules/NRules/IdGenerator.cs
+++ b/src/NRules/NRules/IdGenerator.cs
@@ -1,17 +1,16 @@
-﻿namespace NRules
+﻿namespace NRules;
+
+internal interface IIdGenerator
 {
-    internal interface IIdGenerator
-    {
-        long NextTupleId();
-    }
+    long NextTupleId();
+}
 
-    internal class IdGenerator : IIdGenerator
-    {
-        private long _nextId = 1;
+internal class IdGenerator : IIdGenerator
+{
+    private long _nextId = 1;
 
-        public long NextTupleId()
-        {
-            return _nextId++;
-        }
+    public long NextTupleId()
+    {
+        return _nextId++;
     }
 }

--- a/src/NRules/NRules/LinkedFactSet.cs
+++ b/src/NRules/NRules/LinkedFactSet.cs
@@ -2,62 +2,61 @@ using System.Collections.Generic;
 using NRules.Rete;
 using NRules.RuleModel;
 
-namespace NRules
+namespace NRules;
+
+/// <summary>
+/// Action taken on the linked fact.
+/// </summary>
+public enum LinkedFactAction
+{
+    /// <summary>
+    /// Linked fact is inserted into the session.
+    /// </summary>
+    Insert,
+
+    /// <summary>
+    /// Linked fact is updated in the session.
+    /// </summary>
+    Update,
+
+    /// <summary>
+    /// Linked fact is retracted from the session.
+    /// </summary>
+    Retract,
+}
+
+/// <summary>
+/// Collection of linked facts propagated as a set.
+/// </summary>
+public interface ILinkedFactSet
 {
     /// <summary>
     /// Action taken on the linked fact.
     /// </summary>
-    public enum LinkedFactAction
-    {
-        /// <summary>
-        /// Linked fact is inserted into the session.
-        /// </summary>
-        Insert,
-
-        /// <summary>
-        /// Linked fact is updated in the session.
-        /// </summary>
-        Update,
-
-        /// <summary>
-        /// Linked fact is retracted from the session.
-        /// </summary>
-        Retract,
-    }
+    LinkedFactAction Action { get; }
 
     /// <summary>
-    /// Collection of linked facts propagated as a set.
+    /// Linked facts in the set.
     /// </summary>
-    public interface ILinkedFactSet
+    IEnumerable<IFact> Facts { get; }
+
+    /// <summary>
+    /// Number of linked facts in the set.
+    /// </summary>
+    int FactCount { get; }
+}
+
+internal struct LinkedFactSet : ILinkedFactSet
+{
+    public LinkedFactAction Action { get; }
+    IEnumerable<IFact> ILinkedFactSet.Facts => Facts;
+    int ILinkedFactSet.FactCount => Facts.Count;
+
+    public List<Fact> Facts { get; }
+
+    public LinkedFactSet(LinkedFactAction action)
     {
-        /// <summary>
-        /// Action taken on the linked fact.
-        /// </summary>
-        LinkedFactAction Action { get; }
-
-        /// <summary>
-        /// Linked facts in the set.
-        /// </summary>
-        IEnumerable<IFact> Facts { get; }
-
-        /// <summary>
-        /// Number of linked facts in the set.
-        /// </summary>
-        int FactCount { get; }
-    }
-
-    internal struct LinkedFactSet : ILinkedFactSet
-    {
-        public LinkedFactAction Action { get; }
-        IEnumerable<IFact> ILinkedFactSet.Facts => Facts;
-        int ILinkedFactSet.FactCount => Facts.Count;
-
-        public List<Fact> Facts { get; }
-
-        public LinkedFactSet(LinkedFactAction action)
-        {
-            Action = action;
-            Facts = new List<Fact>();
-        }
+        Action = action;
+        Facts = new List<Fact>();
     }
 }

--- a/src/NRules/NRules/LinkedFactSource.cs
+++ b/src/NRules/NRules/LinkedFactSource.cs
@@ -1,30 +1,29 @@
 ﻿using System.Collections.Generic;
 using NRules.RuleModel;
 
-namespace NRules
+namespace NRules;
+
+/// <summary>
+/// Fact source for linked facts.
+/// </summary>
+public interface ILinkedFactSource : IFactSource
 {
     /// <summary>
-    /// Fact source for linked facts.
+    /// Rule that generated the linked fact.
     /// </summary>
-    public interface ILinkedFactSource : IFactSource
+    IRuleDefinition Rule { get; }
+}
+
+internal class LinkedFactSource : ILinkedFactSource
+{
+    private readonly Activation _activation;
+
+    public LinkedFactSource(Activation activation)
     {
-        /// <summary>
-        /// Rule that generated the linked fact.
-        /// </summary>
-        IRuleDefinition Rule { get; }
+        _activation = activation;
     }
 
-    internal class LinkedFactSource : ILinkedFactSource
-    {
-        private readonly Activation _activation;
-
-        public LinkedFactSource(Activation activation)
-        {
-            _activation = activation;
-        }
-
-        public FactSourceType SourceType => FactSourceType.Linked;
-        public IEnumerable<IFact> Facts => _activation.Facts;
-        public IRuleDefinition Rule => _activation.Rule;
-    }
+    public FactSourceType SourceType => FactSourceType.Linked;
+    public IEnumerable<IFact> Facts => _activation.Facts;
+    public IRuleDefinition Rule => _activation.Rule;
 }

--- a/src/NRules/NRules/NRules.csproj
+++ b/src/NRules/NRules/NRules.csproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NRules/NRules/Rete/AggregateFactSource.cs
+++ b/src/NRules/NRules/Rete/AggregateFactSource.cs
@@ -2,18 +2,17 @@
 using System.Collections.Generic;
 using NRules.RuleModel;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal class AggregateFactSource : IFactSource
 {
-    internal class AggregateFactSource : IFactSource
+    private static readonly IEnumerable<IFact> Empty = Array.Empty<IFact>();
+
+    public AggregateFactSource(IEnumerable<IFact> facts)
     {
-        private static readonly IEnumerable<IFact> Empty = Array.Empty<IFact>();
-
-        public AggregateFactSource(IEnumerable<IFact> facts)
-        {
-            Facts = facts ?? Empty;
-        }
-
-        public FactSourceType SourceType => FactSourceType.Aggregate;
-        public IEnumerable<IFact> Facts { get; }
+        Facts = facts ?? Empty;
     }
+
+    public FactSourceType SourceType => FactSourceType.Aggregate;
+    public IEnumerable<IFact> Facts { get; }
 }

--- a/src/NRules/NRules/Rete/AggregateNode.cs
+++ b/src/NRules/NRules/Rete/AggregateNode.cs
@@ -3,298 +3,297 @@ using NRules.Aggregators;
 using NRules.Diagnostics;
 using NRules.RuleModel;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal class AggregateNode : BinaryBetaNode
 {
-    internal class AggregateNode : BinaryBetaNode
+    private readonly IAggregatorFactory _aggregatorFactory;
+    private readonly bool _isSubnetJoin;
+
+    public string Name { get; }
+    public List<Declaration> Declarations { get; }
+    public ExpressionCollection Expressions { get; }
+    
+    public AggregateNode(ITupleSource leftSource, 
+        IObjectSource rightSource, 
+        string name,
+        List<Declaration> declarations,
+        ExpressionCollection expressions,
+        IAggregatorFactory aggregatorFactory,
+        bool isSubnetJoin)
+        : base(leftSource, rightSource, isSubnetJoin)
     {
-        private readonly IAggregatorFactory _aggregatorFactory;
-        private readonly bool _isSubnetJoin;
+        Name = name;
+        Declarations = declarations;
+        Expressions = expressions;
+        _aggregatorFactory = aggregatorFactory;
+        _isSubnetJoin = isSubnetJoin;
+    }
 
-        public string Name { get; }
-        public List<Declaration> Declarations { get; }
-        public ExpressionCollection Expressions { get; }
-        
-        public AggregateNode(ITupleSource leftSource, 
-            IObjectSource rightSource, 
-            string name,
-            List<Declaration> declarations,
-            ExpressionCollection expressions,
-            IAggregatorFactory aggregatorFactory,
-            bool isSubnetJoin)
-            : base(leftSource, rightSource, isSubnetJoin)
+    public override void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
+    {
+        var aggregationContext = new AggregationContext(context, NodeInfo);
+        var aggregation = new Aggregation();
+
+        using (var counter = PerfCounter.Assert(context, this))
         {
-            Name = name;
-            Declarations = declarations;
-            Expressions = expressions;
-            _aggregatorFactory = aggregatorFactory;
-            _isSubnetJoin = isSubnetJoin;
-        }
-
-        public override void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
-        {
-            var aggregationContext = new AggregationContext(context, NodeInfo);
-            var aggregation = new Aggregation();
-
-            using (var counter = PerfCounter.Assert(context, this))
+            var joinedSets = JoinedSets(context, tuples);
+            foreach (var set in joinedSets)
             {
-                var joinedSets = JoinedSets(context, tuples);
-                foreach (var set in joinedSets)
-                {
-                    IFactAggregator aggregator = CreateFactAggregator(context, set.Tuple);
-                    AddToAggregate(aggregationContext, aggregator, aggregation, set.Tuple, set.Facts);
-                }
-
-                counter.AddInputs(tuples.Count);
-                counter.AddOutputs(aggregation.Count);
+                IFactAggregator aggregator = CreateFactAggregator(context, set.Tuple);
+                AddToAggregate(aggregationContext, aggregator, aggregation, set.Tuple, set.Facts);
             }
 
-            PropagateAggregation(context, aggregation);
+            counter.AddInputs(tuples.Count);
+            counter.AddOutputs(aggregation.Count);
         }
 
-        public override void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
+        PropagateAggregation(context, aggregation);
+    }
+
+    public override void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
+    {
+        var aggregationContext = new AggregationContext(context, NodeInfo);
+        var aggregation = new Aggregation();
+        using (var counter = PerfCounter.Update(context, this))
         {
-            var aggregationContext = new AggregationContext(context, NodeInfo);
-            var aggregation = new Aggregation();
-            using (var counter = PerfCounter.Update(context, this))
+            var joinedSets = JoinedSets(context, tuples);
+            foreach (var set in joinedSets)
             {
-                var joinedSets = JoinedSets(context, tuples);
-                foreach (var set in joinedSets)
+                IFactAggregator aggregator = GetFactAggregator(context, set.Tuple);
+                if (aggregator != null)
                 {
-                    IFactAggregator aggregator = GetFactAggregator(context, set.Tuple);
-                    if (aggregator != null)
+                    if (_isSubnetJoin && set.Facts.Count > 0)
                     {
-                        if (_isSubnetJoin && set.Facts.Count > 0)
-                        {
-                            //Update already propagated from the right
-                            continue;
-                        }
-
-                        UpdateInAggregate(aggregationContext, aggregator, aggregation, set.Tuple, set.Facts);
-                    }
-                    else
-                    {
-                        var matchingFacts = set.Facts;
-                        aggregator = CreateFactAggregator(context, set.Tuple);
-                        AddToAggregate(aggregationContext, aggregator, aggregation, set.Tuple, matchingFacts);
-                    }
-                }
-
-                counter.AddInputs(tuples.Count);
-                counter.AddOutputs(aggregation.Count);
-            }
-
-            PropagateAggregation(context, aggregation);
-        }
-
-        public override void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
-        {
-            var aggregation = new Aggregation();
-            using (var counter = PerfCounter.Retract(context, this))
-            {
-                foreach (var tuple in tuples)
-                {
-                    IFactAggregator aggregator = RemoveFactAggregator(context, tuple);
-                    if (aggregator != null)
-                    {
-                        aggregation.Remove(tuple, aggregator.AggregateFacts);
-                    }
-                }
-
-                counter.AddInputs(tuples.Count);
-                counter.AddOutputs(aggregation.Count);
-            }
-
-            PropagateAggregation(context, aggregation);
-        }
-
-        public override void PropagateAssert(IExecutionContext context, List<Fact> facts)
-        {
-            var aggregationContext = new AggregationContext(context, NodeInfo);
-            var aggregation = new Aggregation();
-            using (var counter = PerfCounter.Assert(context, this))
-            {
-                var joinedSets = JoinedSets(context, facts);
-                foreach (var set in joinedSets)
-                {
-                    if (set.Facts.Count == 0) continue;
-
-                    IFactAggregator aggregator = GetFactAggregator(context, set.Tuple);
-                    if (aggregator == null)
-                    {
-                        aggregator = CreateFactAggregator(context, set.Tuple);
-
-                        var originalSet = JoinedSet(context, set.Tuple);
-                        var matchingOriginalFacts = originalSet.Facts;
-                        AddToAggregate(aggregationContext, aggregator, aggregation, originalSet.Tuple, matchingOriginalFacts);
+                        //Update already propagated from the right
+                        continue;
                     }
 
-                    AddToAggregate(aggregationContext, aggregator, aggregation, set.Tuple, set.Facts);
+                    UpdateInAggregate(aggregationContext, aggregator, aggregation, set.Tuple, set.Facts);
                 }
-
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(aggregation.Count);
-            }
-
-            PropagateAggregation(context, aggregation);
-        }
-
-        public override void PropagateUpdate(IExecutionContext context, List<Fact> facts)
-        {
-            var aggregationContext = new AggregationContext(context, NodeInfo);
-            var aggregation = new Aggregation();
-            using (var counter = PerfCounter.Update(context, this))
-            {
-                var joinedSets = JoinedSets(context, facts);
-                foreach (var set in joinedSets)
+                else
                 {
-                    if (set.Facts.Count == 0) continue;
-
-                    IFactAggregator aggregator = GetFactAggregator(context, set.Tuple);
-                    if (aggregator != null)
-                    {
-                        UpdateInAggregate(aggregationContext, aggregator, aggregation, set.Tuple, set.Facts);
-                    }
-                    else
-                    {
-                        var fullSet = JoinedSet(context, set.Tuple);
-                        aggregator = CreateFactAggregator(context, fullSet.Tuple);
-                        AddToAggregate(aggregationContext, aggregator, aggregation, fullSet.Tuple, fullSet.Facts);
-                    }
+                    var matchingFacts = set.Facts;
+                    aggregator = CreateFactAggregator(context, set.Tuple);
+                    AddToAggregate(aggregationContext, aggregator, aggregation, set.Tuple, matchingFacts);
                 }
-
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(aggregation.Count);
             }
 
-            PropagateAggregation(context, aggregation);
+            counter.AddInputs(tuples.Count);
+            counter.AddOutputs(aggregation.Count);
         }
 
-        public override void PropagateRetract(IExecutionContext context, List<Fact> facts)
+        PropagateAggregation(context, aggregation);
+    }
+
+    public override void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
+    {
+        var aggregation = new Aggregation();
+        using (var counter = PerfCounter.Retract(context, this))
         {
-            var aggregationContext = new AggregationContext(context, NodeInfo);
-            var aggregation = new Aggregation();
-            using (var counter = PerfCounter.Retract(context, this))
+            foreach (var tuple in tuples)
             {
-                var joinedSets = JoinedSets(context, facts);
-                foreach (var set in joinedSets)
+                IFactAggregator aggregator = RemoveFactAggregator(context, tuple);
+                if (aggregator != null)
                 {
-                    if (set.Facts.Count == 0) continue;
-
-                    IFactAggregator aggregator = GetFactAggregator(context, set.Tuple);
-                    if (aggregator != null)
-                    {
-                        RetractFromAggregate(aggregationContext, aggregator, aggregation, set.Tuple, set.Facts);
-                    }
+                    aggregation.Remove(tuple, aggregator.AggregateFacts);
                 }
-
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(aggregation.Count);
             }
 
-            PropagateAggregation(context, aggregation);
+            counter.AddInputs(tuples.Count);
+            counter.AddOutputs(aggregation.Count);
         }
 
-        public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
-        {
-            visitor.VisitAggregateNode(context, this);
-        }
+        PropagateAggregation(context, aggregation);
+    }
 
-        private void AddToAggregate(AggregationContext context, IFactAggregator aggregator, Aggregation aggregation, Tuple tuple, List<Fact> facts)
+    public override void PropagateAssert(IExecutionContext context, List<Fact> facts)
+    {
+        var aggregationContext = new AggregationContext(context, NodeInfo);
+        var aggregation = new Aggregation();
+        using (var counter = PerfCounter.Assert(context, this))
         {
-            try
+            var joinedSets = JoinedSets(context, facts);
+            foreach (var set in joinedSets)
             {
-                aggregator.Add(context, aggregation, tuple, facts);
-            }
-            catch (ExpressionEvaluationException e)
-            {
-                if (!e.IsHandled)
+                if (set.Facts.Count == 0) continue;
+
+                IFactAggregator aggregator = GetFactAggregator(context, set.Tuple);
+                if (aggregator == null)
                 {
-                    throw new RuleLhsExpressionEvaluationException("Failed to evaluate aggregate expression",
-                        e.Expression.ToString(), e.InnerException);
+                    aggregator = CreateFactAggregator(context, set.Tuple);
+
+                    var originalSet = JoinedSet(context, set.Tuple);
+                    var matchingOriginalFacts = originalSet.Facts;
+                    AddToAggregate(aggregationContext, aggregator, aggregation, originalSet.Tuple, matchingOriginalFacts);
                 }
-                ResetAggregator(context.ExecutionContext, aggregation, tuple, aggregator);
+
+                AddToAggregate(aggregationContext, aggregator, aggregation, set.Tuple, set.Facts);
             }
+
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(aggregation.Count);
         }
 
-        private void UpdateInAggregate(AggregationContext context, IFactAggregator aggregator, Aggregation aggregation, Tuple tuple, List<Fact> facts)
+        PropagateAggregation(context, aggregation);
+    }
+
+    public override void PropagateUpdate(IExecutionContext context, List<Fact> facts)
+    {
+        var aggregationContext = new AggregationContext(context, NodeInfo);
+        var aggregation = new Aggregation();
+        using (var counter = PerfCounter.Update(context, this))
         {
-            try
+            var joinedSets = JoinedSets(context, facts);
+            foreach (var set in joinedSets)
             {
-                aggregator.Modify(context, aggregation, tuple, facts);
-            }
-            catch (ExpressionEvaluationException e)
-            {
-                if (!e.IsHandled)
+                if (set.Facts.Count == 0) continue;
+
+                IFactAggregator aggregator = GetFactAggregator(context, set.Tuple);
+                if (aggregator != null)
                 {
-                    throw new RuleLhsExpressionEvaluationException("Failed to evaluate aggregate expression",
-                        e.Expression.ToString(), e.InnerException);
+                    UpdateInAggregate(aggregationContext, aggregator, aggregation, set.Tuple, set.Facts);
                 }
-                ResetAggregator(context.ExecutionContext, aggregation, tuple, aggregator);
-            }
-        }
-
-        private void RetractFromAggregate(AggregationContext context, IFactAggregator aggregator, Aggregation aggregation, Tuple tuple, List<Fact> facts)
-        {
-            try
-            {
-                aggregator.Remove(context, aggregation, tuple, facts);
-            }
-            catch (ExpressionEvaluationException e)
-            {
-                if (!e.IsHandled)
+                else
                 {
-                    throw new RuleLhsExpressionEvaluationException("Failed to evaluate aggregate expression",
-                        e.Expression.ToString(), e.InnerException);
+                    var fullSet = JoinedSet(context, set.Tuple);
+                    aggregator = CreateFactAggregator(context, fullSet.Tuple);
+                    AddToAggregate(aggregationContext, aggregator, aggregation, fullSet.Tuple, fullSet.Facts);
                 }
-                ResetAggregator(context.ExecutionContext, aggregation, tuple, aggregator);
             }
+
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(aggregation.Count);
         }
 
-        private void ResetAggregator(IExecutionContext context, Aggregation aggregation, Tuple tuple, IFactAggregator aggregator)
-        {
-            context.WorkingMemory.RemoveState<IFactAggregator>(this, tuple);
-            aggregation.Remove(tuple, aggregator.AggregateFacts);
-        }
+        PropagateAggregation(context, aggregation);
+    }
 
-        private void PropagateAggregation(IExecutionContext context, Aggregation aggregation)
+    public override void PropagateRetract(IExecutionContext context, List<Fact> facts)
+    {
+        var aggregationContext = new AggregationContext(context, NodeInfo);
+        var aggregation = new Aggregation();
+        using (var counter = PerfCounter.Retract(context, this))
         {
-            foreach (var aggregateList in aggregation.AggregateLists)
+            var joinedSets = JoinedSets(context, facts);
+            foreach (var set in joinedSets)
             {
-                if (aggregateList.Count == 0) continue;
+                if (set.Facts.Count == 0) continue;
 
-                switch (aggregateList.Action)
+                IFactAggregator aggregator = GetFactAggregator(context, set.Tuple);
+                if (aggregator != null)
                 {
-                    case AggregationAction.Added:
-                        MemoryNode.PropagateAssert(context, aggregateList);
-                        break;
-                    case AggregationAction.Modified:
-                        MemoryNode.PropagateUpdate(context, aggregateList);
-                        break;
-                    case AggregationAction.Removed:
-                        MemoryNode.PropagateRetract(context, aggregateList);
-                        break;
+                    RetractFromAggregate(aggregationContext, aggregator, aggregation, set.Tuple, set.Facts);
                 }
             }
+
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(aggregation.Count);
         }
 
-        private IFactAggregator CreateFactAggregator(IExecutionContext context, Tuple tuple)
-        {
-            var aggregator = _aggregatorFactory.Create();
-            var factAggregator = new FactAggregator(aggregator);
-            context.WorkingMemory.SetState(this, tuple, factAggregator);
-            return factAggregator;
-        }
+        PropagateAggregation(context, aggregation);
+    }
 
-        private IFactAggregator GetFactAggregator(IExecutionContext context, Tuple tuple)
-        {
-            var factAggregator = context.WorkingMemory.GetState<IFactAggregator>(this, tuple);
-            return factAggregator;
-        }
+    public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.VisitAggregateNode(context, this);
+    }
 
-        private IFactAggregator RemoveFactAggregator(IExecutionContext context, Tuple tuple)
+    private void AddToAggregate(AggregationContext context, IFactAggregator aggregator, Aggregation aggregation, Tuple tuple, List<Fact> facts)
+    {
+        try
         {
-            var factAggregator = context.WorkingMemory.RemoveState<IFactAggregator>(this, tuple);
-            return factAggregator;
+            aggregator.Add(context, aggregation, tuple, facts);
         }
+        catch (ExpressionEvaluationException e)
+        {
+            if (!e.IsHandled)
+            {
+                throw new RuleLhsExpressionEvaluationException("Failed to evaluate aggregate expression",
+                    e.Expression.ToString(), e.InnerException);
+            }
+            ResetAggregator(context.ExecutionContext, aggregation, tuple, aggregator);
+        }
+    }
+
+    private void UpdateInAggregate(AggregationContext context, IFactAggregator aggregator, Aggregation aggregation, Tuple tuple, List<Fact> facts)
+    {
+        try
+        {
+            aggregator.Modify(context, aggregation, tuple, facts);
+        }
+        catch (ExpressionEvaluationException e)
+        {
+            if (!e.IsHandled)
+            {
+                throw new RuleLhsExpressionEvaluationException("Failed to evaluate aggregate expression",
+                    e.Expression.ToString(), e.InnerException);
+            }
+            ResetAggregator(context.ExecutionContext, aggregation, tuple, aggregator);
+        }
+    }
+
+    private void RetractFromAggregate(AggregationContext context, IFactAggregator aggregator, Aggregation aggregation, Tuple tuple, List<Fact> facts)
+    {
+        try
+        {
+            aggregator.Remove(context, aggregation, tuple, facts);
+        }
+        catch (ExpressionEvaluationException e)
+        {
+            if (!e.IsHandled)
+            {
+                throw new RuleLhsExpressionEvaluationException("Failed to evaluate aggregate expression",
+                    e.Expression.ToString(), e.InnerException);
+            }
+            ResetAggregator(context.ExecutionContext, aggregation, tuple, aggregator);
+        }
+    }
+
+    private void ResetAggregator(IExecutionContext context, Aggregation aggregation, Tuple tuple, IFactAggregator aggregator)
+    {
+        context.WorkingMemory.RemoveState<IFactAggregator>(this, tuple);
+        aggregation.Remove(tuple, aggregator.AggregateFacts);
+    }
+
+    private void PropagateAggregation(IExecutionContext context, Aggregation aggregation)
+    {
+        foreach (var aggregateList in aggregation.AggregateLists)
+        {
+            if (aggregateList.Count == 0) continue;
+
+            switch (aggregateList.Action)
+            {
+                case AggregationAction.Added:
+                    MemoryNode.PropagateAssert(context, aggregateList);
+                    break;
+                case AggregationAction.Modified:
+                    MemoryNode.PropagateUpdate(context, aggregateList);
+                    break;
+                case AggregationAction.Removed:
+                    MemoryNode.PropagateRetract(context, aggregateList);
+                    break;
+            }
+        }
+    }
+
+    private IFactAggregator CreateFactAggregator(IExecutionContext context, Tuple tuple)
+    {
+        var aggregator = _aggregatorFactory.Create();
+        var factAggregator = new FactAggregator(aggregator);
+        context.WorkingMemory.SetState(this, tuple, factAggregator);
+        return factAggregator;
+    }
+
+    private IFactAggregator GetFactAggregator(IExecutionContext context, Tuple tuple)
+    {
+        var factAggregator = context.WorkingMemory.GetState<IFactAggregator>(this, tuple);
+        return factAggregator;
+    }
+
+    private IFactAggregator RemoveFactAggregator(IExecutionContext context, Tuple tuple)
+    {
+        var factAggregator = context.WorkingMemory.RemoveState<IFactAggregator>(this, tuple);
+        return factAggregator;
     }
 }

--- a/src/NRules/NRules/Rete/Aggregation.cs
+++ b/src/NRules/NRules/Rete/Aggregation.cs
@@ -1,65 +1,64 @@
 using System.Collections.Generic;
 using NRules.Aggregators;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal class Aggregation
 {
-    internal class Aggregation
+    private readonly List<AggregateList> _aggregateLists = new();
+    private AggregateList _currentList;
+
+    public List<AggregateList> AggregateLists => _aggregateLists;
+    public int Count { get; private set; }
+
+    public void Add(Tuple tuple, Fact aggregateFact)
     {
-        private readonly List<AggregateList> _aggregateLists = new();
-        private AggregateList _currentList;
+        var list = GetList(AggregationAction.Added);
+        list.Add(tuple, aggregateFact);
+        Count++;
+    }
 
-        public List<AggregateList> AggregateLists => _aggregateLists;
-        public int Count { get; private set; }
+    public void Modify(Tuple tuple, Fact aggregateFact)
+    {
+        var list = GetList(AggregationAction.Modified);
+        list.Add(tuple, aggregateFact);
+        Count++;
+    }
+    
+    public void Remove(Tuple tuple, Fact aggregateFact)
+    {
+        var list = GetList(AggregationAction.Removed);
+        list.Add(tuple, aggregateFact);
+        Count++;
+    }
 
-        public void Add(Tuple tuple, Fact aggregateFact)
+    public void Remove(Tuple tuple, IEnumerable<Fact> aggregateFacts)
+    {
+        var list = GetList(AggregationAction.Removed);
+        foreach (var aggregateFact in aggregateFacts)
         {
-            var list = GetList(AggregationAction.Added);
             list.Add(tuple, aggregateFact);
-            Count++;
-        }
-
-        public void Modify(Tuple tuple, Fact aggregateFact)
-        {
-            var list = GetList(AggregationAction.Modified);
-            list.Add(tuple, aggregateFact);
-            Count++;
-        }
-        
-        public void Remove(Tuple tuple, Fact aggregateFact)
-        {
-            var list = GetList(AggregationAction.Removed);
-            list.Add(tuple, aggregateFact);
-            Count++;
-        }
-
-        public void Remove(Tuple tuple, IEnumerable<Fact> aggregateFacts)
-        {
-            var list = GetList(AggregationAction.Removed);
-            foreach (var aggregateFact in aggregateFacts)
-            {
-                list.Add(tuple, aggregateFact);
-               Count++;
-            }
-        }
-
-        private AggregateList GetList(AggregationAction action)
-        {
-            if (_currentList == null || _currentList.Action != action)
-            {
-                _currentList = new AggregateList(action);
-                _aggregateLists.Add(_currentList);
-            }
-            return _currentList;
+           Count++;
         }
     }
 
-    internal class AggregateList : TupleFactList
+    private AggregateList GetList(AggregationAction action)
     {
-        public AggregationAction Action { get; }
-
-        public AggregateList(AggregationAction action)
+        if (_currentList == null || _currentList.Action != action)
         {
-            Action = action;
+            _currentList = new AggregateList(action);
+            _aggregateLists.Add(_currentList);
         }
+        return _currentList;
+    }
+}
+
+internal class AggregateList : TupleFactList
+{
+    public AggregationAction Action { get; }
+
+    public AggregateList(AggregationAction action)
+    {
+        Action = action;
     }
 }

--- a/src/NRules/NRules/Rete/AlphaMemory.cs
+++ b/src/NRules/NRules/Rete/AlphaMemory.cs
@@ -1,42 +1,41 @@
 ﻿using System.Collections.Generic;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal interface IAlphaMemory
 {
-    internal interface IAlphaMemory
+    IEnumerable<Fact> Facts { get; }
+    int FactCount { get; }
+    bool Contains(Fact fact);
+    void Add(List<Fact> facts);
+    void Remove(List<Fact> facts);
+}
+
+internal class AlphaMemory : IAlphaMemory
+{
+    private readonly HashSet<Fact> _facts = new();
+
+    public IEnumerable<Fact> Facts => _facts;
+    public int FactCount => _facts.Count;
+
+    public bool Contains(Fact fact)
     {
-        IEnumerable<Fact> Facts { get; }
-        int FactCount { get; }
-        bool Contains(Fact fact);
-        void Add(List<Fact> facts);
-        void Remove(List<Fact> facts);
+        return _facts.Contains(fact);
     }
 
-    internal class AlphaMemory : IAlphaMemory
+    public void Add(List<Fact> facts)
     {
-        private readonly HashSet<Fact> _facts = new();
-
-        public IEnumerable<Fact> Facts => _facts;
-        public int FactCount => _facts.Count;
-
-        public bool Contains(Fact fact)
+        foreach (var fact in facts)
         {
-            return _facts.Contains(fact);
+            _facts.Add(fact);
         }
+    }
 
-        public void Add(List<Fact> facts)
+    public void Remove(List<Fact> facts)
+    {
+        foreach (var fact in facts)
         {
-            foreach (var fact in facts)
-            {
-                _facts.Add(fact);
-            }
-        }
-
-        public void Remove(List<Fact> facts)
-        {
-            foreach (var fact in facts)
-            {
-                _facts.Remove(fact);
-            }
+            _facts.Remove(fact);
         }
     }
 }

--- a/src/NRules/NRules/Rete/AlphaMemoryNode.cs
+++ b/src/NRules/NRules/Rete/AlphaMemoryNode.cs
@@ -1,115 +1,114 @@
 ﻿using System.Collections.Generic;
 using NRules.Diagnostics;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal interface IAlphaMemoryNode : IObjectSource
 {
-    internal interface IAlphaMemoryNode : IObjectSource
+    IEnumerable<IObjectSink> Sinks { get; }
+}
+
+internal class AlphaMemoryNode : IObjectSink, IAlphaMemoryNode
+{
+    private readonly List<IObjectSink> _sinks = new();
+
+    public int Id { get; set; }
+    public NodeInfo NodeInfo { get; } = new();
+    public IEnumerable<IObjectSink> Sinks => _sinks;
+
+    public void PropagateAssert(IExecutionContext context, List<Fact> facts)
     {
-        IEnumerable<IObjectSink> Sinks { get; }
+        IAlphaMemory memory = context.WorkingMemory.GetNodeMemory(this);
+        foreach (var sink in _sinks)
+        {
+            sink.PropagateAssert(context, facts);
+        }
+
+        using (var counter = PerfCounter.Assert(context, this))
+        {
+            memory.Add(facts);
+
+            counter.AddItems(facts.Count);
+            counter.SetCount(memory.FactCount);
+        }
     }
 
-    internal class AlphaMemoryNode : IObjectSink, IAlphaMemoryNode
+    public void PropagateUpdate(IExecutionContext context, List<Fact> facts)
     {
-        private readonly List<IObjectSink> _sinks = new();
+        IAlphaMemory memory = context.WorkingMemory.GetNodeMemory(this);
+        var toUpdate = new List<Fact>();
+        var toAssert = new List<Fact>();
 
-        public int Id { get; set; }
-        public NodeInfo NodeInfo { get; } = new();
-        public IEnumerable<IObjectSink> Sinks => _sinks;
-
-        public void PropagateAssert(IExecutionContext context, List<Fact> facts)
+        using (var counter = PerfCounter.Update(context, this))
         {
-            IAlphaMemory memory = context.WorkingMemory.GetNodeMemory(this);
-            foreach (var sink in _sinks)
+            foreach (var fact in facts)
             {
-                sink.PropagateAssert(context, facts);
+                if (memory.Contains(fact))
+                    toUpdate.Add(fact);
+                else
+                    toAssert.Add(fact);
             }
 
-            using (var counter = PerfCounter.Assert(context, this))
-            {
-                memory.Add(facts);
+            counter.AddItems(facts.Count);
+        }
 
-                counter.AddItems(facts.Count);
+        if (toUpdate.Count > 0)
+        {
+            foreach (var sink in _sinks)
+            {
+                sink.PropagateUpdate(context, toUpdate);
+            }
+        }
+        if (toAssert.Count > 0)
+        {
+            PropagateAssert(context, toAssert);
+        }
+    }
+
+    public void PropagateRetract(IExecutionContext context, List<Fact> facts)
+    {
+        IAlphaMemory memory = context.WorkingMemory.GetNodeMemory(this);
+        var toRetract = new List<Fact>(facts.Count);
+        using (var counter = PerfCounter.Retract(context, this))
+        {
+            foreach (var fact in facts)
+            {
+                if (memory.Contains(fact))
+                    toRetract.Add(fact);
+            }
+
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(toRetract.Count);
+        }
+
+        if (toRetract.Count > 0)
+        {
+            foreach (var sink in _sinks)
+            {
+                sink.PropagateRetract(context, toRetract);
+            }
+
+            using (var counter = PerfCounter.Retract(context, this))
+            {
+                memory.Remove(toRetract);
                 counter.SetCount(memory.FactCount);
             }
         }
+    }
 
-        public void PropagateUpdate(IExecutionContext context, List<Fact> facts)
-        {
-            IAlphaMemory memory = context.WorkingMemory.GetNodeMemory(this);
-            var toUpdate = new List<Fact>();
-            var toAssert = new List<Fact>();
+    public IEnumerable<Fact> GetFacts(IExecutionContext context)
+    {
+        IAlphaMemory memory = context.WorkingMemory.GetNodeMemory(this);
+        return memory.Facts;
+    }
 
-            using (var counter = PerfCounter.Update(context, this))
-            {
-                foreach (var fact in facts)
-                {
-                    if (memory.Contains(fact))
-                        toUpdate.Add(fact);
-                    else
-                        toAssert.Add(fact);
-                }
-
-                counter.AddItems(facts.Count);
-            }
-
-            if (toUpdate.Count > 0)
-            {
-                foreach (var sink in _sinks)
-                {
-                    sink.PropagateUpdate(context, toUpdate);
-                }
-            }
-            if (toAssert.Count > 0)
-            {
-                PropagateAssert(context, toAssert);
-            }
-        }
-
-        public void PropagateRetract(IExecutionContext context, List<Fact> facts)
-        {
-            IAlphaMemory memory = context.WorkingMemory.GetNodeMemory(this);
-            var toRetract = new List<Fact>(facts.Count);
-            using (var counter = PerfCounter.Retract(context, this))
-            {
-                foreach (var fact in facts)
-                {
-                    if (memory.Contains(fact))
-                        toRetract.Add(fact);
-                }
-
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(toRetract.Count);
-            }
-
-            if (toRetract.Count > 0)
-            {
-                foreach (var sink in _sinks)
-                {
-                    sink.PropagateRetract(context, toRetract);
-                }
-
-                using (var counter = PerfCounter.Retract(context, this))
-                {
-                    memory.Remove(toRetract);
-                    counter.SetCount(memory.FactCount);
-                }
-            }
-        }
-
-        public IEnumerable<Fact> GetFacts(IExecutionContext context)
-        {
-            IAlphaMemory memory = context.WorkingMemory.GetNodeMemory(this);
-            return memory.Facts;
-        }
-
-        public void Attach(IObjectSink sink)
-        {
-            _sinks.Add(sink);
-        }
-        
-        public void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
-        {
-            visitor.VisitAlphaMemoryNode(context, this);
-        }
+    public void Attach(IObjectSink sink)
+    {
+        _sinks.Add(sink);
+    }
+    
+    public void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.VisitAlphaMemoryNode(context, this);
     }
 }

--- a/src/NRules/NRules/Rete/AlphaNode.cs
+++ b/src/NRules/NRules/Rete/AlphaNode.cs
@@ -2,93 +2,92 @@
 using System.Diagnostics;
 using NRules.Diagnostics;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal abstract class AlphaNode : IObjectSink
 {
-    internal abstract class AlphaNode : IObjectSink
+    public int Id { get; set; }
+    public NodeInfo NodeInfo { get; } = new();
+    public AlphaMemoryNode MemoryNode { get; set; }
+
+    [DebuggerDisplay("Count = {ChildNodes.Count}")]
+    public List<AlphaNode> ChildNodes { get; } = new();
+
+    public abstract bool IsSatisfiedBy(IExecutionContext context, Fact fact);
+
+    public virtual void PropagateAssert(IExecutionContext context, List<Fact> facts)
     {
-        public int Id { get; set; }
-        public NodeInfo NodeInfo { get; } = new();
-        public AlphaMemoryNode MemoryNode { get; set; }
-
-        [DebuggerDisplay("Count = {ChildNodes.Count}")]
-        public List<AlphaNode> ChildNodes { get; } = new();
-
-        public abstract bool IsSatisfiedBy(IExecutionContext context, Fact fact);
-
-        public virtual void PropagateAssert(IExecutionContext context, List<Fact> facts)
+        var toAssert = new List<Fact>();
+        using (var counter = PerfCounter.Assert(context, this))
         {
-            var toAssert = new List<Fact>();
-            using (var counter = PerfCounter.Assert(context, this))
+            foreach (var fact in facts)
             {
-                foreach (var fact in facts)
-                {
-                    if (IsSatisfiedBy(context, fact))
-                        toAssert.Add(fact);
-                }
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(toAssert.Count);
+                if (IsSatisfiedBy(context, fact))
+                    toAssert.Add(fact);
             }
-
-            if (toAssert.Count > 0)
-            {
-                foreach (var childNode in ChildNodes)
-                {
-                    childNode.PropagateAssert(context, toAssert);
-                }
-                MemoryNode?.PropagateAssert(context, toAssert);
-            }
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(toAssert.Count);
         }
 
-        public virtual void PropagateUpdate(IExecutionContext context, List<Fact> facts)
+        if (toAssert.Count > 0)
         {
-            var toUpdate = new List<Fact>();
-            var toRetract = new List<Fact>();
-            using (var counter = PerfCounter.Update(context, this))
-            {
-                foreach (var fact in facts)
-                {
-                    if (IsSatisfiedBy(context, fact))
-                        toUpdate.Add(fact);
-                    else
-                        toRetract.Add(fact);
-                }
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(toUpdate.Count + toRetract.Count);
-            }
-
-            PropagateUpdateInternal(context, toUpdate);
-            PropagateRetractInternal(context, toRetract);
-        }
-
-        public virtual void PropagateRetract(IExecutionContext context, List<Fact> facts)
-        {
-            using (var counter = PerfCounter.Retract(context, this))
-            {
-                counter.AddItems(facts.Count);
-            }
-            PropagateRetractInternal(context, facts);
-        }
-
-        protected void PropagateUpdateInternal(IExecutionContext context, List<Fact> facts)
-        {
-            if (facts.Count == 0) return;
             foreach (var childNode in ChildNodes)
             {
-                childNode.PropagateUpdate(context, facts);
+                childNode.PropagateAssert(context, toAssert);
             }
-            MemoryNode?.PropagateUpdate(context, facts);
+            MemoryNode?.PropagateAssert(context, toAssert);
         }
-
-        protected void PropagateRetractInternal(IExecutionContext context, List<Fact> facts)
-        {
-            if (facts.Count == 0) return;
-            foreach (var childNode in ChildNodes)
-            {
-                childNode.PropagateRetract(context, facts);
-            }
-            MemoryNode?.PropagateRetract(context, facts);
-        }
-
-        public abstract void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor);
     }
+
+    public virtual void PropagateUpdate(IExecutionContext context, List<Fact> facts)
+    {
+        var toUpdate = new List<Fact>();
+        var toRetract = new List<Fact>();
+        using (var counter = PerfCounter.Update(context, this))
+        {
+            foreach (var fact in facts)
+            {
+                if (IsSatisfiedBy(context, fact))
+                    toUpdate.Add(fact);
+                else
+                    toRetract.Add(fact);
+            }
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(toUpdate.Count + toRetract.Count);
+        }
+
+        PropagateUpdateInternal(context, toUpdate);
+        PropagateRetractInternal(context, toRetract);
+    }
+
+    public virtual void PropagateRetract(IExecutionContext context, List<Fact> facts)
+    {
+        using (var counter = PerfCounter.Retract(context, this))
+        {
+            counter.AddItems(facts.Count);
+        }
+        PropagateRetractInternal(context, facts);
+    }
+
+    protected void PropagateUpdateInternal(IExecutionContext context, List<Fact> facts)
+    {
+        if (facts.Count == 0) return;
+        foreach (var childNode in ChildNodes)
+        {
+            childNode.PropagateUpdate(context, facts);
+        }
+        MemoryNode?.PropagateUpdate(context, facts);
+    }
+
+    protected void PropagateRetractInternal(IExecutionContext context, List<Fact> facts)
+    {
+        if (facts.Count == 0) return;
+        foreach (var childNode in ChildNodes)
+        {
+            childNode.PropagateRetract(context, facts);
+        }
+        MemoryNode?.PropagateRetract(context, facts);
+    }
+
+    public abstract void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor);
 }

--- a/src/NRules/NRules/Rete/BetaMemoryNode.cs
+++ b/src/NRules/NRules/Rete/BetaMemoryNode.cs
@@ -1,166 +1,165 @@
 ﻿using System.Collections.Generic;
 using NRules.Diagnostics;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal interface IBetaMemoryNode : ITupleSource, INode
 {
-    internal interface IBetaMemoryNode : ITupleSource, INode
+    IEnumerable<ITupleSink> Sinks { get; }
+    void PropagateAssert(IExecutionContext context, TupleFactList tupleFactList);
+    void PropagateUpdate(IExecutionContext context, TupleFactList tupleFactList);
+    void PropagateRetract(IExecutionContext context, TupleFactList tupleFactList);
+}
+
+internal class BetaMemoryNode : IBetaMemoryNode
+{
+    private readonly List<ITupleSink> _sinks = new();
+
+    public int Id { get; set; }
+    public NodeInfo NodeInfo { get; } = new();
+    public IEnumerable<ITupleSink> Sinks => _sinks;
+
+    public void PropagateAssert(IExecutionContext context, TupleFactList tupleFactList)
     {
-        IEnumerable<ITupleSink> Sinks { get; }
-        void PropagateAssert(IExecutionContext context, TupleFactList tupleFactList);
-        void PropagateUpdate(IExecutionContext context, TupleFactList tupleFactList);
-        void PropagateRetract(IExecutionContext context, TupleFactList tupleFactList);
+        if (tupleFactList.Count == 0) return;
+
+        IBetaMemory memory = context.WorkingMemory.GetNodeMemory(this);
+        var toAssert = new List<Tuple>();
+
+        using (var counter = PerfCounter.Assert(context, this))
+        {
+            var enumerator = tupleFactList.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                var childTuple = new Tuple(context.IdGenerator.NextTupleId(), enumerator.CurrentTuple,
+                    enumerator.CurrentFact);
+                childTuple.GroupId = enumerator.CurrentTuple.Id;
+                toAssert.Add(childTuple);
+            }
+            
+            counter.AddItems(tupleFactList.Count);
+        }
+
+        PropagateAssertInternal(context, memory, toAssert);
     }
 
-    internal class BetaMemoryNode : IBetaMemoryNode
+    public void PropagateUpdate(IExecutionContext context, TupleFactList tupleFactList)
     {
-        private readonly List<ITupleSink> _sinks = new();
+        if (tupleFactList.Count == 0) return;
 
-        public int Id { get; set; }
-        public NodeInfo NodeInfo { get; } = new();
-        public IEnumerable<ITupleSink> Sinks => _sinks;
+        IBetaMemory memory = context.WorkingMemory.GetNodeMemory(this);
+        var toAssert = new List<Tuple>();
+        var toUpdate = new List<Tuple>();
 
-        public void PropagateAssert(IExecutionContext context, TupleFactList tupleFactList)
+        using (var counter = PerfCounter.Update(context, this))
         {
-            if (tupleFactList.Count == 0) return;
-
-            IBetaMemory memory = context.WorkingMemory.GetNodeMemory(this);
-            var toAssert = new List<Tuple>();
-
-            using (var counter = PerfCounter.Assert(context, this))
+            var enumerator = tupleFactList.GetEnumerator();
+            while (enumerator.MoveNext())
             {
-                var enumerator = tupleFactList.GetEnumerator();
-                while (enumerator.MoveNext())
+                Tuple childTuple = memory.FindTuple(enumerator.CurrentTuple, enumerator.CurrentFact);
+                if (childTuple == null)
                 {
-                    var childTuple = new Tuple(context.IdGenerator.NextTupleId(), enumerator.CurrentTuple,
-                        enumerator.CurrentFact);
+                    childTuple = new Tuple(context.IdGenerator.NextTupleId(), enumerator.CurrentTuple, enumerator.CurrentFact);
                     childTuple.GroupId = enumerator.CurrentTuple.Id;
                     toAssert.Add(childTuple);
                 }
-                
-                counter.AddItems(tupleFactList.Count);
-            }
-
-            PropagateAssertInternal(context, memory, toAssert);
-        }
-
-        public void PropagateUpdate(IExecutionContext context, TupleFactList tupleFactList)
-        {
-            if (tupleFactList.Count == 0) return;
-
-            IBetaMemory memory = context.WorkingMemory.GetNodeMemory(this);
-            var toAssert = new List<Tuple>();
-            var toUpdate = new List<Tuple>();
-
-            using (var counter = PerfCounter.Update(context, this))
-            {
-                var enumerator = tupleFactList.GetEnumerator();
-                while (enumerator.MoveNext())
+                else
                 {
-                    Tuple childTuple = memory.FindTuple(enumerator.CurrentTuple, enumerator.CurrentFact);
-                    if (childTuple == null)
-                    {
-                        childTuple = new Tuple(context.IdGenerator.NextTupleId(), enumerator.CurrentTuple, enumerator.CurrentFact);
-                        childTuple.GroupId = enumerator.CurrentTuple.Id;
-                        toAssert.Add(childTuple);
-                    }
-                    else
-                    {
-                        toUpdate.Add(childTuple);
-                    }
+                    toUpdate.Add(childTuple);
                 }
-                
-                counter.AddItems(tupleFactList.Count);
             }
-
-            PropagateAssertInternal(context, memory, toAssert);
-            PropagateUpdateInternal(context, toUpdate);
+            
+            counter.AddItems(tupleFactList.Count);
         }
 
-        public void PropagateRetract(IExecutionContext context, TupleFactList tupleFactList)
+        PropagateAssertInternal(context, memory, toAssert);
+        PropagateUpdateInternal(context, toUpdate);
+    }
+
+    public void PropagateRetract(IExecutionContext context, TupleFactList tupleFactList)
+    {
+        if (tupleFactList.Count == 0) return;
+
+        IBetaMemory memory = context.WorkingMemory.GetNodeMemory(this);
+        var toRetract = new List<Tuple>();
+
+        using (var counter = PerfCounter.Retract(context, this))
         {
-            if (tupleFactList.Count == 0) return;
+            var enumerator = tupleFactList.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                Tuple childTuple = memory.FindTuple(enumerator.CurrentTuple, enumerator.CurrentFact);
+                if (childTuple != null)
+                {
+                    toRetract.Add(childTuple);
+                }
+            }
+            
+            counter.AddInputs(tupleFactList.Count);
+            counter.AddOutputs(toRetract.Count);
+        }
 
-            IBetaMemory memory = context.WorkingMemory.GetNodeMemory(this);
-            var toRetract = new List<Tuple>();
+        PropagateRetractInternal(context, memory, toRetract);
+    }
 
+    private void PropagateAssertInternal(IExecutionContext context, IBetaMemory memory, List<Tuple> tuples)
+    {
+        if (tuples.Count > 0)
+        {
+            for (int i = 0; i < _sinks.Count; i++)
+            {
+                _sinks[i].PropagateAssert(context, tuples);
+            }
+
+            using (var counter = PerfCounter.Assert(context, this))
+            {
+                memory.Add(tuples);
+                counter.SetCount(memory.TupleCount);
+            }
+        }
+    }
+
+    private void PropagateUpdateInternal(IExecutionContext context, List<Tuple> tuples)
+    {
+        if (tuples.Count > 0)
+        {
+            for (int i = 0; i < _sinks.Count; i++)
+            {
+                _sinks[i].PropagateUpdate(context, tuples);
+            }
+        }
+    }
+
+    private void PropagateRetractInternal(IExecutionContext context, IBetaMemory memory, List<Tuple> tuples)
+    {
+        if (tuples.Count > 0)
+        {
             using (var counter = PerfCounter.Retract(context, this))
             {
-                var enumerator = tupleFactList.GetEnumerator();
-                while (enumerator.MoveNext())
-                {
-                    Tuple childTuple = memory.FindTuple(enumerator.CurrentTuple, enumerator.CurrentFact);
-                    if (childTuple != null)
-                    {
-                        toRetract.Add(childTuple);
-                    }
-                }
-                
-                counter.AddInputs(tupleFactList.Count);
-                counter.AddOutputs(toRetract.Count);
+                memory.Remove(tuples);
+                counter.SetCount(memory.TupleCount);
             }
 
-            PropagateRetractInternal(context, memory, toRetract);
-        }
-
-        private void PropagateAssertInternal(IExecutionContext context, IBetaMemory memory, List<Tuple> tuples)
-        {
-            if (tuples.Count > 0)
+            for (int i = _sinks.Count - 1; i >= 0; i--)
             {
-                for (int i = 0; i < _sinks.Count; i++)
-                {
-                    _sinks[i].PropagateAssert(context, tuples);
-                }
-
-                using (var counter = PerfCounter.Assert(context, this))
-                {
-                    memory.Add(tuples);
-                    counter.SetCount(memory.TupleCount);
-                }
+                _sinks[i].PropagateRetract(context, tuples);
             }
         }
+    }
 
-        private void PropagateUpdateInternal(IExecutionContext context, List<Tuple> tuples)
-        {
-            if (tuples.Count > 0)
-            {
-                for (int i = 0; i < _sinks.Count; i++)
-                {
-                    _sinks[i].PropagateUpdate(context, tuples);
-                }
-            }
-        }
+    public IEnumerable<Tuple> GetTuples(IExecutionContext context)
+    {
+        IBetaMemory memory = context.WorkingMemory.GetNodeMemory(this);
+        return memory.Tuples;
+    }
 
-        private void PropagateRetractInternal(IExecutionContext context, IBetaMemory memory, List<Tuple> tuples)
-        {
-            if (tuples.Count > 0)
-            {
-                using (var counter = PerfCounter.Retract(context, this))
-                {
-                    memory.Remove(tuples);
-                    counter.SetCount(memory.TupleCount);
-                }
+    public void Attach(ITupleSink sink)
+    {
+        _sinks.Add(sink);
+    }
 
-                for (int i = _sinks.Count - 1; i >= 0; i--)
-                {
-                    _sinks[i].PropagateRetract(context, tuples);
-                }
-            }
-        }
-
-        public IEnumerable<Tuple> GetTuples(IExecutionContext context)
-        {
-            IBetaMemory memory = context.WorkingMemory.GetNodeMemory(this);
-            return memory.Tuples;
-        }
-
-        public void Attach(ITupleSink sink)
-        {
-            _sinks.Add(sink);
-        }
-
-        public void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
-        {
-            visitor.VisitBetaMemoryNode(context, this);
-        }
+    public void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.VisitBetaMemoryNode(context, this);
     }
 }

--- a/src/NRules/NRules/Rete/BetaNode.cs
+++ b/src/NRules/NRules/Rete/BetaNode.cs
@@ -1,18 +1,17 @@
 ﻿using System.Collections.Generic;
 using NRules.Diagnostics;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal abstract class BetaNode : ITupleSink
 {
-    internal abstract class BetaNode : ITupleSink
-    {
-        public int Id { get; set; }
-        public NodeInfo NodeInfo { get; } = new();
-        public BetaMemoryNode MemoryNode { get; set; }
+    public int Id { get; set; }
+    public NodeInfo NodeInfo { get; } = new();
+    public BetaMemoryNode MemoryNode { get; set; }
 
-        public abstract void PropagateAssert(IExecutionContext context, List<Tuple> tuples);
-        public abstract void PropagateUpdate(IExecutionContext context, List<Tuple> tuples);
-        public abstract void PropagateRetract(IExecutionContext context, List<Tuple> tuples);
+    public abstract void PropagateAssert(IExecutionContext context, List<Tuple> tuples);
+    public abstract void PropagateUpdate(IExecutionContext context, List<Tuple> tuples);
+    public abstract void PropagateRetract(IExecutionContext context, List<Tuple> tuples);
 
-        public abstract void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor);
-    }
+    public abstract void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor);
 }

--- a/src/NRules/NRules/Rete/BinaryBetaNode.cs
+++ b/src/NRules/NRules/Rete/BinaryBetaNode.cs
@@ -1,124 +1,123 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal abstract class BinaryBetaNode : BetaNode, IObjectSink
 {
-    internal abstract class BinaryBetaNode : BetaNode, IObjectSink
+    private readonly bool _isSubnetJoin;
+    private static readonly List<TupleFactSet> EmptySetList = new();
+    private static readonly Dictionary<long, List<Fact>> EmptyGroups = new();
+
+    public ITupleSource LeftSource { get; }
+    public IObjectSource RightSource { get; }
+
+    protected BinaryBetaNode(ITupleSource leftSource, IObjectSource rightSource, bool isSubnetJoin)
     {
-        private readonly bool _isSubnetJoin;
-        private static readonly List<TupleFactSet> EmptySetList = new();
-        private static readonly Dictionary<long, List<Fact>> EmptyGroups = new();
+        _isSubnetJoin = isSubnetJoin;
+        LeftSource = leftSource;
+        RightSource = rightSource;
 
-        public ITupleSource LeftSource { get; }
-        public IObjectSource RightSource { get; }
+        LeftSource.Attach(this);
+        RightSource.Attach(this);
+    }
 
-        protected BinaryBetaNode(ITupleSource leftSource, IObjectSource rightSource, bool isSubnetJoin)
+    public abstract void PropagateAssert(IExecutionContext context, List<Fact> facts);
+    public abstract void PropagateUpdate(IExecutionContext context, List<Fact> facts);
+    public abstract void PropagateRetract(IExecutionContext context, List<Fact> facts);
+
+    protected TupleFactSet JoinedSet(IExecutionContext context, Tuple tuple)
+    {
+        int level = tuple.Level;
+        var facts = RightSource.GetFacts(context).ToList();
+        if (facts.Count > 0 && _isSubnetJoin)
         {
-            _isSubnetJoin = isSubnetJoin;
-            LeftSource = leftSource;
-            RightSource = rightSource;
+            var factGroups = GroupFacts(facts, level);
+            if (factGroups.Count > 0)
+                return JoinByGroupId(tuple, factGroups);
+        }
+        return new TupleFactSet(tuple, facts);
+    }
 
-            LeftSource.Attach(this);
-            RightSource.Attach(this);
+    protected List<TupleFactSet> JoinedSets(IExecutionContext context, List<Tuple> tuples)
+    {
+        if (tuples.Count == 0) return EmptySetList;
+
+        var facts = RightSource.GetFacts(context).ToList();
+        if (facts.Count > 0 && _isSubnetJoin)
+        {
+            int level = tuples[0].Level;
+            var factGroups = GroupFacts(facts, level);
+            if (factGroups.Count > 0)
+                return JoinByGroupId(tuples, factGroups);
         }
 
-        public abstract void PropagateAssert(IExecutionContext context, List<Fact> facts);
-        public abstract void PropagateUpdate(IExecutionContext context, List<Fact> facts);
-        public abstract void PropagateRetract(IExecutionContext context, List<Fact> facts);
+        return CrossJoin(tuples, facts);
+    }
 
-        protected TupleFactSet JoinedSet(IExecutionContext context, Tuple tuple)
+    protected IEnumerable<TupleFactSet> JoinedSets(IExecutionContext context, List<Fact> facts)
+    {
+        var tuples = LeftSource.GetTuples(context).ToList();
+        if (tuples.Count == 0) return EmptySetList;
+
+        if (_isSubnetJoin)
         {
-            int level = tuple.Level;
-            var facts = RightSource.GetFacts(context).ToList();
-            if (facts.Count > 0 && _isSubnetJoin)
+            int level = tuples[0].Level;
+            var factGroups = GroupFacts(facts, level);
+            if (factGroups.Count > 0)
+                return JoinByGroupId(tuples, factGroups);
+        }
+
+        return CrossJoin(tuples, facts);
+    }
+
+    private List<TupleFactSet> JoinByGroupId(IEnumerable<Tuple> tuples, Dictionary<long, List<Fact>> factGroups)
+    {
+        var sets = new List<TupleFactSet>();
+        foreach (var tuple in tuples)
+        {
+            var tupleFactSet = JoinByGroupId(tuple, factGroups);
+            sets.Add(tupleFactSet);
+        }
+        return sets;
+    }
+
+    private static TupleFactSet JoinByGroupId(Tuple tuple, IDictionary<long, List<Fact>> factGroups)
+    {
+        var tupleFactSet = factGroups.TryGetValue(tuple.Id, out var tupleFacts)
+            ? new TupleFactSet(tuple, tupleFacts)
+            : new TupleFactSet(tuple, new List<Fact>());
+        return tupleFactSet;
+    }
+
+    private List<TupleFactSet> CrossJoin(List<Tuple> tuples, List<Fact> facts)
+    {
+        var sets = new List<TupleFactSet>(tuples.Count);
+        foreach (var tuple in tuples)
+        {
+            sets.Add(new TupleFactSet(tuple, facts));
+        }
+        return sets;
+    }
+
+    private Dictionary<long, List<Fact>> GroupFacts(List<Fact> facts, int level)
+    {
+        if (facts.Count == 0 || !facts[0].IsWrapperFact) return EmptyGroups;
+
+        //This can be further optimized by grouping tuples by GroupId
+        //and only descending to parent tuples once per group
+        var factGroups = new Dictionary<long, List<Fact>>();
+        foreach (var fact in facts)
+        {
+            var wrapperFact = (WrapperFact) fact;
+            long groupId = wrapperFact.WrappedTuple.GetGroupId(level);
+            if (!factGroups.TryGetValue(groupId, out var factGroup))
             {
-                var factGroups = GroupFacts(facts, level);
-                if (factGroups.Count > 0)
-                    return JoinByGroupId(tuple, factGroups);
+                factGroup = new List<Fact>();
+                factGroups[groupId] = factGroup;
             }
-            return new TupleFactSet(tuple, facts);
+            factGroup.Add(wrapperFact);
         }
-
-        protected List<TupleFactSet> JoinedSets(IExecutionContext context, List<Tuple> tuples)
-        {
-            if (tuples.Count == 0) return EmptySetList;
-
-            var facts = RightSource.GetFacts(context).ToList();
-            if (facts.Count > 0 && _isSubnetJoin)
-            {
-                int level = tuples[0].Level;
-                var factGroups = GroupFacts(facts, level);
-                if (factGroups.Count > 0)
-                    return JoinByGroupId(tuples, factGroups);
-            }
-
-            return CrossJoin(tuples, facts);
-        }
-
-        protected IEnumerable<TupleFactSet> JoinedSets(IExecutionContext context, List<Fact> facts)
-        {
-            var tuples = LeftSource.GetTuples(context).ToList();
-            if (tuples.Count == 0) return EmptySetList;
-
-            if (_isSubnetJoin)
-            {
-                int level = tuples[0].Level;
-                var factGroups = GroupFacts(facts, level);
-                if (factGroups.Count > 0)
-                    return JoinByGroupId(tuples, factGroups);
-            }
-
-            return CrossJoin(tuples, facts);
-        }
-
-        private List<TupleFactSet> JoinByGroupId(IEnumerable<Tuple> tuples, Dictionary<long, List<Fact>> factGroups)
-        {
-            var sets = new List<TupleFactSet>();
-            foreach (var tuple in tuples)
-            {
-                var tupleFactSet = JoinByGroupId(tuple, factGroups);
-                sets.Add(tupleFactSet);
-            }
-            return sets;
-        }
-
-        private static TupleFactSet JoinByGroupId(Tuple tuple, IDictionary<long, List<Fact>> factGroups)
-        {
-            var tupleFactSet = factGroups.TryGetValue(tuple.Id, out var tupleFacts)
-                ? new TupleFactSet(tuple, tupleFacts)
-                : new TupleFactSet(tuple, new List<Fact>());
-            return tupleFactSet;
-        }
-
-        private List<TupleFactSet> CrossJoin(List<Tuple> tuples, List<Fact> facts)
-        {
-            var sets = new List<TupleFactSet>(tuples.Count);
-            foreach (var tuple in tuples)
-            {
-                sets.Add(new TupleFactSet(tuple, facts));
-            }
-            return sets;
-        }
-
-        private Dictionary<long, List<Fact>> GroupFacts(List<Fact> facts, int level)
-        {
-            if (facts.Count == 0 || !facts[0].IsWrapperFact) return EmptyGroups;
-
-            //This can be further optimized by grouping tuples by GroupId
-            //and only descending to parent tuples once per group
-            var factGroups = new Dictionary<long, List<Fact>>();
-            foreach (var fact in facts)
-            {
-                var wrapperFact = (WrapperFact) fact;
-                long groupId = wrapperFact.WrappedTuple.GetGroupId(level);
-                if (!factGroups.TryGetValue(groupId, out var factGroup))
-                {
-                    factGroup = new List<Fact>();
-                    factGroups[groupId] = factGroup;
-                }
-                factGroup.Add(wrapperFact);
-            }
-            return factGroups;
-        }
+        return factGroups;
     }
 }

--- a/src/NRules/NRules/Rete/BindingNode.cs
+++ b/src/NRules/NRules/Rete/BindingNode.cs
@@ -3,133 +3,132 @@ using System.Collections.Generic;
 using NRules.Diagnostics;
 using NRules.RuleModel;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal class BindingNode : BetaNode
 {
-    internal class BindingNode : BetaNode
+    private readonly ILhsTupleExpression<object> _compiledExpression;
+
+    public ExpressionElement ExpressionElement { get; }
+    public Type ResultType { get; }
+    public ITupleSource Source { get; }
+    
+    public BindingNode(ExpressionElement expressionElement, ILhsTupleExpression<object> compiledExpression, Type resultType, ITupleSource source)
     {
-        private readonly ILhsTupleExpression<object> _compiledExpression;
+        ExpressionElement = expressionElement;
+        _compiledExpression = compiledExpression;
+        ResultType = resultType;
+        Source = source;
 
-        public ExpressionElement ExpressionElement { get; }
-        public Type ResultType { get; }
-        public ITupleSource Source { get; }
-        
-        public BindingNode(ExpressionElement expressionElement, ILhsTupleExpression<object> compiledExpression, Type resultType, ITupleSource source)
+        Source.Attach(this);
+    }
+
+    public override void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toAssert = new TupleFactList();
+        using (var counter = PerfCounter.Assert(context, this))
         {
-            ExpressionElement = expressionElement;
-            _compiledExpression = compiledExpression;
-            ResultType = resultType;
-            Source = source;
-
-            Source.Attach(this);
-        }
-
-        public override void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
-        {
-            var toAssert = new TupleFactList();
-            using (var counter = PerfCounter.Assert(context, this))
+            foreach (var tuple in tuples)
             {
-                foreach (var tuple in tuples)
+                AssertBinding(context, tuple, toAssert);
+            }
+
+            counter.AddItems(tuples.Count);
+        }
+        MemoryNode.PropagateAssert(context, toAssert);
+    }
+
+    public override void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toAssert = new TupleFactList();
+        var toUpdate = new TupleFactList();
+        var toRetract = new TupleFactList();
+        using (var counter = PerfCounter.Update(context, this))
+        {
+            foreach (var tuple in tuples)
+            {
+                var fact = context.WorkingMemory.GetState<Fact>(this, tuple);
+                if (fact != null)
+                {
+                    UpdateBinding(context, tuple, fact, toUpdate, toRetract);
+                }
+                else
                 {
                     AssertBinding(context, tuple, toAssert);
                 }
-
-                counter.AddItems(tuples.Count);
             }
-            MemoryNode.PropagateAssert(context, toAssert);
+
+            counter.AddItems(tuples.Count);
         }
+        MemoryNode.PropagateRetract(context, toRetract);
+        MemoryNode.PropagateUpdate(context, toUpdate);
+        MemoryNode.PropagateAssert(context, toAssert);
+    }
 
-        public override void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
+    public override void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toRetract = new TupleFactList();
+        using (var counter = PerfCounter.Retract(context, this))
         {
-            var toAssert = new TupleFactList();
-            var toUpdate = new TupleFactList();
-            var toRetract = new TupleFactList();
-            using (var counter = PerfCounter.Update(context, this))
+            foreach (var tuple in tuples)
             {
-                foreach (var tuple in tuples)
-                {
-                    var fact = context.WorkingMemory.GetState<Fact>(this, tuple);
-                    if (fact != null)
-                    {
-                        UpdateBinding(context, tuple, fact, toUpdate, toRetract);
-                    }
-                    else
-                    {
-                        AssertBinding(context, tuple, toAssert);
-                    }
-                }
-
-                counter.AddItems(tuples.Count);
-            }
-            MemoryNode.PropagateRetract(context, toRetract);
-            MemoryNode.PropagateUpdate(context, toUpdate);
-            MemoryNode.PropagateAssert(context, toAssert);
-        }
-
-        public override void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
-        {
-            var toRetract = new TupleFactList();
-            using (var counter = PerfCounter.Retract(context, this))
-            {
-                foreach (var tuple in tuples)
-                {
-                    RetractBinding(context, tuple, toRetract);
-                }
-
-                counter.AddItems(tuples.Count);
-            }
-            MemoryNode.PropagateRetract(context, toRetract);
-        }
-
-        private void AssertBinding(IExecutionContext context, Tuple tuple, TupleFactList toAssert)
-        {
-            try
-            {
-                var value = _compiledExpression.Invoke(context, NodeInfo, tuple);
-                var fact = new Fact(value, ResultType);
-                context.WorkingMemory.SetState(this, tuple, fact);
-                toAssert.Add(tuple, fact);
-            }
-            catch (ExpressionEvaluationException e)
-            {
-                if (!e.IsHandled)
-                {
-                    throw new RuleLhsExpressionEvaluationException("Failed to evaluate binding expression",
-                        e.Expression.ToString(), e.InnerException);
-                }
-            }
-        }
-
-        private void UpdateBinding(IExecutionContext context, Tuple tuple, Fact fact, TupleFactList toUpdate, TupleFactList toRetract)
-        {
-            try
-            {
-                var value = _compiledExpression.Invoke(context, NodeInfo, tuple);
-                fact.RawObject = value;
-                toUpdate.Add(tuple, fact);
-            }
-            catch (ExpressionEvaluationException e)
-            {
-                if (!e.IsHandled)
-                {
-                    throw new RuleLhsExpressionEvaluationException("Failed to evaluate binding expression",
-                        e.Expression.ToString(), e.InnerException);
-                }
                 RetractBinding(context, tuple, toRetract);
             }
-        }
 
-        private void RetractBinding(IExecutionContext context, Tuple tuple, TupleFactList toRetract)
+            counter.AddItems(tuples.Count);
+        }
+        MemoryNode.PropagateRetract(context, toRetract);
+    }
+
+    private void AssertBinding(IExecutionContext context, Tuple tuple, TupleFactList toAssert)
+    {
+        try
         {
-            var fact = context.WorkingMemory.RemoveState<Fact>(this, tuple);
-            if (fact != null)
+            var value = _compiledExpression.Invoke(context, NodeInfo, tuple);
+            var fact = new Fact(value, ResultType);
+            context.WorkingMemory.SetState(this, tuple, fact);
+            toAssert.Add(tuple, fact);
+        }
+        catch (ExpressionEvaluationException e)
+        {
+            if (!e.IsHandled)
             {
-                toRetract.Add(tuple, fact);
+                throw new RuleLhsExpressionEvaluationException("Failed to evaluate binding expression",
+                    e.Expression.ToString(), e.InnerException);
             }
         }
+    }
 
-        public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    private void UpdateBinding(IExecutionContext context, Tuple tuple, Fact fact, TupleFactList toUpdate, TupleFactList toRetract)
+    {
+        try
         {
-            visitor.VisitBindingNode(context, this);
+            var value = _compiledExpression.Invoke(context, NodeInfo, tuple);
+            fact.RawObject = value;
+            toUpdate.Add(tuple, fact);
         }
+        catch (ExpressionEvaluationException e)
+        {
+            if (!e.IsHandled)
+            {
+                throw new RuleLhsExpressionEvaluationException("Failed to evaluate binding expression",
+                    e.Expression.ToString(), e.InnerException);
+            }
+            RetractBinding(context, tuple, toRetract);
+        }
+    }
+
+    private void RetractBinding(IExecutionContext context, Tuple tuple, TupleFactList toRetract)
+    {
+        var fact = context.WorkingMemory.RemoveState<Fact>(this, tuple);
+        if (fact != null)
+        {
+            toRetract.Add(tuple, fact);
+        }
+    }
+
+    public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.VisitBindingNode(context, this);
     }
 }

--- a/src/NRules/NRules/Rete/DummyNode.cs
+++ b/src/NRules/NRules/Rete/DummyNode.cs
@@ -1,59 +1,58 @@
 ﻿using System.Collections.Generic;
 using NRules.Diagnostics;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal class DummyNode : IBetaMemoryNode
 {
-    internal class DummyNode : IBetaMemoryNode
+    private readonly List<ITupleSink> _sinks = new();
+
+    public int Id { get; set; }
+    public NodeInfo NodeInfo { get; } = new NodeInfo();
+    public IEnumerable<ITupleSink> Sinks => _sinks;
+
+    public void Activate(IExecutionContext context)
     {
-        private readonly List<ITupleSink> _sinks = new();
+        var tuple = new Tuple(context.IdGenerator.NextTupleId());
+        var tupleList = new List<Tuple>();
+        tupleList.Add(tuple);
 
-        public int Id { get; set; }
-        public NodeInfo NodeInfo { get; } = new NodeInfo();
-        public IEnumerable<ITupleSink> Sinks => _sinks;
-
-        public void Activate(IExecutionContext context)
+        IBetaMemory memory = context.WorkingMemory.GetNodeMemory(this);
+        foreach (ITupleSink sink in _sinks)
         {
-            var tuple = new Tuple(context.IdGenerator.NextTupleId());
-            var tupleList = new List<Tuple>();
-            tupleList.Add(tuple);
-
-            IBetaMemory memory = context.WorkingMemory.GetNodeMemory(this);
-            foreach (ITupleSink sink in _sinks)
-            {
-                sink.PropagateAssert(context, tupleList);
-            }
-            memory.Add(tupleList);
+            sink.PropagateAssert(context, tupleList);
         }
+        memory.Add(tupleList);
+    }
 
-        public IEnumerable<Tuple> GetTuples(IExecutionContext context)
-        {
-            IBetaMemory memory = context.WorkingMemory.GetNodeMemory(this);
-            return memory.Tuples;
-        }
+    public IEnumerable<Tuple> GetTuples(IExecutionContext context)
+    {
+        IBetaMemory memory = context.WorkingMemory.GetNodeMemory(this);
+        return memory.Tuples;
+    }
 
-        public void Attach(ITupleSink sink)
-        {
-            _sinks.Add(sink);
-        }
+    public void Attach(ITupleSink sink)
+    {
+        _sinks.Add(sink);
+    }
 
-        public void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
-        {
-            visitor.VisitDummyNode(context, this);
-        }
+    public void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.VisitDummyNode(context, this);
+    }
 
-        public void PropagateAssert(IExecutionContext context, TupleFactList tupleFactList)
-        {
-            //Do nothing
-        }
+    public void PropagateAssert(IExecutionContext context, TupleFactList tupleFactList)
+    {
+        //Do nothing
+    }
 
-        public void PropagateUpdate(IExecutionContext context, TupleFactList tupleFactList)
-        {
-            //Do nothing
-        }
+    public void PropagateUpdate(IExecutionContext context, TupleFactList tupleFactList)
+    {
+        //Do nothing
+    }
 
-        public void PropagateRetract(IExecutionContext context, TupleFactList tupleFactList)
-        {
-            //Do nothing
-        }
+    public void PropagateRetract(IExecutionContext context, TupleFactList tupleFactList)
+    {
+        //Do nothing
     }
 }

--- a/src/NRules/NRules/Rete/ExistsNode.cs
+++ b/src/NRules/NRules/Rete/ExistsNode.cs
@@ -1,133 +1,132 @@
 ﻿using System.Collections.Generic;
 using NRules.Diagnostics;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal class ExistsNode : BinaryBetaNode
 {
-    internal class ExistsNode : BinaryBetaNode
+    public ExistsNode(ITupleSource leftSource, IObjectSource rightSource) : base(leftSource, rightSource, true)
     {
-        public ExistsNode(ITupleSource leftSource, IObjectSource rightSource) : base(leftSource, rightSource, true)
-        {
-        }
+    }
 
-        public override void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
+    public override void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toAssert = new TupleFactList();
+        using (var counter = PerfCounter.Assert(context, this))
         {
-            var toAssert = new TupleFactList();
-            using (var counter = PerfCounter.Assert(context, this))
+            var joinedSets = JoinedSets(context, tuples);
+            foreach (var set in joinedSets)
             {
-                var joinedSets = JoinedSets(context, tuples);
-                foreach (var set in joinedSets)
+                var quantifier = context.CreateQuantifier(this, set.Tuple);
+                quantifier.Value += set.Facts.Count;
+                if (quantifier.Value > 0)
                 {
-                    var quantifier = context.CreateQuantifier(this, set.Tuple);
-                    quantifier.Value += set.Facts.Count;
-                    if (quantifier.Value > 0)
-                    {
-                        toAssert.Add(set.Tuple, null);
-                    }
+                    toAssert.Add(set.Tuple, null);
                 }
-
-                counter.AddInputs(tuples.Count);
-                counter.AddOutputs(toAssert.Count);
             }
 
-            MemoryNode.PropagateAssert(context, toAssert);
+            counter.AddInputs(tuples.Count);
+            counter.AddOutputs(toAssert.Count);
         }
 
-        public override void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
+        MemoryNode.PropagateAssert(context, toAssert);
+    }
+
+    public override void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toUpdate = new TupleFactList();
+        using (var counter = PerfCounter.Update(context, this))
         {
-            var toUpdate = new TupleFactList();
-            using (var counter = PerfCounter.Update(context, this))
+            foreach (var tuple in tuples)
             {
-                foreach (var tuple in tuples)
+                if (context.GetQuantifier(this, tuple).Value > 0)
                 {
-                    if (context.GetQuantifier(this, tuple).Value > 0)
-                    {
-                        toUpdate.Add(tuple, null);
-                    }
+                    toUpdate.Add(tuple, null);
                 }
-
-                counter.AddInputs(tuples.Count);
-                counter.AddOutputs(toUpdate.Count);
-            }
-            
-            MemoryNode.PropagateUpdate(context, toUpdate);
-        }
-
-        public override void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
-        {
-            var toRetract = new TupleFactList();
-            using (var counter = PerfCounter.Retract(context, this))
-            {
-                foreach (var tuple in tuples)
-                {
-                    if (context.RemoveQuantifier(this, tuple).Value > 0)
-                    {
-                        toRetract.Add(tuple, null);
-                    }
-                }
-
-                counter.AddInputs(tuples.Count);
-                counter.AddOutputs(toRetract.Count);
             }
 
-            MemoryNode.PropagateRetract(context, toRetract);
+            counter.AddInputs(tuples.Count);
+            counter.AddOutputs(toUpdate.Count);
         }
+        
+        MemoryNode.PropagateUpdate(context, toUpdate);
+    }
 
-        public override void PropagateAssert(IExecutionContext context, List<Fact> facts)
+    public override void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toRetract = new TupleFactList();
+        using (var counter = PerfCounter.Retract(context, this))
         {
-            var toAssert = new TupleFactList();
-            using (var counter = PerfCounter.Assert(context, this))
+            foreach (var tuple in tuples)
             {
-                var joinedSets = JoinedSets(context, facts);
-                foreach (var set in joinedSets)
+                if (context.RemoveQuantifier(this, tuple).Value > 0)
                 {
-                    var quantifier = context.GetQuantifier(this, set.Tuple);
-                    int startingCount = quantifier.Value;
-                    quantifier.Value += set.Facts.Count;
-                    if (startingCount == 0 && quantifier.Value > 0)
-                    {
-                        toAssert.Add(set.Tuple, null);
-                    }
+                    toRetract.Add(tuple, null);
                 }
-
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(toAssert.Count);
             }
 
-            MemoryNode.PropagateAssert(context, toAssert);
+            counter.AddInputs(tuples.Count);
+            counter.AddOutputs(toRetract.Count);
         }
 
-        public override void PropagateUpdate(IExecutionContext context, List<Fact> facts)
-        {
-            //Do nothing
-        }
+        MemoryNode.PropagateRetract(context, toRetract);
+    }
 
-        public override void PropagateRetract(IExecutionContext context, List<Fact> facts)
+    public override void PropagateAssert(IExecutionContext context, List<Fact> facts)
+    {
+        var toAssert = new TupleFactList();
+        using (var counter = PerfCounter.Assert(context, this))
         {
-            var toRetract = new TupleFactList();
-            using (var counter = PerfCounter.Retract(context, this))
+            var joinedSets = JoinedSets(context, facts);
+            foreach (var set in joinedSets)
             {
-                var joinedSets = JoinedSets(context, facts);
-                foreach (var set in joinedSets)
+                var quantifier = context.GetQuantifier(this, set.Tuple);
+                int startingCount = quantifier.Value;
+                quantifier.Value += set.Facts.Count;
+                if (startingCount == 0 && quantifier.Value > 0)
                 {
-                    var quantifier = context.GetQuantifier(this, set.Tuple);
-                    int startingCount = quantifier.Value;
-                    quantifier.Value -= set.Facts.Count;
-                    if (startingCount > 0 && quantifier.Value == 0)
-                    {
-                        toRetract.Add(set.Tuple, null);
-                    }
+                    toAssert.Add(set.Tuple, null);
                 }
-
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(toRetract.Count);
             }
 
-            MemoryNode.PropagateRetract(context, toRetract);
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(toAssert.Count);
         }
 
-        public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+        MemoryNode.PropagateAssert(context, toAssert);
+    }
+
+    public override void PropagateUpdate(IExecutionContext context, List<Fact> facts)
+    {
+        //Do nothing
+    }
+
+    public override void PropagateRetract(IExecutionContext context, List<Fact> facts)
+    {
+        var toRetract = new TupleFactList();
+        using (var counter = PerfCounter.Retract(context, this))
         {
-            visitor.VisitExistsNode(context, this);
+            var joinedSets = JoinedSets(context, facts);
+            foreach (var set in joinedSets)
+            {
+                var quantifier = context.GetQuantifier(this, set.Tuple);
+                int startingCount = quantifier.Value;
+                quantifier.Value -= set.Facts.Count;
+                if (startingCount > 0 && quantifier.Value == 0)
+                {
+                    toRetract.Add(set.Tuple, null);
+                }
+            }
+
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(toRetract.Count);
         }
+
+        MemoryNode.PropagateRetract(context, toRetract);
+    }
+
+    public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.VisitExistsNode(context, this);
     }
 }

--- a/src/NRules/NRules/Rete/Fact.cs
+++ b/src/NRules/NRules/Rete/Fact.cs
@@ -2,78 +2,77 @@
 using System.Diagnostics;
 using NRules.RuleModel;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+[DebuggerDisplay("Fact {Object}")]
+internal class Fact : IFact
 {
-    [DebuggerDisplay("Fact {Object}")]
-    internal class Fact : IFact
+    private object _object;
+
+    public Fact()
     {
-        private object _object;
-
-        public Fact()
-        {
-        }
-
-        public Fact(object @object)
-        {
-            _object = @object;
-            FactType = @object.GetType();
-        }
-
-        public Fact(object @object, Type declaredType)
-        {
-            _object = @object;
-            FactType = @object?.GetType() ?? declaredType;
-        }
-
-        public virtual Type FactType { get; }
-
-        public object RawObject
-        {
-            get => _object;
-            set => _object = value;
-        }
-
-        public virtual IFactSource Source
-        {
-            get => null;
-            set => throw new InvalidOperationException("Source is only supported on synthetic facts");
-        }
-
-        public virtual object Object => _object;
-        public virtual bool IsWrapperFact => false;
-        Type IFact.Type => FactType;
-        object IFact.Value => Object;
-        IFactSource IFact.Source => Source;
     }
 
-    [DebuggerDisplay("Fact {Source.SourceType} {Object}")]
-    internal class SyntheticFact : Fact
+    public Fact(object @object)
     {
-        public SyntheticFact(object @object)
-            : base(@object)
-        {
-        }
-
-        public override IFactSource Source { get; set; }
+        _object = @object;
+        FactType = @object.GetType();
     }
 
-    [DebuggerDisplay("Fact Tuple({WrappedTuple.Count}) -> {Object}")]
-    internal class WrapperFact : Fact
+    public Fact(object @object, Type declaredType)
     {
-        public WrapperFact(Tuple tuple)
-            : base(tuple)
-        {
-        }
+        _object = @object;
+        FactType = @object?.GetType() ?? declaredType;
+    }
 
-        public override Type FactType => WrappedTuple.RightFact?.FactType;
-        public override object Object => WrappedTuple.RightFact?.Object;
-        public Tuple WrappedTuple => (Tuple) RawObject;
-        public override bool IsWrapperFact => true;
+    public virtual Type FactType { get; }
 
-        public override IFactSource Source
-        {
-            get => WrappedTuple.RightFact?.Source;
-            set {}
-        }
+    public object RawObject
+    {
+        get => _object;
+        set => _object = value;
+    }
+
+    public virtual IFactSource Source
+    {
+        get => null;
+        set => throw new InvalidOperationException("Source is only supported on synthetic facts");
+    }
+
+    public virtual object Object => _object;
+    public virtual bool IsWrapperFact => false;
+    Type IFact.Type => FactType;
+    object IFact.Value => Object;
+    IFactSource IFact.Source => Source;
+}
+
+[DebuggerDisplay("Fact {Source.SourceType} {Object}")]
+internal class SyntheticFact : Fact
+{
+    public SyntheticFact(object @object)
+        : base(@object)
+    {
+    }
+
+    public override IFactSource Source { get; set; }
+}
+
+[DebuggerDisplay("Fact Tuple({WrappedTuple.Count}) -> {Object}")]
+internal class WrapperFact : Fact
+{
+    public WrapperFact(Tuple tuple)
+        : base(tuple)
+    {
+    }
+
+    public override Type FactType => WrappedTuple.RightFact?.FactType;
+    public override object Object => WrappedTuple.RightFact?.Object;
+    public Tuple WrappedTuple => (Tuple) RawObject;
+    public override bool IsWrapperFact => true;
+
+    public override IFactSource Source
+    {
+        get => WrappedTuple.RightFact?.Source;
+        set {}
     }
 }

--- a/src/NRules/NRules/Rete/FactAggregator.cs
+++ b/src/NRules/NRules/Rete/FactAggregator.cs
@@ -3,106 +3,105 @@ using System.Collections.Generic;
 using NRules.Aggregators;
 using NRules.Collections;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal interface IFactAggregator
 {
-    internal interface IFactAggregator
+    void Add(AggregationContext context, Aggregation aggregation, Tuple tuple, IEnumerable<Fact> facts);
+    void Modify(AggregationContext context, Aggregation aggregation, Tuple tuple, IEnumerable<Fact> facts);
+    void Remove(AggregationContext context, Aggregation aggregation, Tuple tuple, IEnumerable<Fact> facts);
+    IEnumerable<Fact> AggregateFacts { get; }
+}
+
+internal class FactAggregator : IFactAggregator
+{
+    private readonly IAggregator _aggregator;
+    private readonly OrderedDictionary<object, Fact> _aggregateFactMap = new();
+
+    public FactAggregator(IAggregator aggregator)
     {
-        void Add(AggregationContext context, Aggregation aggregation, Tuple tuple, IEnumerable<Fact> facts);
-        void Modify(AggregationContext context, Aggregation aggregation, Tuple tuple, IEnumerable<Fact> facts);
-        void Remove(AggregationContext context, Aggregation aggregation, Tuple tuple, IEnumerable<Fact> facts);
-        IEnumerable<Fact> AggregateFacts { get; }
+        _aggregator = aggregator;
     }
 
-    internal class FactAggregator : IFactAggregator
+    public IEnumerable<Fact> AggregateFacts => _aggregateFactMap.Values;
+    
+    public void Add(AggregationContext context, Aggregation aggregation, Tuple tuple, IEnumerable<Fact> facts)
     {
-        private readonly IAggregator _aggregator;
-        private readonly OrderedDictionary<object, Fact> _aggregateFactMap = new();
+        var results = _aggregator.Add(context, tuple, facts);
+        AddAggregationResult(aggregation, tuple, results);
+    }
 
-        public FactAggregator(IAggregator aggregator)
-        {
-            _aggregator = aggregator;
-        }
+    public void Modify(AggregationContext context, Aggregation aggregation, Tuple tuple, IEnumerable<Fact> facts)
+    {
+        var results = _aggregator.Modify(context, tuple, facts);
+        AddAggregationResult(aggregation, tuple, results);
+    }
 
-        public IEnumerable<Fact> AggregateFacts => _aggregateFactMap.Values;
-        
-        public void Add(AggregationContext context, Aggregation aggregation, Tuple tuple, IEnumerable<Fact> facts)
-        {
-            var results = _aggregator.Add(context, tuple, facts);
-            AddAggregationResult(aggregation, tuple, results);
-        }
+    public void Remove(AggregationContext context, Aggregation aggregation, Tuple tuple, IEnumerable<Fact> facts)
+    {
+        var results = _aggregator.Remove(context, tuple, facts);
+        AddAggregationResult(aggregation, tuple, results);
+    }
 
-        public void Modify(AggregationContext context, Aggregation aggregation, Tuple tuple, IEnumerable<Fact> facts)
+    private void AddAggregationResult(Aggregation aggregation, Tuple tuple, IEnumerable<AggregationResult> results)
+    {
+        foreach (var result in results)
         {
-            var results = _aggregator.Modify(context, tuple, facts);
-            AddAggregationResult(aggregation, tuple, results);
-        }
-
-        public void Remove(AggregationContext context, Aggregation aggregation, Tuple tuple, IEnumerable<Fact> facts)
-        {
-            var results = _aggregator.Remove(context, tuple, facts);
-            AddAggregationResult(aggregation, tuple, results);
-        }
-
-        private void AddAggregationResult(Aggregation aggregation, Tuple tuple, IEnumerable<AggregationResult> results)
-        {
-            foreach (var result in results)
+            switch (result.Action)
             {
-                switch (result.Action)
-                {
-                    case AggregationAction.Added:
-                        var addedFact = CreateAggregateFact(result);
-                        aggregation.Add(tuple, addedFact);
-                        break;
-                    case AggregationAction.Modified:
-                        var modifiedFact = GetAggregateFact(result);
-                        aggregation.Modify(tuple, modifiedFact);
-                        break;
-                    case AggregationAction.Removed:
-                        var removedFact = RemoveAggregateFact(result);
-                        aggregation.Remove(tuple, removedFact);
-                        break;
-                }
+                case AggregationAction.Added:
+                    var addedFact = CreateAggregateFact(result);
+                    aggregation.Add(tuple, addedFact);
+                    break;
+                case AggregationAction.Modified:
+                    var modifiedFact = GetAggregateFact(result);
+                    aggregation.Modify(tuple, modifiedFact);
+                    break;
+                case AggregationAction.Removed:
+                    var removedFact = RemoveAggregateFact(result);
+                    aggregation.Remove(tuple, removedFact);
+                    break;
             }
         }
+    }
 
-        private Fact CreateAggregateFact(AggregationResult result)
+    private Fact CreateAggregateFact(AggregationResult result)
+    {
+        var fact = new SyntheticFact(result.Aggregate);
+        fact.Source = new AggregateFactSource(result.Source);
+        _aggregateFactMap.Add(result.Aggregate, fact);
+        return fact;
+    }
+
+    private Fact GetAggregateFact(AggregationResult result)
+    {
+        if (!_aggregateFactMap.TryGetValue(result.Previous ?? result.Aggregate, out var fact))
         {
-            var fact = new SyntheticFact(result.Aggregate);
-            fact.Source = new AggregateFactSource(result.Source);
-            _aggregateFactMap.Add(result.Aggregate, fact);
-            return fact;
+            throw new InvalidOperationException(
+                $"Fact for aggregate object does not exist. AggregatorType={_aggregator.GetType()}, FactType={result.Aggregate.GetType()}");
         }
 
-        private Fact GetAggregateFact(AggregationResult result)
+        fact.Source = new AggregateFactSource(result.Source);
+        if (!ReferenceEquals(fact.RawObject, result.Aggregate))
         {
-            if (!_aggregateFactMap.TryGetValue(result.Previous ?? result.Aggregate, out var fact))
-            {
-                throw new InvalidOperationException(
-                    $"Fact for aggregate object does not exist. AggregatorType={_aggregator.GetType()}, FactType={result.Aggregate.GetType()}");
-            }
-
-            fact.Source = new AggregateFactSource(result.Source);
-            if (!ReferenceEquals(fact.RawObject, result.Aggregate))
-            {
-                _aggregateFactMap.Remove(fact.RawObject);
-                fact.RawObject = result.Aggregate;
-                _aggregateFactMap.Add(fact.RawObject, fact);
-            }
-            return fact;
-        }
-
-        private Fact RemoveAggregateFact(AggregationResult result)
-        {
-            if (!_aggregateFactMap.TryGetValue(result.Aggregate, out var fact))
-            {
-                throw new InvalidOperationException(
-                    $"Fact for aggregate object does not exist. AggregatorType={_aggregator.GetType()}, FactType={result.Aggregate.GetType()}");
-            }
-
             _aggregateFactMap.Remove(fact.RawObject);
             fact.RawObject = result.Aggregate;
-            fact.Source = null;
-            return fact;
+            _aggregateFactMap.Add(fact.RawObject, fact);
         }
+        return fact;
+    }
+
+    private Fact RemoveAggregateFact(AggregationResult result)
+    {
+        if (!_aggregateFactMap.TryGetValue(result.Aggregate, out var fact))
+        {
+            throw new InvalidOperationException(
+                $"Fact for aggregate object does not exist. AggregatorType={_aggregator.GetType()}, FactType={result.Aggregate.GetType()}");
+        }
+
+        _aggregateFactMap.Remove(fact.RawObject);
+        fact.RawObject = result.Aggregate;
+        fact.Source = null;
+        return fact;
     }
 }

--- a/src/NRules/NRules/Rete/INode.cs
+++ b/src/NRules/NRules/Rete/INode.cs
@@ -1,11 +1,10 @@
 ﻿using NRules.Diagnostics;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal interface INode
 {
-    internal interface INode
-    {
-        int Id { get; }
-        NodeInfo NodeInfo { get; }
-        void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor);
-    }
+    int Id { get; }
+    NodeInfo NodeInfo { get; }
+    void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor);
 }

--- a/src/NRules/NRules/Rete/IObjectSink.cs
+++ b/src/NRules/NRules/Rete/IObjectSink.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal interface IObjectSink : INode
 {
-    internal interface IObjectSink : INode
-    {
-        void PropagateAssert(IExecutionContext context, List<Fact> facts);
-        void PropagateUpdate(IExecutionContext context, List<Fact> facts);
-        void PropagateRetract(IExecutionContext context, List<Fact> facts);
-    }
+    void PropagateAssert(IExecutionContext context, List<Fact> facts);
+    void PropagateUpdate(IExecutionContext context, List<Fact> facts);
+    void PropagateRetract(IExecutionContext context, List<Fact> facts);
 }

--- a/src/NRules/NRules/Rete/IObjectSource.cs
+++ b/src/NRules/NRules/Rete/IObjectSource.cs
@@ -1,10 +1,9 @@
 using System.Collections.Generic;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal interface IObjectSource
 {
-    internal interface IObjectSource
-    {
-        IEnumerable<Fact> GetFacts(IExecutionContext context);
-        void Attach(IObjectSink sink);
-    }
+    IEnumerable<Fact> GetFacts(IExecutionContext context);
+    void Attach(IObjectSink sink);
 }

--- a/src/NRules/NRules/Rete/ITupleSink.cs
+++ b/src/NRules/NRules/Rete/ITupleSink.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal interface ITupleSink : INode
 {
-    internal interface ITupleSink : INode
-    {
-        void PropagateAssert(IExecutionContext context, List<Tuple> tuples);
-        void PropagateUpdate(IExecutionContext context, List<Tuple> tuples);
-        void PropagateRetract(IExecutionContext context, List<Tuple> tuples);
-    }
+    void PropagateAssert(IExecutionContext context, List<Tuple> tuples);
+    void PropagateUpdate(IExecutionContext context, List<Tuple> tuples);
+    void PropagateRetract(IExecutionContext context, List<Tuple> tuples);
 }

--- a/src/NRules/NRules/Rete/ITupleSource.cs
+++ b/src/NRules/NRules/Rete/ITupleSource.cs
@@ -1,10 +1,9 @@
 using System.Collections.Generic;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal interface ITupleSource
 {
-    internal interface ITupleSource
-    {
-        IEnumerable<Tuple> GetTuples(IExecutionContext context);
-        void Attach(ITupleSink sink);
-    }
+    IEnumerable<Tuple> GetTuples(IExecutionContext context);
+    void Attach(ITupleSink sink);
 }

--- a/src/NRules/NRules/Rete/IndexMap.cs
+++ b/src/NRules/NRules/Rete/IndexMap.cs
@@ -5,64 +5,63 @@ using System.Linq;
 using NRules.RuleModel;
 using NRules.Utilities;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+[DebuggerDisplay("[{string.Join(\" \",_map)}]")]
+internal class IndexMap : IEquatable<IndexMap>
 {
-    [DebuggerDisplay("[{string.Join(\" \",_map)}]")]
-    internal class IndexMap : IEquatable<IndexMap>
+    private readonly int[] _map;
+
+    private IndexMap(int[] map)
     {
-        private readonly int[] _map;
+        _map = map;
+    }
 
-        private IndexMap(int[] map)
-        {
-            _map = map;
-        }
+    public static IndexMap Empty = new(Array.Empty<int>());
+    public static IndexMap Unit = new(new[] {0});
 
-        public static IndexMap Empty = new(Array.Empty<int>());
-        public static IndexMap Unit = new(new[] {0});
+    public bool HasData => _map.Any(x => x >= 0);
+    public int Length => _map.Length;
+    public int this[int index] => (index >= 0 && index < _map.Length) ? _map[index] : -1;
 
-        public bool HasData => _map.Any(x => x >= 0);
-        public int Length => _map.Length;
-        public int this[int index] => (index >= 0 && index < _map.Length) ? _map[index] : -1;
+    public static IndexMap CreateMap(IEnumerable<Declaration> declarations, IEnumerable<Declaration> baseDeclarations)
+    {
+        var positionMap = declarations.ToIndexMap();
+        var map = baseDeclarations
+            .Select(positionMap.IndexOrDefault).ToArray();
+        return new IndexMap(map);
+    }
 
-        public static IndexMap CreateMap(IEnumerable<Declaration> declarations, IEnumerable<Declaration> baseDeclarations)
-        {
-            var positionMap = declarations.ToIndexMap();
-            var map = baseDeclarations
-                .Select(positionMap.IndexOrDefault).ToArray();
-            return new IndexMap(map);
-        }
-
-        public static IndexMap Compose(IndexMap first, IndexMap second)
-        {
-            var map = first._map.Select(x => second[x]).ToArray();
-            return new IndexMap(map);
-        }
+    public static IndexMap Compose(IndexMap first, IndexMap second)
+    {
+        var map = first._map.Select(x => second[x]).ToArray();
+        return new IndexMap(map);
+    }
+    
+    public bool Equals(IndexMap other)
+    {
+        if (_map.Length != other._map.Length) 
+            return false;
         
-        public bool Equals(IndexMap other)
+        for (int i = 0; i < _map.Length; i++)
         {
-            if (_map.Length != other._map.Length) 
+            if (_map[i] != other._map[i])
                 return false;
-            
-            for (int i = 0; i < _map.Length; i++)
-            {
-                if (_map[i] != other._map[i])
-                    return false;
-            }
-
-            return true;
         }
 
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
-            return Equals((IndexMap) obj);
-        }
+        return true;
+    }
 
-        public override int GetHashCode()
-        {
-            return _map.Length;
-        }
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != GetType()) return false;
+        return Equals((IndexMap) obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return _map.Length;
     }
 }

--- a/src/NRules/NRules/Rete/JoinNode.cs
+++ b/src/NRules/NRules/Rete/JoinNode.cs
@@ -2,192 +2,191 @@
 using NRules.Diagnostics;
 using NRules.RuleModel;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal class JoinNode : BinaryBetaNode
 {
-    internal class JoinNode : BinaryBetaNode
+    private readonly List<ILhsExpression<bool>> _compiledExpressions;
+    private readonly bool _isSubnetJoin;
+
+    public List<Declaration> Declarations { get; }
+    public List<ExpressionElement> ExpressionElements { get; }
+
+    public JoinNode(ITupleSource leftSource, 
+        IObjectSource rightSource,
+        List<Declaration> declarations,
+        List<ExpressionElement> expressionElements,
+        List<ILhsExpression<bool>> compiledExpressions,
+        bool isSubnetJoin)
+        : base(leftSource, rightSource, isSubnetJoin)
     {
-        private readonly List<ILhsExpression<bool>> _compiledExpressions;
-        private readonly bool _isSubnetJoin;
+        Declarations = declarations;
+        ExpressionElements = expressionElements;
+        _compiledExpressions = compiledExpressions;
+        _isSubnetJoin = isSubnetJoin;
+    }
 
-        public List<Declaration> Declarations { get; }
-        public List<ExpressionElement> ExpressionElements { get; }
-
-        public JoinNode(ITupleSource leftSource, 
-            IObjectSource rightSource,
-            List<Declaration> declarations,
-            List<ExpressionElement> expressionElements,
-            List<ILhsExpression<bool>> compiledExpressions,
-            bool isSubnetJoin)
-            : base(leftSource, rightSource, isSubnetJoin)
+    public override void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toAssert = new TupleFactList();
+        using (var counter = PerfCounter.Assert(context, this))
         {
-            Declarations = declarations;
-            ExpressionElements = expressionElements;
-            _compiledExpressions = compiledExpressions;
-            _isSubnetJoin = isSubnetJoin;
-        }
-
-        public override void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
-        {
-            var toAssert = new TupleFactList();
-            using (var counter = PerfCounter.Assert(context, this))
+            var joinedSets = JoinedSets(context, tuples);
+            foreach (var set in joinedSets)
+            foreach (var fact in set.Facts)
             {
-                var joinedSets = JoinedSets(context, tuples);
-                foreach (var set in joinedSets)
-                foreach (var fact in set.Facts)
+                if (MatchesConditions(context, set.Tuple, fact))
                 {
-                    if (MatchesConditions(context, set.Tuple, fact))
-                    {
-                        toAssert.Add(set.Tuple, fact);
-                    }
+                    toAssert.Add(set.Tuple, fact);
                 }
-
-                counter.AddInputs(tuples.Count);
-                counter.AddOutputs(toAssert.Count);
             }
 
-            MemoryNode.PropagateAssert(context, toAssert);
+            counter.AddInputs(tuples.Count);
+            counter.AddOutputs(toAssert.Count);
         }
 
-        public override void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
+        MemoryNode.PropagateAssert(context, toAssert);
+    }
+
+    public override void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
+    {
+        if (_isSubnetJoin) return;
+        
+        var toUpdate = new TupleFactList();
+        var toRetract = new TupleFactList();
+        using (var counter = PerfCounter.Update(context, this))
         {
-            if (_isSubnetJoin) return;
-            
-            var toUpdate = new TupleFactList();
-            var toRetract = new TupleFactList();
-            using (var counter = PerfCounter.Update(context, this))
+            var joinedSets = JoinedSets(context, tuples);
+            foreach (var set in joinedSets)
+            foreach (var fact in set.Facts)
             {
-                var joinedSets = JoinedSets(context, tuples);
-                foreach (var set in joinedSets)
-                foreach (var fact in set.Facts)
+                if (MatchesConditions(context, set.Tuple, fact))
                 {
-                    if (MatchesConditions(context, set.Tuple, fact))
-                    {
-                        toUpdate.Add(set.Tuple, fact);
-                    }
-                    else
-                    {
-                        toRetract.Add(set.Tuple, fact);
-                    }
+                    toUpdate.Add(set.Tuple, fact);
                 }
-
-                counter.AddInputs(tuples.Count);
-                counter.AddOutputs(toUpdate.Count + toRetract.Count);
-            }
-
-            MemoryNode.PropagateRetract(context, toRetract);
-            MemoryNode.PropagateUpdate(context, toUpdate);
-        }
-
-        public override void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
-        {
-            var toRetract = new TupleFactList();
-            using (var counter = PerfCounter.Retract(context, this))
-            {
-                var joinedSets = JoinedSets(context, tuples);
-                foreach (var set in joinedSets)
-                foreach (var fact in set.Facts)
+                else
                 {
                     toRetract.Add(set.Tuple, fact);
                 }
-             
-                counter.AddInputs(tuples.Count);
-                counter.AddOutputs(toRetract.Count);
             }
 
-            MemoryNode.PropagateRetract(context, toRetract);
+            counter.AddInputs(tuples.Count);
+            counter.AddOutputs(toUpdate.Count + toRetract.Count);
         }
 
-        public override void PropagateAssert(IExecutionContext context, List<Fact> facts)
+        MemoryNode.PropagateRetract(context, toRetract);
+        MemoryNode.PropagateUpdate(context, toUpdate);
+    }
+
+    public override void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toRetract = new TupleFactList();
+        using (var counter = PerfCounter.Retract(context, this))
         {
-            var toAssert = new TupleFactList();
-            using (var counter = PerfCounter.Assert(context, this))
+            var joinedSets = JoinedSets(context, tuples);
+            foreach (var set in joinedSets)
+            foreach (var fact in set.Facts)
             {
-                var joinedSets = JoinedSets(context, facts);
-                foreach (var set in joinedSets)
-                foreach (var fact in set.Facts)
+                toRetract.Add(set.Tuple, fact);
+            }
+         
+            counter.AddInputs(tuples.Count);
+            counter.AddOutputs(toRetract.Count);
+        }
+
+        MemoryNode.PropagateRetract(context, toRetract);
+    }
+
+    public override void PropagateAssert(IExecutionContext context, List<Fact> facts)
+    {
+        var toAssert = new TupleFactList();
+        using (var counter = PerfCounter.Assert(context, this))
+        {
+            var joinedSets = JoinedSets(context, facts);
+            foreach (var set in joinedSets)
+            foreach (var fact in set.Facts)
+            {
+                if (MatchesConditions(context, set.Tuple, fact))
                 {
-                    if (MatchesConditions(context, set.Tuple, fact))
-                    {
-                        toAssert.Add(set.Tuple, fact);
-                    }
+                    toAssert.Add(set.Tuple, fact);
                 }
-
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(toAssert.Count);
             }
 
-            MemoryNode.PropagateAssert(context, toAssert);
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(toAssert.Count);
         }
 
-        public override void PropagateUpdate(IExecutionContext context, List<Fact> facts)
+        MemoryNode.PropagateAssert(context, toAssert);
+    }
+
+    public override void PropagateUpdate(IExecutionContext context, List<Fact> facts)
+    {
+        var toUpdate = new TupleFactList();
+        var toRetract = new TupleFactList();
+        using (var counter = PerfCounter.Update(context, this))
         {
-            var toUpdate = new TupleFactList();
-            var toRetract = new TupleFactList();
-            using (var counter = PerfCounter.Update(context, this))
+            var joinedSets = JoinedSets(context, facts);
+            foreach (var set in joinedSets)
+            foreach (var fact in set.Facts)
             {
-                var joinedSets = JoinedSets(context, facts);
-                foreach (var set in joinedSets)
-                foreach (var fact in set.Facts)
-                {
-                    if (MatchesConditions(context, set.Tuple, fact))
-                        toUpdate.Add(set.Tuple, fact);
-                    else
-                        toRetract.Add(set.Tuple, fact);
-                }
-
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(toUpdate.Count + toRetract.Count);
-            }
-
-            MemoryNode.PropagateRetract(context, toRetract);
-            MemoryNode.PropagateUpdate(context, toUpdate);
-        }
-
-        public override void PropagateRetract(IExecutionContext context, List<Fact> facts)
-        {
-            var toRetract = new TupleFactList();
-            using (var counter = PerfCounter.Retract(context, this))
-            {
-                var joinedSets = JoinedSets(context, facts);
-                foreach (var set in joinedSets)
-                foreach (var fact in set.Facts)
-                {
+                if (MatchesConditions(context, set.Tuple, fact))
+                    toUpdate.Add(set.Tuple, fact);
+                else
                     toRetract.Add(set.Tuple, fact);
-                }
-
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(toRetract.Count);
             }
 
-            MemoryNode.PropagateRetract(context, toRetract);
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(toUpdate.Count + toRetract.Count);
         }
 
-        private bool MatchesConditions(IExecutionContext context, Tuple left, Fact right)
+        MemoryNode.PropagateRetract(context, toRetract);
+        MemoryNode.PropagateUpdate(context, toUpdate);
+    }
+
+    public override void PropagateRetract(IExecutionContext context, List<Fact> facts)
+    {
+        var toRetract = new TupleFactList();
+        using (var counter = PerfCounter.Retract(context, this))
         {
-            try
+            var joinedSets = JoinedSets(context, facts);
+            foreach (var set in joinedSets)
+            foreach (var fact in set.Facts)
             {
-                foreach (var expression in _compiledExpressions)
-                {
-                    if (!expression.Invoke(context, NodeInfo, left, right))
-                        return false;
-                }
-                return true;
+                toRetract.Add(set.Tuple, fact);
             }
-            catch (ExpressionEvaluationException e)
-            {
-                if (!e.IsHandled)
-                {
-                    throw new RuleLhsExpressionEvaluationException(
-                        "Failed to evaluate condition", e.Expression.ToString(), e.InnerException);
-                }
 
-                return false;
-            }
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(toRetract.Count);
         }
 
-        public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+        MemoryNode.PropagateRetract(context, toRetract);
+    }
+
+    private bool MatchesConditions(IExecutionContext context, Tuple left, Fact right)
+    {
+        try
         {
-            visitor.VisitJoinNode(context, this);
+            foreach (var expression in _compiledExpressions)
+            {
+                if (!expression.Invoke(context, NodeInfo, left, right))
+                    return false;
+            }
+            return true;
         }
+        catch (ExpressionEvaluationException e)
+        {
+            if (!e.IsHandled)
+            {
+                throw new RuleLhsExpressionEvaluationException(
+                    "Failed to evaluate condition", e.Expression.ToString(), e.InnerException);
+            }
+
+            return false;
+        }
+    }
+
+    public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.VisitJoinNode(context, this);
     }
 }

--- a/src/NRules/NRules/Rete/LhsExpression.cs
+++ b/src/NRules/NRules/Rete/LhsExpression.cs
@@ -3,141 +3,140 @@ using System.Linq.Expressions;
 using NRules.Diagnostics;
 using NRules.Utilities;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal interface ILhsExpression<out TResult>
 {
-    internal interface ILhsExpression<out TResult>
+    TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Tuple tuple, Fact fact);
+}
+
+internal interface ILhsFactExpression<out TResult> : ILhsExpression<TResult>
+{
+    TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Fact fact);
+}
+
+internal interface ILhsTupleExpression<out TResult> : ILhsExpression<TResult>
+{
+    TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Tuple tuple);
+}
+
+internal sealed class LhsExpression<TResult> : ILhsExpression<TResult>
+{
+    private readonly LambdaExpression _expression;
+    private readonly Func<Tuple, Fact, TResult> _compiledExpression;
+    private readonly IArgumentMap _argumentMap;
+
+    public LhsExpression(LambdaExpression expression, Func<Tuple, Fact, TResult> compiledExpression, IArgumentMap argumentMap)
     {
-        TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Tuple tuple, Fact fact);
+        _expression = expression;
+        _compiledExpression = compiledExpression;
+        _argumentMap = argumentMap;
     }
 
-    internal interface ILhsFactExpression<out TResult> : ILhsExpression<TResult>
+    public TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Tuple tuple, Fact fact)
     {
-        TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Fact fact);
-    }
-
-    internal interface ILhsTupleExpression<out TResult> : ILhsExpression<TResult>
-    {
-        TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Tuple tuple);
-    }
-
-    internal sealed class LhsExpression<TResult> : ILhsExpression<TResult>
-    {
-        private readonly LambdaExpression _expression;
-        private readonly Func<Tuple, Fact, TResult> _compiledExpression;
-        private readonly IArgumentMap _argumentMap;
-
-        public LhsExpression(LambdaExpression expression, Func<Tuple, Fact, TResult> compiledExpression, IArgumentMap argumentMap)
+        Exception exception = null;
+        TResult result = default;
+        try
         {
-            _expression = expression;
-            _compiledExpression = compiledExpression;
-            _argumentMap = argumentMap;
+            result = _compiledExpression(tuple, fact);
+            return result;
         }
-
-        public TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Tuple tuple, Fact fact)
+        catch (Exception e)
         {
-            Exception exception = null;
-            TResult result = default;
-            try
-            {
-                result = _compiledExpression(tuple, fact);
-                return result;
-            }
-            catch (Exception e)
-            {
-                exception = e;
-                bool isHandled = false;
-                context.EventAggregator.RaiseLhsExpressionFailed(context.Session, e, _expression, _argumentMap, tuple, fact, nodeInfo, ref isHandled);
-                throw new ExpressionEvaluationException(e, _expression, isHandled);
-            }
-            finally
-            {
-                if (context.EventAggregator.TraceEnabled)
-                    context.EventAggregator.RaiseLhsExpressionEvaluated(context.Session, exception, _expression, _argumentMap, result, tuple, fact, nodeInfo);
-            }
+            exception = e;
+            bool isHandled = false;
+            context.EventAggregator.RaiseLhsExpressionFailed(context.Session, e, _expression, _argumentMap, tuple, fact, nodeInfo, ref isHandled);
+            throw new ExpressionEvaluationException(e, _expression, isHandled);
+        }
+        finally
+        {
+            if (context.EventAggregator.TraceEnabled)
+                context.EventAggregator.RaiseLhsExpressionEvaluated(context.Session, exception, _expression, _argumentMap, result, tuple, fact, nodeInfo);
         }
     }
+}
 
-    internal sealed class LhsFactExpression<TResult> : ILhsFactExpression<TResult>
+internal sealed class LhsFactExpression<TResult> : ILhsFactExpression<TResult>
+{
+    private readonly LambdaExpression _expression;
+    private readonly Func<Fact, TResult> _compiledExpression;
+    private readonly IArgumentMap _argumentMap;
+
+    public LhsFactExpression(LambdaExpression expression, Func<Fact, TResult> compiledExpression, IArgumentMap argumentMap)
     {
-        private readonly LambdaExpression _expression;
-        private readonly Func<Fact, TResult> _compiledExpression;
-        private readonly IArgumentMap _argumentMap;
-
-        public LhsFactExpression(LambdaExpression expression, Func<Fact, TResult> compiledExpression, IArgumentMap argumentMap)
-        {
-            _expression = expression;
-            _compiledExpression = compiledExpression;
-            _argumentMap = argumentMap;
-        }
-
-        public TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Fact fact)
-        {
-            return Invoke(context, nodeInfo, null, fact);
-        }
-
-        public TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Tuple tuple, Fact fact)
-        {
-            Exception exception = null;
-            TResult result = default;
-            try
-            {
-                result = _compiledExpression(fact);
-                return result;
-            }
-            catch (Exception e)
-            {
-                exception = e;
-                bool isHandled = false;
-                context.EventAggregator.RaiseLhsExpressionFailed(context.Session, e, _expression, _argumentMap, tuple, fact, nodeInfo, ref isHandled);
-                throw new ExpressionEvaluationException(e, _expression, isHandled);
-            }
-            finally
-            {
-                if (context.EventAggregator.TraceEnabled)
-                    context.EventAggregator.RaiseLhsExpressionEvaluated(context.Session, exception, _expression, _argumentMap, result, tuple, fact, nodeInfo);
-            }
-        }
+        _expression = expression;
+        _compiledExpression = compiledExpression;
+        _argumentMap = argumentMap;
     }
 
-    internal sealed class LhsTupleExpression<TResult> : ILhsTupleExpression<TResult>
+    public TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Fact fact)
     {
-        private readonly LambdaExpression _expression;
-        private readonly Func<Tuple, TResult> _compiledExpression;
-        private readonly IArgumentMap _argumentMap;
+        return Invoke(context, nodeInfo, null, fact);
+    }
 
-        public LhsTupleExpression(LambdaExpression expression, Func<Tuple, TResult> compiledExpression, IArgumentMap argumentMap)
+    public TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Tuple tuple, Fact fact)
+    {
+        Exception exception = null;
+        TResult result = default;
+        try
         {
-            _expression = expression;
-            _compiledExpression = compiledExpression;
-            _argumentMap = argumentMap;
+            result = _compiledExpression(fact);
+            return result;
         }
-
-        public TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Tuple tuple)
+        catch (Exception e)
         {
-            return Invoke(context, nodeInfo, tuple, null);
+            exception = e;
+            bool isHandled = false;
+            context.EventAggregator.RaiseLhsExpressionFailed(context.Session, e, _expression, _argumentMap, tuple, fact, nodeInfo, ref isHandled);
+            throw new ExpressionEvaluationException(e, _expression, isHandled);
         }
-
-        public TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Tuple tuple, Fact fact)
+        finally
         {
-            Exception exception = null;
-            TResult result = default;
-            try
-            {
-                result = _compiledExpression(tuple);
-                return result;
-            }
-            catch (Exception e)
-            {
-                exception = e;
-                bool isHandled = false;
-                context.EventAggregator.RaiseLhsExpressionFailed(context.Session, e, _expression, _argumentMap, tuple, fact, nodeInfo, ref isHandled);
-                throw new ExpressionEvaluationException(e, _expression, isHandled);
-            }
-            finally
-            {
-                if (context.EventAggregator.TraceEnabled)
-                    context.EventAggregator.RaiseLhsExpressionEvaluated(context.Session, exception, _expression, _argumentMap, result, tuple, fact, nodeInfo);
-            }
+            if (context.EventAggregator.TraceEnabled)
+                context.EventAggregator.RaiseLhsExpressionEvaluated(context.Session, exception, _expression, _argumentMap, result, tuple, fact, nodeInfo);
+        }
+    }
+}
+
+internal sealed class LhsTupleExpression<TResult> : ILhsTupleExpression<TResult>
+{
+    private readonly LambdaExpression _expression;
+    private readonly Func<Tuple, TResult> _compiledExpression;
+    private readonly IArgumentMap _argumentMap;
+
+    public LhsTupleExpression(LambdaExpression expression, Func<Tuple, TResult> compiledExpression, IArgumentMap argumentMap)
+    {
+        _expression = expression;
+        _compiledExpression = compiledExpression;
+        _argumentMap = argumentMap;
+    }
+
+    public TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Tuple tuple)
+    {
+        return Invoke(context, nodeInfo, tuple, null);
+    }
+
+    public TResult Invoke(IExecutionContext context, NodeInfo nodeInfo, Tuple tuple, Fact fact)
+    {
+        Exception exception = null;
+        TResult result = default;
+        try
+        {
+            result = _compiledExpression(tuple);
+            return result;
+        }
+        catch (Exception e)
+        {
+            exception = e;
+            bool isHandled = false;
+            context.EventAggregator.RaiseLhsExpressionFailed(context.Session, e, _expression, _argumentMap, tuple, fact, nodeInfo, ref isHandled);
+            throw new ExpressionEvaluationException(e, _expression, isHandled);
+        }
+        finally
+        {
+            if (context.EventAggregator.TraceEnabled)
+                context.EventAggregator.RaiseLhsExpressionEvaluated(context.Session, exception, _expression, _argumentMap, result, tuple, fact, nodeInfo);
         }
     }
 }

--- a/src/NRules/NRules/Rete/Network.cs
+++ b/src/NRules/NRules/Rete/Network.cs
@@ -1,91 +1,90 @@
 ﻿using System.Collections.Generic;
 using NRules.Diagnostics;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal interface INetwork
 {
-    internal interface INetwork
+    void PropagateAssert(IExecutionContext context, List<Fact> factObjects);
+    void PropagateUpdate(IExecutionContext context, List<Fact> factObjects);
+    void PropagateRetract(IExecutionContext context, List<Fact> factObjects);
+    void Activate(IExecutionContext context);
+    void Visit<TContext>(TContext context, ReteNodeVisitor<TContext> visitor);
+    ReteGraph GetSchema();
+}
+
+internal class Network : INetwork
+{
+    private readonly RootNode _root;
+    private readonly DummyNode _dummyNode;
+
+    public Network(RootNode root, DummyNode dummyNode)
     {
-        void PropagateAssert(IExecutionContext context, List<Fact> factObjects);
-        void PropagateUpdate(IExecutionContext context, List<Fact> factObjects);
-        void PropagateRetract(IExecutionContext context, List<Fact> factObjects);
-        void Activate(IExecutionContext context);
-        void Visit<TContext>(TContext context, ReteNodeVisitor<TContext> visitor);
-        ReteGraph GetSchema();
+        _root = root;
+        _dummyNode = dummyNode;
     }
 
-    internal class Network : INetwork
+    public void PropagateAssert(IExecutionContext context, List<Fact> facts)
     {
-        private readonly RootNode _root;
-        private readonly DummyNode _dummyNode;
-
-        public Network(RootNode root, DummyNode dummyNode)
+        foreach (var fact in facts)
         {
-            _root = root;
-            _dummyNode = dummyNode;
+            context.EventAggregator.RaiseFactInserting(context.Session, fact);
         }
 
-        public void PropagateAssert(IExecutionContext context, List<Fact> facts)
+        _root.PropagateAssert(context, facts);
+
+        foreach (var fact in facts)
         {
-            foreach (var fact in facts)
-            {
-                context.EventAggregator.RaiseFactInserting(context.Session, fact);
-            }
+            context.EventAggregator.RaiseFactInserted(context.Session, fact);
+        }
+    }
 
-            _root.PropagateAssert(context, facts);
-
-            foreach (var fact in facts)
-            {
-                context.EventAggregator.RaiseFactInserted(context.Session, fact);
-            }
+    public void PropagateUpdate(IExecutionContext context, List<Fact> facts)
+    {
+        foreach (var fact in facts)
+        {
+            context.EventAggregator.RaiseFactUpdating(context.Session, fact);
         }
 
-        public void PropagateUpdate(IExecutionContext context, List<Fact> facts)
+        _root.PropagateUpdate(context, facts);
+
+        foreach (var fact in facts)
         {
-            foreach (var fact in facts)
-            {
-                context.EventAggregator.RaiseFactUpdating(context.Session, fact);
-            }
+            context.EventAggregator.RaiseFactUpdated(context.Session, fact);
+        }
+    }
 
-            _root.PropagateUpdate(context, facts);
-
-            foreach (var fact in facts)
-            {
-                context.EventAggregator.RaiseFactUpdated(context.Session, fact);
-            }
+    public void PropagateRetract(IExecutionContext context, List<Fact> facts)
+    {
+        foreach (var fact in facts)
+        {
+            context.EventAggregator.RaiseFactRetracting(context.Session, fact);
         }
 
-        public void PropagateRetract(IExecutionContext context, List<Fact> facts)
+        _root.PropagateRetract(context, facts);
+
+        foreach (var fact in facts)
         {
-            foreach (var fact in facts)
-            {
-                context.EventAggregator.RaiseFactRetracting(context.Session, fact);
-            }
-
-            _root.PropagateRetract(context, facts);
-
-            foreach (var fact in facts)
-            {
-                context.EventAggregator.RaiseFactRetracted(context.Session, fact);
-            }
+            context.EventAggregator.RaiseFactRetracted(context.Session, fact);
         }
+    }
 
-        public void Activate(IExecutionContext context)
-        {
-            _dummyNode.Activate(context);
-        }
+    public void Activate(IExecutionContext context)
+    {
+        _dummyNode.Activate(context);
+    }
 
-        public void Visit<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
-        {
-            visitor.Visit(context, _root);
-            visitor.Visit(context, _dummyNode);
-        }
+    public void Visit<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.Visit(context, _root);
+        visitor.Visit(context, _dummyNode);
+    }
 
-        public ReteGraph GetSchema()
-        {
-            var builder = new SchemaBuilder();
-            var visitor = new SchemaReteVisitor();
-            Visit(builder, visitor);
-            return builder.Build();
-        }
+    public ReteGraph GetSchema()
+    {
+        var builder = new SchemaBuilder();
+        var visitor = new SchemaReteVisitor();
+        Visit(builder, visitor);
+        return builder.Build();
     }
 }

--- a/src/NRules/NRules/Rete/NotNode.cs
+++ b/src/NRules/NRules/Rete/NotNode.cs
@@ -1,133 +1,132 @@
 ﻿using System.Collections.Generic;
 using NRules.Diagnostics;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal class NotNode : BinaryBetaNode
 {
-    internal class NotNode : BinaryBetaNode
+    public NotNode(ITupleSource leftSource, IObjectSource rightSource) : base(leftSource, rightSource, true)
     {
-        public NotNode(ITupleSource leftSource, IObjectSource rightSource) : base(leftSource, rightSource, true)
-        {
-        }
+    }
 
-        public override void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
+    public override void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toAssert = new TupleFactList();
+        using (var counter = PerfCounter.Assert(context, this))
         {
-            var toAssert = new TupleFactList();
-            using (var counter = PerfCounter.Assert(context, this))
+            var joinedSets = JoinedSets(context, tuples);
+            foreach (var set in joinedSets)
             {
-                var joinedSets = JoinedSets(context, tuples);
-                foreach (var set in joinedSets)
+                var quantifier = context.CreateQuantifier(this, set.Tuple);
+                quantifier.Value += set.Facts.Count;
+                if (quantifier.Value == 0)
                 {
-                    var quantifier = context.CreateQuantifier(this, set.Tuple);
-                    quantifier.Value += set.Facts.Count;
-                    if (quantifier.Value == 0)
-                    {
-                        toAssert.Add(set.Tuple, null);
-                    }
+                    toAssert.Add(set.Tuple, null);
                 }
-
-                counter.AddInputs(tuples.Count);
-                counter.AddOutputs(toAssert.Count);
             }
 
-            MemoryNode.PropagateAssert(context, toAssert);
+            counter.AddInputs(tuples.Count);
+            counter.AddOutputs(toAssert.Count);
         }
 
-        public override void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
-        {
-            var toUpdate = new TupleFactList();
-            using (var counter = PerfCounter.Update(context, this))
-            {
-                foreach (var tuple in tuples)
-                {
-                    if (context.GetQuantifier(this, tuple).Value == 0)
-                    {
-                        toUpdate.Add(tuple, null);
-                    }
-                }
+        MemoryNode.PropagateAssert(context, toAssert);
+    }
 
-                counter.AddInputs(tuples.Count);
-                counter.AddOutputs(toUpdate.Count);
+    public override void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toUpdate = new TupleFactList();
+        using (var counter = PerfCounter.Update(context, this))
+        {
+            foreach (var tuple in tuples)
+            {
+                if (context.GetQuantifier(this, tuple).Value == 0)
+                {
+                    toUpdate.Add(tuple, null);
+                }
             }
 
-            MemoryNode.PropagateUpdate(context, toUpdate);
+            counter.AddInputs(tuples.Count);
+            counter.AddOutputs(toUpdate.Count);
         }
 
-        public override void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
-        {
-            var toRetract = new TupleFactList();
-            using (var counter = PerfCounter.Retract(context, this))
-            {
-                foreach (var tuple in tuples)
-                {
-                    if (context.RemoveQuantifier(this, tuple).Value == 0)
-                    {
-                        toRetract.Add(tuple, null);
-                    }
-                }
+        MemoryNode.PropagateUpdate(context, toUpdate);
+    }
 
-                counter.AddInputs(tuples.Count);
-                counter.AddOutputs(toRetract.Count);
+    public override void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toRetract = new TupleFactList();
+        using (var counter = PerfCounter.Retract(context, this))
+        {
+            foreach (var tuple in tuples)
+            {
+                if (context.RemoveQuantifier(this, tuple).Value == 0)
+                {
+                    toRetract.Add(tuple, null);
+                }
             }
 
-            MemoryNode.PropagateRetract(context, toRetract);
+            counter.AddInputs(tuples.Count);
+            counter.AddOutputs(toRetract.Count);
         }
 
-        public override void PropagateAssert(IExecutionContext context, List<Fact> facts)
-        {
-            var toRetract = new TupleFactList();
-            using (var counter = PerfCounter.Assert(context, this))
-            {
-                var joinedSets = JoinedSets(context, facts);
-                foreach (var set in joinedSets)
-                {
-                    var quantifier = context.GetQuantifier(this, set.Tuple);
-                    int startingCount = quantifier.Value;
-                    quantifier.Value += set.Facts.Count;
-                    if (startingCount == 0 && quantifier.Value > 0)
-                    {
-                        toRetract.Add(set.Tuple, null);
-                    }
-                }
+        MemoryNode.PropagateRetract(context, toRetract);
+    }
 
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(toRetract.Count);
+    public override void PropagateAssert(IExecutionContext context, List<Fact> facts)
+    {
+        var toRetract = new TupleFactList();
+        using (var counter = PerfCounter.Assert(context, this))
+        {
+            var joinedSets = JoinedSets(context, facts);
+            foreach (var set in joinedSets)
+            {
+                var quantifier = context.GetQuantifier(this, set.Tuple);
+                int startingCount = quantifier.Value;
+                quantifier.Value += set.Facts.Count;
+                if (startingCount == 0 && quantifier.Value > 0)
+                {
+                    toRetract.Add(set.Tuple, null);
+                }
             }
 
-            MemoryNode.PropagateRetract(context, toRetract);
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(toRetract.Count);
         }
 
-        public override void PropagateUpdate(IExecutionContext context, List<Fact> facts)
-        {
-            //Do nothing
-        }
+        MemoryNode.PropagateRetract(context, toRetract);
+    }
 
-        public override void PropagateRetract(IExecutionContext context, List<Fact> facts)
+    public override void PropagateUpdate(IExecutionContext context, List<Fact> facts)
+    {
+        //Do nothing
+    }
+
+    public override void PropagateRetract(IExecutionContext context, List<Fact> facts)
+    {
+        var toAssert = new TupleFactList();
+        using (var counter = PerfCounter.Retract(context, this))
         {
-            var toAssert = new TupleFactList();
-            using (var counter = PerfCounter.Retract(context, this))
+            var joinedSets = JoinedSets(context, facts);
+            foreach (var set in joinedSets)
             {
-                var joinedSets = JoinedSets(context, facts);
-                foreach (var set in joinedSets)
+                var quantifier = context.GetQuantifier(this, set.Tuple);
+                int startingCount = quantifier.Value;
+                quantifier.Value -= set.Facts.Count;
+                if (startingCount > 0 && quantifier.Value == 0)
                 {
-                    var quantifier = context.GetQuantifier(this, set.Tuple);
-                    int startingCount = quantifier.Value;
-                    quantifier.Value -= set.Facts.Count;
-                    if (startingCount > 0 && quantifier.Value == 0)
-                    {
-                        toAssert.Add(set.Tuple, null);
-                    }
+                    toAssert.Add(set.Tuple, null);
                 }
-
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(toAssert.Count);
             }
 
-            MemoryNode.PropagateAssert(context, toAssert);
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(toAssert.Count);
         }
 
-        public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
-        {
-            visitor.VisitNotNode(context, this);
-        }
+        MemoryNode.PropagateAssert(context, toAssert);
+    }
+
+    public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.VisitNotNode(context, this);
     }
 }

--- a/src/NRules/NRules/Rete/ObjectInputAdapter.cs
+++ b/src/NRules/NRules/Rete/ObjectInputAdapter.cs
@@ -1,109 +1,108 @@
 ﻿using System.Collections.Generic;
 using NRules.Diagnostics;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal class ObjectInputAdapter : ITupleSink, IAlphaMemoryNode
 {
-    internal class ObjectInputAdapter : ITupleSink, IAlphaMemoryNode
+    private readonly ITupleSource _source;
+    private readonly List<IObjectSink> _sinks = new();
+
+    public int Id { get; set; }
+    public NodeInfo NodeInfo { get; } = new();
+    public IEnumerable<IObjectSink> Sinks => _sinks;
+
+    public ObjectInputAdapter(IBetaMemoryNode source)
     {
-        private readonly ITupleSource _source;
-        private readonly List<IObjectSink> _sinks = new();
+        _source = source;
+        source.Attach(this);
+    }
 
-        public int Id { get; set; }
-        public NodeInfo NodeInfo { get; } = new();
-        public IEnumerable<IObjectSink> Sinks => _sinks;
-
-        public ObjectInputAdapter(IBetaMemoryNode source)
+    public void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toAssert = new List<Fact>(tuples.Count);
+        using (var counter = PerfCounter.Assert(context, this))
         {
-            _source = source;
-            source.Attach(this);
+            foreach (var tuple in tuples)
+            {
+                var wrapperFact = new WrapperFact(tuple);
+                context.WorkingMemory.SetState(this, tuple, wrapperFact);
+                toAssert.Add(wrapperFact);
+            }
+            counter.AddItems(tuples.Count);
         }
 
-        public void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
+        foreach (var sink in _sinks)
         {
-            var toAssert = new List<Fact>(tuples.Count);
-            using (var counter = PerfCounter.Assert(context, this))
-            {
-                foreach (var tuple in tuples)
-                {
-                    var wrapperFact = new WrapperFact(tuple);
-                    context.WorkingMemory.SetState(this, tuple, wrapperFact);
-                    toAssert.Add(wrapperFact);
-                }
-                counter.AddItems(tuples.Count);
-            }
+            sink.PropagateAssert(context, toAssert);
+        }
+    }
 
-            foreach (var sink in _sinks)
+    public void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toUpdate = new List<Fact>(tuples.Count);
+        using (var counter = PerfCounter.Update(context, this))
+        {
+            foreach (var tuple in tuples)
             {
-                sink.PropagateAssert(context, toAssert);
+                var wrapperFact = context.WorkingMemory.GetStateOrThrow<WrapperFact>(this, tuple);
+                toUpdate.Add(wrapperFact);
             }
+            counter.AddItems(tuples.Count);
         }
 
-        public void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
+        foreach (var sink in _sinks)
         {
-            var toUpdate = new List<Fact>(tuples.Count);
-            using (var counter = PerfCounter.Update(context, this))
-            {
-                foreach (var tuple in tuples)
-                {
-                    var wrapperFact = context.WorkingMemory.GetStateOrThrow<WrapperFact>(this, tuple);
-                    toUpdate.Add(wrapperFact);
-                }
-                counter.AddItems(tuples.Count);
-            }
+            sink.PropagateUpdate(context, toUpdate);
+        }
+    }
 
-            foreach (var sink in _sinks)
+    public void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
+    {
+        var toRetract = new List<Fact>(tuples.Count);
+        using (var counter = PerfCounter.Retract(context, this))
+        {
+            foreach (var tuple in tuples)
             {
-                sink.PropagateUpdate(context, toUpdate);
+                var wrapperFact = context.WorkingMemory.GetStateOrThrow<WrapperFact>(this, tuple);
+                toRetract.Add(wrapperFact);
             }
+            counter.AddItems(tuples.Count);
         }
 
-        public void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
+        foreach (var sink in _sinks)
         {
-            var toRetract = new List<Fact>(tuples.Count);
-            using (var counter = PerfCounter.Retract(context, this))
-            {
-                foreach (var tuple in tuples)
-                {
-                    var wrapperFact = context.WorkingMemory.GetStateOrThrow<WrapperFact>(this, tuple);
-                    toRetract.Add(wrapperFact);
-                }
-                counter.AddItems(tuples.Count);
-            }
-
-            foreach (var sink in _sinks)
-            {
-                sink.PropagateRetract(context, toRetract);
-            }
-
-            using (PerfCounter.Retract(context, this))
-            {
-                foreach (var tuple in tuples)
-                {
-                    context.WorkingMemory.RemoveStateOrThrow<WrapperFact>(this, tuple);
-                }
-            }
+            sink.PropagateRetract(context, toRetract);
         }
 
-        public IEnumerable<Fact> GetFacts(IExecutionContext context)
+        using (PerfCounter.Retract(context, this))
         {
-            var sourceTuples = _source.GetTuples(context);
-            var sourceFacts = new List<Fact>();
-            foreach (var sourceTuple in sourceTuples)
+            foreach (var tuple in tuples)
             {
-                var wrapperFact = context.WorkingMemory.GetStateOrThrow<WrapperFact>(this, sourceTuple);
-                sourceFacts.Add(wrapperFact);
+                context.WorkingMemory.RemoveStateOrThrow<WrapperFact>(this, tuple);
             }
-            return sourceFacts;
         }
+    }
 
-        public void Attach(IObjectSink sink)
+    public IEnumerable<Fact> GetFacts(IExecutionContext context)
+    {
+        var sourceTuples = _source.GetTuples(context);
+        var sourceFacts = new List<Fact>();
+        foreach (var sourceTuple in sourceTuples)
         {
-            _sinks.Add(sink);
+            var wrapperFact = context.WorkingMemory.GetStateOrThrow<WrapperFact>(this, sourceTuple);
+            sourceFacts.Add(wrapperFact);
         }
+        return sourceFacts;
+    }
 
-        public void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
-        {
-            visitor.VisitObjectInputAdapter(context, this);
-        }
+    public void Attach(IObjectSink sink)
+    {
+        _sinks.Add(sink);
+    }
+
+    public void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.VisitObjectInputAdapter(context, this);
     }
 }

--- a/src/NRules/NRules/Rete/Quantifier.cs
+++ b/src/NRules/NRules/Rete/Quantifier.cs
@@ -1,7 +1,6 @@
-﻿namespace NRules.Rete
+﻿namespace NRules.Rete;
+
+internal class Quantifier
 {
-    internal class Quantifier
-    {
-        public int Value { get; set; }
-    }
+    public int Value { get; set; }
 }

--- a/src/NRules/NRules/Rete/ReteBuilder.cs
+++ b/src/NRules/NRules/Rete/ReteBuilder.cs
@@ -5,457 +5,456 @@ using NRules.Aggregators;
 using NRules.RuleModel;
 using NRules.Utilities;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal interface IReteBuilder
 {
-    internal interface IReteBuilder
+    int GetNodeId();
+    IEnumerable<ITerminal> AddRule(IRuleDefinition rule);
+    INetwork Build();
+}
+
+internal class ReteBuilder : RuleElementVisitor<ReteBuilderContext>, IReteBuilder
+{
+    private readonly RootNode _root;
+    private readonly DummyNode _dummyNode;
+    private readonly AggregatorRegistry _aggregatorRegistry;
+    private readonly ExpressionElementComparer _expressionComparer;
+    private readonly IRuleExpressionCompiler _ruleExpressionCompiler;
+
+    private int _nextNodeId = 1;
+
+    public ReteBuilder(RuleCompilerOptions options, AggregatorRegistry aggregatorRegistry, IRuleExpressionCompiler ruleExpressionCompiler)
     {
-        int GetNodeId();
-        IEnumerable<ITerminal> AddRule(IRuleDefinition rule);
-        INetwork Build();
+        _root = new RootNode {Id = GetNodeId()};
+        _dummyNode = new DummyNode {Id = GetNodeId()};
+        _aggregatorRegistry = aggregatorRegistry;
+        _expressionComparer = new ExpressionElementComparer(options);
+        _ruleExpressionCompiler = ruleExpressionCompiler;
     }
 
-    internal class ReteBuilder : RuleElementVisitor<ReteBuilderContext>, IReteBuilder
+    public int GetNodeId()
     {
-        private readonly RootNode _root;
-        private readonly DummyNode _dummyNode;
-        private readonly AggregatorRegistry _aggregatorRegistry;
-        private readonly ExpressionElementComparer _expressionComparer;
-        private readonly IRuleExpressionCompiler _ruleExpressionCompiler;
+        return _nextNodeId++;
+    }
 
-        private int _nextNodeId = 1;
-
-        public ReteBuilder(RuleCompilerOptions options, AggregatorRegistry aggregatorRegistry, IRuleExpressionCompiler ruleExpressionCompiler)
-        {
-            _root = new RootNode {Id = GetNodeId()};
-            _dummyNode = new DummyNode {Id = GetNodeId()};
-            _aggregatorRegistry = aggregatorRegistry;
-            _expressionComparer = new ExpressionElementComparer(options);
-            _ruleExpressionCompiler = ruleExpressionCompiler;
-        }
-
-        public int GetNodeId()
-        {
-            return _nextNodeId++;
-        }
-
-        public IEnumerable<ITerminal> AddRule(IRuleDefinition rule)
-        {
-            var ruleDeclarations = rule.LeftHandSide.Exports.ToList();
-            var terminals = new List<ITerminal>();
-            rule.LeftHandSide.Match(
-                and =>
+    public IEnumerable<ITerminal> AddRule(IRuleDefinition rule)
+    {
+        var ruleDeclarations = rule.LeftHandSide.Exports.ToList();
+        var terminals = new List<ITerminal>();
+        rule.LeftHandSide.Match(
+            and =>
+            {
+                var context = new ReteBuilderContext(rule, _dummyNode);
+                Visit(context, and);
+                var terminal = BuildTerminal(context, and, ruleDeclarations);
+                terminals.Add(terminal);
+            },
+            or =>
+            {
+                foreach (var childElement in or.ChildElements)
                 {
                     var context = new ReteBuilderContext(rule, _dummyNode);
-                    Visit(context, and);
-                    var terminal = BuildTerminal(context, and, ruleDeclarations);
+                    Visit(context, childElement);
+                    var terminal = BuildTerminal(context, childElement, ruleDeclarations);
                     terminals.Add(terminal);
-                },
-                or =>
-                {
-                    foreach (var childElement in or.ChildElements)
-                    {
-                        var context = new ReteBuilderContext(rule, _dummyNode);
-                        Visit(context, childElement);
-                        var terminal = BuildTerminal(context, childElement, ruleDeclarations);
-                        terminals.Add(terminal);
-                    }
-                });
-            return terminals;
-        }
+                }
+            });
+        return terminals;
+    }
 
-        private Terminal BuildTerminal(ReteBuilderContext context, RuleElement element, IEnumerable<Declaration> ruleDeclarations)
+    private Terminal BuildTerminal(ReteBuilderContext context, RuleElement element, IEnumerable<Declaration> ruleDeclarations)
+    {
+        if (context.AlphaSource != null)
+        {
+            BuildJoinNode(context);
+        }
+        var factMap = IndexMap.CreateMap(ruleDeclarations, context.Declarations);
+        var terminalNode = new Terminal(context.BetaSource, factMap);
+        return terminalNode;
+    }
+
+    protected override void VisitAnd(ReteBuilderContext context, AndElement element)
+    {
+        foreach (var childElement in element.ChildElements)
         {
             if (context.AlphaSource != null)
             {
                 BuildJoinNode(context);
             }
-            var factMap = IndexMap.CreateMap(ruleDeclarations, context.Declarations);
-            var terminalNode = new Terminal(context.BetaSource, factMap);
-            return terminalNode;
+            Visit(context, childElement);
         }
+    }
 
-        protected override void VisitAnd(ReteBuilderContext context, AndElement element)
+    protected override void VisitOr(ReteBuilderContext context, OrElement element)
+    {
+        throw new InvalidOperationException("Group Or element must be normalized");
+    }
+
+    protected override void VisitForAll(ReteBuilderContext context, ForAllElement element)
+    {
+        throw new InvalidOperationException("ForAll element must be normalized");
+    }
+
+    protected override void VisitNot(ReteBuilderContext context, NotElement element)
+    {
+        VisitSource(context, element, element.Source);
+        BuildNotNode(context, element);
+    }
+
+    protected override void VisitExists(ReteBuilderContext context, ExistsElement element)
+    {
+        VisitSource(context, element, element.Source);
+        BuildExistsNode(context, element);
+    }
+
+    protected override void VisitAggregate(ReteBuilderContext context, AggregateElement element)
+    {
+        VisitSource(context, element, element.Source);
+        BuildAggregateNode(context, element);
+    }
+
+    protected override void VisitPattern(ReteBuilderContext context, PatternElement element)
+    {
+        var conditions = element.Expressions.Find(PatternElement.ConditionName)
+            .Cast<ExpressionElement>().ToList();
+        if (element.Source == null)
         {
-            foreach (var childElement in element.ChildElements)
+            context.CurrentAlphaNode = _root;
+            context.RegisterDeclaration(element.Declaration);
+
+            BuildTypeNode(context, element, element.ValueType);
+
+            var alphaConditions = new List<ExpressionElement>();
+            var betaConditions = new List<ExpressionElement>();
+            foreach (var condition in conditions)
             {
-                if (context.AlphaSource != null)
-                {
-                    BuildJoinNode(context);
-                }
-                Visit(context, childElement);
+                if (condition.Imports.Count() == 1 &&
+                    Equals(condition.Imports.Single(), element.Declaration))
+                    alphaConditions.Add(condition);
+                else
+                    betaConditions.Add(condition);
+            }
+            
+            foreach (var alphaCondition in alphaConditions)
+            {
+                BuildSelectionNode(context, alphaCondition);
+            }
+            BuildAlphaMemoryNode(context);
+
+            if (betaConditions.Count > 0)
+            {
+                BuildJoinNode(context, betaConditions);
             }
         }
-
-        protected override void VisitOr(ReteBuilderContext context, OrElement element)
+        else
         {
-            throw new InvalidOperationException("Group Or element must be normalized");
-        }
-
-        protected override void VisitForAll(ReteBuilderContext context, ForAllElement element)
-        {
-            throw new InvalidOperationException("ForAll element must be normalized");
-        }
-
-        protected override void VisitNot(ReteBuilderContext context, NotElement element)
-        {
-            VisitSource(context, element, element.Source);
-            BuildNotNode(context, element);
-        }
-
-        protected override void VisitExists(ReteBuilderContext context, ExistsElement element)
-        {
-            VisitSource(context, element, element.Source);
-            BuildExistsNode(context, element);
-        }
-
-        protected override void VisitAggregate(ReteBuilderContext context, AggregateElement element)
-        {
-            VisitSource(context, element, element.Source);
-            BuildAggregateNode(context, element);
-        }
-
-        protected override void VisitPattern(ReteBuilderContext context, PatternElement element)
-        {
-            var conditions = element.Expressions.Find(PatternElement.ConditionName)
-                .Cast<ExpressionElement>().ToList();
-            if (element.Source == null)
+            var isJoined = element.Imports.Any();
+            if (isJoined)
             {
-                context.CurrentAlphaNode = _root;
-                context.RegisterDeclaration(element.Declaration);
-
-                BuildTypeNode(context, element, element.ValueType);
-
-                var alphaConditions = new List<ExpressionElement>();
-                var betaConditions = new List<ExpressionElement>();
-                foreach (var condition in conditions)
+                if (conditions.Any())
                 {
-                    if (condition.Imports.Count() == 1 &&
-                        Equals(condition.Imports.Single(), element.Declaration))
-                        alphaConditions.Add(condition);
-                    else
-                        betaConditions.Add(condition);
+                    BuildSubnet(context, element);
+
+                    context.RegisterDeclaration(element.Declaration);
+                    BuildJoinNode(context, conditions);
                 }
-                
-                foreach (var alphaCondition in alphaConditions)
+                else
                 {
-                    BuildSelectionNode(context, alphaCondition);
-                }
-                BuildAlphaMemoryNode(context);
-
-                if (betaConditions.Count > 0)
-                {
-                    BuildJoinNode(context, betaConditions);
+                    Visit(context, element.Source);
+                    context.RegisterDeclaration(element.Declaration);
                 }
             }
             else
             {
-                var isJoined = element.Imports.Any();
-                if (isJoined)
+                var joinContext = new ReteBuilderContext(context.Rule, _dummyNode);
+                BuildSubnet(joinContext, element);
+
+                joinContext.RegisterDeclaration(element.Declaration);
+                if (conditions.Any())
                 {
-                    if (conditions.Any())
-                    {
-                        BuildSubnet(context, element);
-
-                        context.RegisterDeclaration(element.Declaration);
-                        BuildJoinNode(context, conditions);
-                    }
-                    else
-                    {
-                        Visit(context, element.Source);
-                        context.RegisterDeclaration(element.Declaration);
-                    }
+                    BuildJoinNode(joinContext, conditions);
+                    BuildAdapter(joinContext);
                 }
-                else
-                {
-                    var joinContext = new ReteBuilderContext(context.Rule, _dummyNode);
-                    BuildSubnet(joinContext, element);
+                context.AlphaSource = joinContext.AlphaSource;
 
-                    joinContext.RegisterDeclaration(element.Declaration);
-                    if (conditions.Any())
-                    {
-                        BuildJoinNode(joinContext, conditions);
-                        BuildAdapter(joinContext);
-                    }
-                    context.AlphaSource = joinContext.AlphaSource;
-
-                    context.RegisterDeclaration(element.Declaration);
-                }
+                context.RegisterDeclaration(element.Declaration);
             }
         }
+    }
 
-        protected override void VisitBinding(ReteBuilderContext context, BindingElement element)
+    protected override void VisitBinding(ReteBuilderContext context, BindingElement element)
+    {
+        BuildBindingNode(context, element);
+    }
+
+    private void VisitSource(ReteBuilderContext context, RuleElement element, RuleElement source)
+    {
+        var isJoined = source.Imports.Any();
+        var subnetContext = isJoined ? new ReteBuilderContext(context) : new ReteBuilderContext(context.Rule, _dummyNode);
+
+        Visit(subnetContext, source);
+
+        if (subnetContext.AlphaSource == null)
         {
-            BuildBindingNode(context, element);
+            BuildAdapter(subnetContext);
+            context.HasSubnet = isJoined;
         }
+        context.AlphaSource = subnetContext.AlphaSource;
+    }
 
-        private void VisitSource(ReteBuilderContext context, RuleElement element, RuleElement source)
+    private void BuildSubnet(ReteBuilderContext context, PatternElement element)
+    {
+        var isJoined = element.Source.Imports.Any();
+        var subnetContext = isJoined ? new ReteBuilderContext(context) : new ReteBuilderContext(context.Rule, _dummyNode);
+
+        Visit(subnetContext, element.Source);
+
+        if (subnetContext.AlphaSource == null)
         {
-            var isJoined = source.Imports.Any();
-            var subnetContext = isJoined ? new ReteBuilderContext(context) : new ReteBuilderContext(context.Rule, _dummyNode);
+            BuildAdapter(subnetContext);
+            context.HasSubnet = isJoined;
+        }
+        context.AlphaSource = subnetContext.AlphaSource;
+    }
+    
+    private void BuildAdapter(ReteBuilderContext context)
+    {
+        var adapter = context.BetaSource
+            .Sinks.OfType<ObjectInputAdapter>()
+            .SingleOrDefault();
+        if (adapter == null)
+        {
+            adapter = new ObjectInputAdapter(context.BetaSource);
+            adapter.Id = GetNodeId();
+        }
+        adapter.NodeInfo.Add(context.Rule);
+        context.AlphaSource = adapter;
+    }
 
-            Visit(subnetContext, source);
-
-            if (subnetContext.AlphaSource == null)
+    private void BuildJoinNode(ReteBuilderContext context, List<ExpressionElement> conditions = null)
+    {
+        var expressionElements = conditions ?? new List<ExpressionElement>();
+        var node = context.BetaSource
+            .Sinks.OfType<JoinNode>()
+            .FirstOrDefault(x =>
+                x.RightSource == context.AlphaSource &&
+                x.LeftSource == context.BetaSource &&
+                _expressionComparer.AreEqual(
+                    x.Declarations, x.ExpressionElements, 
+                    context.Declarations, expressionElements));
+        if (node == null)
+        {
+            var compiledExpressions = new List<ILhsExpression<bool>>(expressionElements.Count);
+            foreach (var expressionElement in expressionElements)
             {
-                BuildAdapter(subnetContext);
-                context.HasSubnet = isJoined;
+                var compiledExpression = _ruleExpressionCompiler.CompileLhsExpression<bool>(expressionElement, context.Declarations);
+                compiledExpressions.Add(compiledExpression);
             }
-            context.AlphaSource = subnetContext.AlphaSource;
+            node = new JoinNode(context.BetaSource, context.AlphaSource, context.Declarations.ToList(), expressionElements, compiledExpressions, context.HasSubnet);
+            node.Id = GetNodeId();
         }
+        node.NodeInfo.Add(context.Rule);
+        BuildBetaMemoryNode(context, node);
+        context.ResetAlphaSource();
+    }
 
-        private void BuildSubnet(ReteBuilderContext context, PatternElement element)
+    private void BuildNotNode(ReteBuilderContext context, RuleElement element)
+    {
+        var node = context.AlphaSource
+            .Sinks.OfType<NotNode>()
+            .FirstOrDefault(x =>
+                x.RightSource == context.AlphaSource &&
+                x.LeftSource == context.BetaSource);
+        if (node == null)
         {
-            var isJoined = element.Source.Imports.Any();
-            var subnetContext = isJoined ? new ReteBuilderContext(context) : new ReteBuilderContext(context.Rule, _dummyNode);
-
-            Visit(subnetContext, element.Source);
-
-            if (subnetContext.AlphaSource == null)
-            {
-                BuildAdapter(subnetContext);
-                context.HasSubnet = isJoined;
-            }
-            context.AlphaSource = subnetContext.AlphaSource;
+            node = new NotNode(context.BetaSource, context.AlphaSource);
+            node.Id = GetNodeId();
         }
-        
-        private void BuildAdapter(ReteBuilderContext context)
+        node.NodeInfo.Add(context.Rule);
+        BuildBetaMemoryNode(context, node);
+        context.ResetAlphaSource();
+    }
+
+    private void BuildExistsNode(ReteBuilderContext context, RuleElement element)
+    {
+        var node = context.AlphaSource
+            .Sinks.OfType<ExistsNode>()
+            .FirstOrDefault(x =>
+                x.RightSource == context.AlphaSource &&
+                x.LeftSource == context.BetaSource);
+        if (node == null)
         {
-            var adapter = context.BetaSource
-                .Sinks.OfType<ObjectInputAdapter>()
-                .SingleOrDefault();
-            if (adapter == null)
-            {
-                adapter = new ObjectInputAdapter(context.BetaSource);
-                adapter.Id = GetNodeId();
-            }
-            adapter.NodeInfo.Add(context.Rule);
-            context.AlphaSource = adapter;
+            node = new ExistsNode(context.BetaSource, context.AlphaSource);
+            node.Id = GetNodeId();
         }
+        node.NodeInfo.Add(context.Rule);
+        BuildBetaMemoryNode(context, node);
+        context.ResetAlphaSource();
+    }
 
-        private void BuildJoinNode(ReteBuilderContext context, List<ExpressionElement> conditions = null)
+    private void BuildAggregateNode(ReteBuilderContext context, AggregateElement element)
+    {
+        var node = context.AlphaSource
+            .Sinks.OfType<AggregateNode>()
+            .FirstOrDefault(x =>
+                x.RightSource == context.AlphaSource &&
+                x.LeftSource == context.BetaSource &&
+                x.Name == element.Name &&
+                _expressionComparer.AreEqual(
+                    x.Declarations, x.Expressions,
+                    context.Declarations, element.Expressions));
+        if (node == null)
         {
-            var expressionElements = conditions ?? new List<ExpressionElement>();
-            var node = context.BetaSource
-                .Sinks.OfType<JoinNode>()
-                .FirstOrDefault(x =>
-                    x.RightSource == context.AlphaSource &&
-                    x.LeftSource == context.BetaSource &&
-                    _expressionComparer.AreEqual(
-                        x.Declarations, x.ExpressionElements, 
-                        context.Declarations, expressionElements));
-            if (node == null)
-            {
-                var compiledExpressions = new List<ILhsExpression<bool>>(expressionElements.Count);
-                foreach (var expressionElement in expressionElements)
-                {
-                    var compiledExpression = _ruleExpressionCompiler.CompileLhsExpression<bool>(expressionElement, context.Declarations);
-                    compiledExpressions.Add(compiledExpression);
-                }
-                node = new JoinNode(context.BetaSource, context.AlphaSource, context.Declarations.ToList(), expressionElements, compiledExpressions, context.HasSubnet);
-                node.Id = GetNodeId();
-            }
-            node.NodeInfo.Add(context.Rule);
-            BuildBetaMemoryNode(context, node);
-            context.ResetAlphaSource();
+            var aggregatorFactory = BuildAggregatorFactory(context, element);
+            node = new AggregateNode(context.BetaSource, context.AlphaSource, element.Name,
+                context.Declarations.ToList(), element.Expressions, aggregatorFactory, context.HasSubnet);
+            node.Id = GetNodeId();
+            node.NodeInfo.OutputType = element.ResultType;
         }
+        node.NodeInfo.Add(context.Rule);
+        BuildBetaMemoryNode(context, node);
+        context.ResetAlphaSource();
+    }
 
-        private void BuildNotNode(ReteBuilderContext context, RuleElement element)
+    private void BuildBindingNode(ReteBuilderContext context, BindingElement element)
+    {
+        var node = context.BetaSource
+            .Sinks.OfType<BindingNode>()
+            .FirstOrDefault(x =>
+                _expressionComparer.AreEqual(x.ExpressionElement, element));
+        if (node == null)
         {
-            var node = context.AlphaSource
-                .Sinks.OfType<NotNode>()
-                .FirstOrDefault(x =>
-                    x.RightSource == context.AlphaSource &&
-                    x.LeftSource == context.BetaSource);
-            if (node == null)
-            {
-                node = new NotNode(context.BetaSource, context.AlphaSource);
-                node.Id = GetNodeId();
-            }
-            node.NodeInfo.Add(context.Rule);
-            BuildBetaMemoryNode(context, node);
-            context.ResetAlphaSource();
+            var compiledExpression = _ruleExpressionCompiler.CompileLhsTupleExpression<object>(element, context.Declarations);
+            node = new BindingNode(element, compiledExpression, element.ResultType, context.BetaSource);
+            node.Id = GetNodeId();
+            node.NodeInfo.OutputType = element.ResultType;
         }
+        node.NodeInfo.Add(context.Rule);
+        BuildBetaMemoryNode(context, node);
+        context.ResetAlphaSource();
+    }
 
-        private void BuildExistsNode(ReteBuilderContext context, RuleElement element)
+    private void BuildBetaMemoryNode(ReteBuilderContext context, BetaNode betaNode)
+    {
+        BetaMemoryNode memoryNode = betaNode.MemoryNode;
+        if (memoryNode == null)
         {
-            var node = context.AlphaSource
-                .Sinks.OfType<ExistsNode>()
-                .FirstOrDefault(x =>
-                    x.RightSource == context.AlphaSource &&
-                    x.LeftSource == context.BetaSource);
-            if (node == null)
-            {
-                node = new ExistsNode(context.BetaSource, context.AlphaSource);
-                node.Id = GetNodeId();
-            }
-            node.NodeInfo.Add(context.Rule);
-            BuildBetaMemoryNode(context, node);
-            context.ResetAlphaSource();
+            memoryNode = new BetaMemoryNode();
+            memoryNode.Id = GetNodeId();
+            betaNode.MemoryNode = memoryNode;
         }
+        betaNode.MemoryNode.NodeInfo.Add(context.Rule);
+        context.BetaSource = betaNode.MemoryNode;
+    }
 
-        private void BuildAggregateNode(ReteBuilderContext context, AggregateElement element)
+    private void BuildTypeNode(ReteBuilderContext context, RuleElement element, Type declarationType)
+    {
+        TypeNode node = context.CurrentAlphaNode
+            .ChildNodes.OfType<TypeNode>()
+            .FirstOrDefault(tn => tn.FilterType == declarationType);
+
+        if (node == null)
         {
-            var node = context.AlphaSource
-                .Sinks.OfType<AggregateNode>()
-                .FirstOrDefault(x =>
-                    x.RightSource == context.AlphaSource &&
-                    x.LeftSource == context.BetaSource &&
-                    x.Name == element.Name &&
-                    _expressionComparer.AreEqual(
-                        x.Declarations, x.Expressions,
-                        context.Declarations, element.Expressions));
-            if (node == null)
-            {
-                var aggregatorFactory = BuildAggregatorFactory(context, element);
-                node = new AggregateNode(context.BetaSource, context.AlphaSource, element.Name,
-                    context.Declarations.ToList(), element.Expressions, aggregatorFactory, context.HasSubnet);
-                node.Id = GetNodeId();
-                node.NodeInfo.OutputType = element.ResultType;
-            }
-            node.NodeInfo.Add(context.Rule);
-            BuildBetaMemoryNode(context, node);
-            context.ResetAlphaSource();
+            node = new TypeNode(declarationType);
+            node.Id = GetNodeId();
+            node.NodeInfo.OutputType = declarationType;
+            context.CurrentAlphaNode.ChildNodes.Add(node);
         }
+        node.NodeInfo.Add(context.Rule);
+        context.CurrentAlphaNode = node;
+    }
 
-        private void BuildBindingNode(ReteBuilderContext context, BindingElement element)
+    private void BuildSelectionNode(ReteBuilderContext context, ExpressionElement element)
+    {
+        SelectionNode node = context.CurrentAlphaNode
+            .ChildNodes.OfType<SelectionNode>()
+            .FirstOrDefault(sn => _expressionComparer.AreEqual(sn.ExpressionElement, element));
+
+        if (node == null)
         {
-            var node = context.BetaSource
-                .Sinks.OfType<BindingNode>()
-                .FirstOrDefault(x =>
-                    _expressionComparer.AreEqual(x.ExpressionElement, element));
-            if (node == null)
-            {
-                var compiledExpression = _ruleExpressionCompiler.CompileLhsTupleExpression<object>(element, context.Declarations);
-                node = new BindingNode(element, compiledExpression, element.ResultType, context.BetaSource);
-                node.Id = GetNodeId();
-                node.NodeInfo.OutputType = element.ResultType;
-            }
-            node.NodeInfo.Add(context.Rule);
-            BuildBetaMemoryNode(context, node);
-            context.ResetAlphaSource();
+            var compiledExpression = _ruleExpressionCompiler.CompileLhsFactExpression<bool>(element);
+            node = new SelectionNode(element, compiledExpression);
+            node.Id = GetNodeId();
+            node.NodeInfo.OutputType = context.Declarations.Last().Type;
+            context.CurrentAlphaNode.ChildNodes.Add(node);
         }
+        node.NodeInfo.Add(context.Rule);
+        context.CurrentAlphaNode = node;
+    }
 
-        private void BuildBetaMemoryNode(ReteBuilderContext context, BetaNode betaNode)
+    private void BuildAlphaMemoryNode(ReteBuilderContext context)
+    {
+        AlphaMemoryNode memoryNode = context.CurrentAlphaNode.MemoryNode;
+        if (memoryNode == null)
         {
-            BetaMemoryNode memoryNode = betaNode.MemoryNode;
-            if (memoryNode == null)
-            {
-                memoryNode = new BetaMemoryNode();
-                memoryNode.Id = GetNodeId();
-                betaNode.MemoryNode = memoryNode;
-            }
-            betaNode.MemoryNode.NodeInfo.Add(context.Rule);
-            context.BetaSource = betaNode.MemoryNode;
+            memoryNode = new AlphaMemoryNode();
+            memoryNode.Id = GetNodeId();
+            memoryNode.NodeInfo.OutputType = context.Declarations.Last().Type;
+            context.CurrentAlphaNode.MemoryNode = memoryNode;
         }
+        memoryNode.NodeInfo.Add(context.Rule);
+        context.AlphaSource = memoryNode;
+    }
 
-        private void BuildTypeNode(ReteBuilderContext context, RuleElement element, Type declarationType)
+    private IAggregatorFactory BuildAggregatorFactory(ReteBuilderContext context, AggregateElement element)
+    {
+        IAggregatorFactory factory;
+        switch (element.Name)
         {
-            TypeNode node = context.CurrentAlphaNode
-                .ChildNodes.OfType<TypeNode>()
-                .FirstOrDefault(tn => tn.FilterType == declarationType);
-
-            if (node == null)
-            {
-                node = new TypeNode(declarationType);
-                node.Id = GetNodeId();
-                node.NodeInfo.OutputType = declarationType;
-                context.CurrentAlphaNode.ChildNodes.Add(node);
-            }
-            node.NodeInfo.Add(context.Rule);
-            context.CurrentAlphaNode = node;
+            case AggregateElement.CollectName:
+                factory = new CollectionAggregatorFactory();
+                break;
+            case AggregateElement.GroupByName:
+                factory = new GroupByAggregatorFactory();
+                break;
+            case AggregateElement.ProjectName:
+                factory = new ProjectionAggregatorFactory();
+                break;
+            case AggregateElement.FlattenName:
+                factory = new FlatteningAggregatorFactory();
+                break;
+            default:
+                factory = GetCustomFactory(element);
+                break;
         }
+        var compiledExpressions = CompileExpressions(context, element);
+        factory.Compile(element, compiledExpressions);
+        return factory;
+    }
 
-        private void BuildSelectionNode(ReteBuilderContext context, ExpressionElement element)
+    private IAggregatorFactory GetCustomFactory(AggregateElement element)
+    {
+        Type factoryType = element.CustomFactoryType;
+        if (factoryType == null)
         {
-            SelectionNode node = context.CurrentAlphaNode
-                .ChildNodes.OfType<SelectionNode>()
-                .FirstOrDefault(sn => _expressionComparer.AreEqual(sn.ExpressionElement, element));
-
-            if (node == null)
-            {
-                var compiledExpression = _ruleExpressionCompiler.CompileLhsFactExpression<bool>(element);
-                node = new SelectionNode(element, compiledExpression);
-                node.Id = GetNodeId();
-                node.NodeInfo.OutputType = context.Declarations.Last().Type;
-                context.CurrentAlphaNode.ChildNodes.Add(node);
-            }
-            node.NodeInfo.Add(context.Rule);
-            context.CurrentAlphaNode = node;
+            factoryType = _aggregatorRegistry[element.Name];
         }
 
-        private void BuildAlphaMemoryNode(ReteBuilderContext context)
+        if (factoryType == null)
         {
-            AlphaMemoryNode memoryNode = context.CurrentAlphaNode.MemoryNode;
-            if (memoryNode == null)
-            {
-                memoryNode = new AlphaMemoryNode();
-                memoryNode.Id = GetNodeId();
-                memoryNode.NodeInfo.OutputType = context.Declarations.Last().Type;
-                context.CurrentAlphaNode.MemoryNode = memoryNode;
-            }
-            memoryNode.NodeInfo.Add(context.Rule);
-            context.AlphaSource = memoryNode;
+            throw new ArgumentException($"Custom aggregator does not have a factory registered. Name={element.Name}");
         }
 
-        private IAggregatorFactory BuildAggregatorFactory(ReteBuilderContext context, AggregateElement element)
+        var factory = (IAggregatorFactory)Activator.CreateInstance(factoryType);
+        return factory;
+    }
+
+    private IEnumerable<IAggregateExpression> CompileExpressions(ReteBuilderContext context, AggregateElement element)
+    {
+        var declarations = context.Declarations.Concat(element.Source.Declaration).ToList();
+        var result = new List<IAggregateExpression>(element.Expressions.Count);
+        foreach (var expression in element.Expressions)
         {
-            IAggregatorFactory factory;
-            switch (element.Name)
-            {
-                case AggregateElement.CollectName:
-                    factory = new CollectionAggregatorFactory();
-                    break;
-                case AggregateElement.GroupByName:
-                    factory = new GroupByAggregatorFactory();
-                    break;
-                case AggregateElement.ProjectName:
-                    factory = new ProjectionAggregatorFactory();
-                    break;
-                case AggregateElement.FlattenName:
-                    factory = new FlatteningAggregatorFactory();
-                    break;
-                default:
-                    factory = GetCustomFactory(element);
-                    break;
-            }
-            var compiledExpressions = CompileExpressions(context, element);
-            factory.Compile(element, compiledExpressions);
-            return factory;
+            var aggregateExpression = _ruleExpressionCompiler.CompileAggregateExpression(expression, declarations);
+            result.Add(aggregateExpression);
         }
+        return result;
+    }
 
-        private IAggregatorFactory GetCustomFactory(AggregateElement element)
-        {
-            Type factoryType = element.CustomFactoryType;
-            if (factoryType == null)
-            {
-                factoryType = _aggregatorRegistry[element.Name];
-            }
-
-            if (factoryType == null)
-            {
-                throw new ArgumentException($"Custom aggregator does not have a factory registered. Name={element.Name}");
-            }
-
-            var factory = (IAggregatorFactory)Activator.CreateInstance(factoryType);
-            return factory;
-        }
-
-        private IEnumerable<IAggregateExpression> CompileExpressions(ReteBuilderContext context, AggregateElement element)
-        {
-            var declarations = context.Declarations.Concat(element.Source.Declaration).ToList();
-            var result = new List<IAggregateExpression>(element.Expressions.Count);
-            foreach (var expression in element.Expressions)
-            {
-                var aggregateExpression = _ruleExpressionCompiler.CompileAggregateExpression(expression, declarations);
-                result.Add(aggregateExpression);
-            }
-            return result;
-        }
-
-        public INetwork Build()
-        {
-            INetwork network = new Network(_root, _dummyNode);
-            return network;
-        }
+    public INetwork Build()
+    {
+        INetwork network = new Network(_root, _dummyNode);
+        return network;
     }
 }

--- a/src/NRules/NRules/Rete/ReteBuilderContext.cs
+++ b/src/NRules/NRules/Rete/ReteBuilderContext.cs
@@ -1,43 +1,42 @@
 ﻿using System.Collections.Generic;
 using NRules.RuleModel;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal class ReteBuilderContext
 {
-    internal class ReteBuilderContext
+    private readonly List<Declaration> _declarations;
+
+    public ReteBuilderContext(IRuleDefinition rule, DummyNode dummyNode)
     {
-        private readonly List<Declaration> _declarations;
+        Rule = rule;
+        _declarations = new List<Declaration>();
+        BetaSource = dummyNode;
+    }
 
-        public ReteBuilderContext(IRuleDefinition rule, DummyNode dummyNode)
-        {
-            Rule = rule;
-            _declarations = new List<Declaration>();
-            BetaSource = dummyNode;
-        }
+    public ReteBuilderContext(ReteBuilderContext context)
+    {
+        Rule = context.Rule;
+        BetaSource = context.BetaSource;
+        _declarations = new List<Declaration>(context._declarations);
+    }
 
-        public ReteBuilderContext(ReteBuilderContext context)
-        {
-            Rule = context.Rule;
-            BetaSource = context.BetaSource;
-            _declarations = new List<Declaration>(context._declarations);
-        }
+    public IRuleDefinition Rule { get; }
+    public List<Declaration> Declarations => _declarations;
 
-        public IRuleDefinition Rule { get; }
-        public List<Declaration> Declarations => _declarations;
+    public AlphaNode CurrentAlphaNode { get; set; }
+    public IAlphaMemoryNode AlphaSource { get; set; }
+    public IBetaMemoryNode BetaSource { get; set; }
+    public bool HasSubnet { get; set; }
 
-        public AlphaNode CurrentAlphaNode { get; set; }
-        public IAlphaMemoryNode AlphaSource { get; set; }
-        public IBetaMemoryNode BetaSource { get; set; }
-        public bool HasSubnet { get; set; }
+    public void RegisterDeclaration(Declaration declaration)
+    {
+        _declarations.Add(declaration);
+    }
 
-        public void RegisterDeclaration(Declaration declaration)
-        {
-            _declarations.Add(declaration);
-        }
-
-        public void ResetAlphaSource()
-        {
-            AlphaSource = null;
-            HasSubnet = false;
-        }
+    public void ResetAlphaSource()
+    {
+        AlphaSource = null;
+        HasSubnet = false;
     }
 }

--- a/src/NRules/NRules/Rete/ReteNodeVisitor.cs
+++ b/src/NRules/NRules/Rete/ReteNodeVisitor.cs
@@ -1,103 +1,102 @@
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal class ReteNodeVisitor<TContext>
 {
-    internal class ReteNodeVisitor<TContext>
+    public virtual void Visit(TContext context, INode node)
     {
-        public virtual void Visit(TContext context, INode node)
-        {
-            node.Accept(context, this);
-        }
+        node.Accept(context, this);
+    }
 
-        protected internal virtual void VisitRootNode(TContext context, RootNode node)
-        {
-            VisitAlphaNode(context, node);
-        }
+    protected internal virtual void VisitRootNode(TContext context, RootNode node)
+    {
+        VisitAlphaNode(context, node);
+    }
 
-        protected internal virtual void VisitTypeNode(TContext context, TypeNode node)
-        {
-            VisitAlphaNode(context, node);
-        }
+    protected internal virtual void VisitTypeNode(TContext context, TypeNode node)
+    {
+        VisitAlphaNode(context, node);
+    }
 
-        protected internal virtual void VisitSelectionNode(TContext context, SelectionNode node)
-        {
-            VisitAlphaNode(context, node);
-        }
+    protected internal virtual void VisitSelectionNode(TContext context, SelectionNode node)
+    {
+        VisitAlphaNode(context, node);
+    }
 
-        protected internal virtual void VisitAlphaMemoryNode(TContext context, AlphaMemoryNode node)
+    protected internal virtual void VisitAlphaMemoryNode(TContext context, AlphaMemoryNode node)
+    {
+        foreach (var objectSink in node.Sinks)
         {
-            foreach (var objectSink in node.Sinks)
-            {
-                Visit(context, objectSink);
-            }
+            Visit(context, objectSink);
         }
+    }
 
-        protected virtual void VisitAlphaNode(TContext context, AlphaNode node)
+    protected virtual void VisitAlphaNode(TContext context, AlphaNode node)
+    {
+        foreach (var childNode in node.ChildNodes)
         {
-            foreach (var childNode in node.ChildNodes)
-            {
-                Visit(context, childNode);
-            }
-            if (node.MemoryNode != null)
-            {
-                Visit(context, node.MemoryNode);
-            }
+            Visit(context, childNode);
         }
-
-        protected internal virtual void VisitAggregateNode(TContext context, AggregateNode node)
-        {
-            VisitBetaNode(context, node);
-        }
-
-        protected internal virtual void VisitNotNode(TContext context, NotNode node)
-        {
-            VisitBetaNode(context, node);
-        }
-
-        protected internal virtual void VisitJoinNode(TContext context, JoinNode node)
-        {
-            VisitBetaNode(context, node);
-        }
-
-        protected internal virtual void VisitExistsNode(TContext context, ExistsNode node)
-        {
-            VisitBetaNode(context, node);
-        }
-        
-        protected internal virtual void VisitObjectInputAdapter(TContext context, ObjectInputAdapter node)
-        {
-            foreach (var objectSink in node.Sinks)
-            {
-                Visit(context, objectSink);
-            }
-        }
-
-        protected internal virtual void VisitBindingNode(TContext context, BindingNode node)
-        {
-            VisitBetaNode(context, node);
-        }
-
-        protected internal virtual void VisitBetaMemoryNode(TContext context, BetaMemoryNode node)
-        {
-            foreach (var tupleSink in node.Sinks)
-            {
-                Visit(context, tupleSink);
-            }
-        }
-
-        protected virtual void VisitBetaNode(TContext context, BetaNode node)
+        if (node.MemoryNode != null)
         {
             Visit(context, node.MemoryNode);
         }
+    }
 
-        protected internal virtual void VisitRuleNode(TContext context, RuleNode node)
+    protected internal virtual void VisitAggregateNode(TContext context, AggregateNode node)
+    {
+        VisitBetaNode(context, node);
+    }
+
+    protected internal virtual void VisitNotNode(TContext context, NotNode node)
+    {
+        VisitBetaNode(context, node);
+    }
+
+    protected internal virtual void VisitJoinNode(TContext context, JoinNode node)
+    {
+        VisitBetaNode(context, node);
+    }
+
+    protected internal virtual void VisitExistsNode(TContext context, ExistsNode node)
+    {
+        VisitBetaNode(context, node);
+    }
+    
+    protected internal virtual void VisitObjectInputAdapter(TContext context, ObjectInputAdapter node)
+    {
+        foreach (var objectSink in node.Sinks)
         {
+            Visit(context, objectSink);
         }
+    }
 
-        protected internal virtual void VisitDummyNode(TContext context, DummyNode node)
+    protected internal virtual void VisitBindingNode(TContext context, BindingNode node)
+    {
+        VisitBetaNode(context, node);
+    }
+
+    protected internal virtual void VisitBetaMemoryNode(TContext context, BetaMemoryNode node)
+    {
+        foreach (var tupleSink in node.Sinks)
         {
-            foreach (var tupleSink in node.Sinks)
-            {
-                Visit(context, tupleSink);
-            }
+            Visit(context, tupleSink);
+        }
+    }
+
+    protected virtual void VisitBetaNode(TContext context, BetaNode node)
+    {
+        Visit(context, node.MemoryNode);
+    }
+
+    protected internal virtual void VisitRuleNode(TContext context, RuleNode node)
+    {
+    }
+
+    protected internal virtual void VisitDummyNode(TContext context, DummyNode node)
+    {
+        foreach (var tupleSink in node.Sinks)
+        {
+            Visit(context, tupleSink);
         }
     }
 }

--- a/src/NRules/NRules/Rete/RootNode.cs
+++ b/src/NRules/NRules/Rete/RootNode.cs
@@ -1,15 +1,14 @@
-﻿namespace NRules.Rete
-{
-    internal class RootNode : AlphaNode
-    {
-        public override bool IsSatisfiedBy(IExecutionContext context, Fact fact)
-        {
-            return true;
-        }
+﻿namespace NRules.Rete;
 
-        public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
-        {
-            visitor.VisitRootNode(context, this);
-        }
+internal class RootNode : AlphaNode
+{
+    public override bool IsSatisfiedBy(IExecutionContext context, Fact fact)
+    {
+        return true;
+    }
+
+    public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.VisitRootNode(context, this);
     }
 }

--- a/src/NRules/NRules/Rete/RuleNode.cs
+++ b/src/NRules/NRules/Rete/RuleNode.cs
@@ -1,59 +1,58 @@
 ﻿using System.Collections.Generic;
 using NRules.Diagnostics;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal class RuleNode : ITupleSink
 {
-    internal class RuleNode : ITupleSink
+    public int Id { get; set; }
+    public NodeInfo NodeInfo { get; } = new();
+    public ICompiledRule CompiledRule { get; }
+
+    public RuleNode(ICompiledRule compiledRule)
     {
-        public int Id { get; set; }
-        public NodeInfo NodeInfo { get; } = new();
-        public ICompiledRule CompiledRule { get; }
+        CompiledRule = compiledRule;
+    }
 
-        public RuleNode(ICompiledRule compiledRule)
+    public void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
+    {
+        using var counter = PerfCounter.Assert(context, this);
+        foreach (var tuple in tuples)
         {
-            CompiledRule = compiledRule;
+            var activation = new Activation(CompiledRule, tuple);
+            context.WorkingMemory.SetState(this, tuple, activation);
+            context.Agenda.Add(activation);
+            context.EventAggregator.RaiseActivationCreated(context.Session, activation);
         }
+        counter.AddItems(tuples.Count);
+    }
 
-        public void PropagateAssert(IExecutionContext context, List<Tuple> tuples)
+    public void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
+    {
+        using var counter = PerfCounter.Update(context, this);
+        foreach (var tuple in tuples)
         {
-            using var counter = PerfCounter.Assert(context, this);
-            foreach (var tuple in tuples)
-            {
-                var activation = new Activation(CompiledRule, tuple);
-                context.WorkingMemory.SetState(this, tuple, activation);
-                context.Agenda.Add(activation);
-                context.EventAggregator.RaiseActivationCreated(context.Session, activation);
-            }
-            counter.AddItems(tuples.Count);
+            var activation = context.WorkingMemory.GetStateOrThrow<Activation>(this, tuple);
+            context.Agenda.Modify(activation);
+            context.EventAggregator.RaiseActivationUpdated(context.Session, activation);
         }
+        counter.AddItems(tuples.Count);
+    }
 
-        public void PropagateUpdate(IExecutionContext context, List<Tuple> tuples)
+    public void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
+    {
+        using var counter = PerfCounter.Retract(context, this);
+        foreach (var tuple in tuples)
         {
-            using var counter = PerfCounter.Update(context, this);
-            foreach (var tuple in tuples)
-            {
-                var activation = context.WorkingMemory.GetStateOrThrow<Activation>(this, tuple);
-                context.Agenda.Modify(activation);
-                context.EventAggregator.RaiseActivationUpdated(context.Session, activation);
-            }
-            counter.AddItems(tuples.Count);
+            var activation = context.WorkingMemory.RemoveStateOrThrow<Activation>(this, tuple);
+            context.Agenda.Remove(activation);
+            context.EventAggregator.RaiseActivationDeleted(context.Session, activation);
         }
+        counter.AddItems(tuples.Count);
+    }
 
-        public void PropagateRetract(IExecutionContext context, List<Tuple> tuples)
-        {
-            using var counter = PerfCounter.Retract(context, this);
-            foreach (var tuple in tuples)
-            {
-                var activation = context.WorkingMemory.RemoveStateOrThrow<Activation>(this, tuple);
-                context.Agenda.Remove(activation);
-                context.EventAggregator.RaiseActivationDeleted(context.Session, activation);
-            }
-            counter.AddItems(tuples.Count);
-        }
-
-        public void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
-        {
-            visitor.VisitRuleNode(context, this);
-        }
+    public void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.VisitRuleNode(context, this);
     }
 }

--- a/src/NRules/NRules/Rete/SelectionNode.cs
+++ b/src/NRules/NRules/Rete/SelectionNode.cs
@@ -1,40 +1,39 @@
 ﻿using NRules.RuleModel;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal class SelectionNode : AlphaNode
 {
-    internal class SelectionNode : AlphaNode
+    private readonly ILhsFactExpression<bool> _compiledExpression;
+
+    public ExpressionElement ExpressionElement { get; }
+
+    public SelectionNode(ExpressionElement expressionElement, ILhsFactExpression<bool> compiledExpression)
     {
-        private readonly ILhsFactExpression<bool> _compiledExpression;
+        ExpressionElement = expressionElement;
+        _compiledExpression = compiledExpression;
+    }
 
-        public ExpressionElement ExpressionElement { get; }
-
-        public SelectionNode(ExpressionElement expressionElement, ILhsFactExpression<bool> compiledExpression)
+    public override bool IsSatisfiedBy(IExecutionContext context, Fact fact)
+    {
+        try
         {
-            ExpressionElement = expressionElement;
-            _compiledExpression = compiledExpression;
+            return _compiledExpression.Invoke(context, NodeInfo, fact);
         }
-
-        public override bool IsSatisfiedBy(IExecutionContext context, Fact fact)
+        catch (ExpressionEvaluationException e)
         {
-            try
+            if (!e.IsHandled)
             {
-                return _compiledExpression.Invoke(context, NodeInfo, fact);
+                throw new RuleLhsExpressionEvaluationException(
+                    "Failed to evaluate condition", e.Expression.ToString(), e.InnerException);
             }
-            catch (ExpressionEvaluationException e)
-            {
-                if (!e.IsHandled)
-                {
-                    throw new RuleLhsExpressionEvaluationException(
-                        "Failed to evaluate condition", e.Expression.ToString(), e.InnerException);
-                }
 
-                return false;
-            }
+            return false;
         }
+    }
 
-        public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
-        {
-            visitor.VisitSelectionNode(context, this);
-        }
+    public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.VisitSelectionNode(context, this);
     }
 }

--- a/src/NRules/NRules/Rete/Terminal.cs
+++ b/src/NRules/NRules/Rete/Terminal.cs
@@ -1,20 +1,19 @@
-﻿namespace NRules.Rete
+﻿namespace NRules.Rete;
+
+internal interface ITerminal
 {
-    internal interface ITerminal
-    {
-        ITupleSource Source { get; }
-        IndexMap FactMap { get; }
-    }
+    ITupleSource Source { get; }
+    IndexMap FactMap { get; }
+}
 
-    internal class Terminal : ITerminal
-    {
-        public ITupleSource Source { get; }
-        public IndexMap FactMap { get; }
+internal class Terminal : ITerminal
+{
+    public ITupleSource Source { get; }
+    public IndexMap FactMap { get; }
 
-        public Terminal(ITupleSource source, IndexMap factMap)
-        {
-            Source = source;
-            FactMap = factMap;
-        }
+    public Terminal(ITupleSource source, IndexMap factMap)
+    {
+        Source = source;
+        FactMap = factMap;
     }
 }

--- a/src/NRules/NRules/Rete/Tuple.cs
+++ b/src/NRules/NRules/Rete/Tuple.cs
@@ -4,114 +4,113 @@ using System.Diagnostics;
 using System.Linq;
 using NRules.RuleModel;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+[DebuggerDisplay("Tuple ({Count})")]
+[DebuggerTypeProxy(typeof(TupleDebugView))]
+internal sealed class Tuple : ITuple
 {
-    [DebuggerDisplay("Tuple ({Count})")]
-    [DebuggerTypeProxy(typeof(TupleDebugView))]
-    internal sealed class Tuple : ITuple
+    private const long NoGroup = 0;
+
+    public Tuple(long id)
     {
-        private const long NoGroup = 0;
+        Id = id;
+        GroupId = NoGroup;
+        Count = 0;
+        Level = 0;
+    }
 
-        public Tuple(long id)
+    public Tuple(long id, Tuple left, Fact right) : this(id)
+    {
+        RightFact = right;
+        LeftTuple = left;
+        Count = left.Count;
+        if (right != null) Count++;
+        Level = left.Level + 1;
+    }
+
+    public Fact RightFact { get; }
+    public Tuple LeftTuple { get; }
+    public int Count { get; }
+    public long Id { get; }
+    public int Level { get; }
+
+    public long GroupId { get; set; }
+    
+    public long GetGroupId(int level)
+    {
+        if (level == Level - 1) return GroupId;
+        long groupId = LeftTuple?.GetGroupId(level) ?? NoGroup;
+        return groupId;
+    }
+
+    /// <summary>
+    /// Facts contained in the tuple in reverse order (fast iteration over linked list).
+    /// Reverse collection to get facts in their actual order.
+    /// </summary>
+    public IEnumerable<IFact> Facts => new Enumerable(this);
+
+    public Enumerator GetEnumerator() => new(this);
+
+    internal class TupleDebugView
+    {
+        public readonly string Facts;
+
+        public TupleDebugView(Tuple tuple)
         {
-            Id = id;
-            GroupId = NoGroup;
-            Count = 0;
-            Level = 0;
+            var facts = string.Join(" || ", tuple.Facts.Reverse().Select(f => f.Value).ToArray());
+            Facts = $"[{facts}]";
+        }
+    }
+
+    internal class Enumerable : IEnumerable<Fact>, IEnumerator<Fact>
+    {
+        private readonly Tuple _tuple;
+        private Enumerator _enumerator;
+
+        public Enumerable(Tuple tuple)
+        {
+            _tuple = tuple;
+            _enumerator = new Enumerator(tuple);
         }
 
-        public Tuple(long id, Tuple left, Fact right) : this(id)
+        public IEnumerator<Fact> GetEnumerator()
         {
-            RightFact = right;
-            LeftTuple = left;
-            Count = left.Count;
-            if (right != null) Count++;
-            Level = left.Level + 1;
+            return this;
         }
 
-        public Fact RightFact { get; }
-        public Tuple LeftTuple { get; }
-        public int Count { get; }
-        public long Id { get; }
-        public int Level { get; }
-
-        public long GroupId { get; set; }
-        
-        public long GetGroupId(int level)
+        IEnumerator IEnumerable.GetEnumerator()
         {
-            if (level == Level - 1) return GroupId;
-            long groupId = LeftTuple?.GetGroupId(level) ?? NoGroup;
-            return groupId;
+            return GetEnumerator();
         }
 
-        /// <summary>
-        /// Facts contained in the tuple in reverse order (fast iteration over linked list).
-        /// Reverse collection to get facts in their actual order.
-        /// </summary>
-        public IEnumerable<IFact> Facts => new Enumerable(this);
+        public void Dispose() {}
+        public bool MoveNext() => _enumerator.MoveNext();
+        public void Reset() => _enumerator = new Enumerator(_tuple);
+        public Fact Current => _enumerator.Current;
+        object IEnumerator.Current => Current;
+    }
 
-        public Enumerator GetEnumerator() => new(this);
+    internal struct Enumerator
+    {
+        private Tuple _tuple;
 
-        internal class TupleDebugView
+        public Enumerator(Tuple tuple)
         {
-            public readonly string Facts;
-
-            public TupleDebugView(Tuple tuple)
-            {
-                var facts = string.Join(" || ", tuple.Facts.Reverse().Select(f => f.Value).ToArray());
-                Facts = $"[{facts}]";
-            }
+            _tuple = tuple;
+            Current = null;
         }
 
-        internal class Enumerable : IEnumerable<Fact>, IEnumerator<Fact>
+        public bool MoveNext()
         {
-            private readonly Tuple _tuple;
-            private Enumerator _enumerator;
-
-            public Enumerable(Tuple tuple)
+            do
             {
-                _tuple = tuple;
-                _enumerator = new Enumerator(tuple);
-            }
-
-            public IEnumerator<Fact> GetEnumerator()
-            {
-                return this;
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
-
-            public void Dispose() {}
-            public bool MoveNext() => _enumerator.MoveNext();
-            public void Reset() => _enumerator = new Enumerator(_tuple);
-            public Fact Current => _enumerator.Current;
-            object IEnumerator.Current => Current;
+                Current = _tuple.RightFact;
+                _tuple = _tuple.LeftTuple;
+            } while (Current == null && _tuple != null);
+            return Current != null;
         }
 
-        internal struct Enumerator
-        {
-            private Tuple _tuple;
-
-            public Enumerator(Tuple tuple)
-            {
-                _tuple = tuple;
-                Current = null;
-            }
-
-            public bool MoveNext()
-            {
-                do
-                {
-                    Current = _tuple.RightFact;
-                    _tuple = _tuple.LeftTuple;
-                } while (Current == null && _tuple != null);
-                return Current != null;
-            }
-
-            public Fact Current { get; private set; }
-        }
+        public Fact Current { get; private set; }
     }
 }

--- a/src/NRules/NRules/Rete/TupleExtensions.cs
+++ b/src/NRules/NRules/Rete/TupleExtensions.cs
@@ -2,36 +2,35 @@ using System.Collections.Generic;
 using System.Linq;
 using NRules.RuleModel;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+internal static class TupleExtensions
 {
-    internal static class TupleExtensions
+    /// <summary>
+    /// Facts contained in the tuple in correct order.
+    /// </summary>
+    /// <remarks>This method has to reverse the linked list and is slow.</remarks>
+    public static IEnumerable<IFact> OrderedFacts(this ITuple tuple)
     {
-        /// <summary>
-        /// Facts contained in the tuple in correct order.
-        /// </summary>
-        /// <remarks>This method has to reverse the linked list and is slow.</remarks>
-        public static IEnumerable<IFact> OrderedFacts(this ITuple tuple)
-        {
-            return tuple.Facts.Reverse();
-        }
+        return tuple.Facts.Reverse();
+    }
 
-        public static Quantifier CreateQuantifier(this IExecutionContext context, INode node, Tuple tuple)
-        {
-            var quantifier = new Quantifier();
-            context.WorkingMemory.SetState(node, tuple, quantifier);
-            return quantifier;
-        }
+    public static Quantifier CreateQuantifier(this IExecutionContext context, INode node, Tuple tuple)
+    {
+        var quantifier = new Quantifier();
+        context.WorkingMemory.SetState(node, tuple, quantifier);
+        return quantifier;
+    }
 
-        public static Quantifier GetQuantifier(this IExecutionContext context, INode node, Tuple tuple)
-        {
-            var quantifier = context.WorkingMemory.GetStateOrThrow<Quantifier>(node, tuple);
-            return quantifier;
-        }
+    public static Quantifier GetQuantifier(this IExecutionContext context, INode node, Tuple tuple)
+    {
+        var quantifier = context.WorkingMemory.GetStateOrThrow<Quantifier>(node, tuple);
+        return quantifier;
+    }
 
-        public static Quantifier RemoveQuantifier(this IExecutionContext context, INode node, Tuple tuple)
-        {
-            var quantifier = context.WorkingMemory.RemoveStateOrThrow<Quantifier>(node, tuple);
-            return quantifier;
-        }
+    public static Quantifier RemoveQuantifier(this IExecutionContext context, INode node, Tuple tuple)
+    {
+        var quantifier = context.WorkingMemory.RemoveStateOrThrow<Quantifier>(node, tuple);
+        return quantifier;
     }
 }

--- a/src/NRules/NRules/Rete/TupleFactList.cs
+++ b/src/NRules/NRules/Rete/TupleFactList.cs
@@ -1,49 +1,48 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+[DebuggerDisplay("TupleFactList ({Count})")]
+internal class TupleFactList
 {
-    [DebuggerDisplay("TupleFactList ({Count})")]
-    internal class TupleFactList
+    private readonly List<Tuple> _tuples = new(); 
+    private readonly List<Fact> _facts = new();
+
+    public int Count => _tuples.Count;
+
+    public void Add(Tuple tuple, Fact fact)
     {
-        private readonly List<Tuple> _tuples = new(); 
-        private readonly List<Fact> _facts = new();
+        _tuples.Add(tuple);
+        _facts.Add(fact);
+    }
 
-        public int Count => _tuples.Count;
+    public struct Enumerator
+    {
+        private List<Tuple>.Enumerator _tupleEnumerator;
+        private List<Fact>.Enumerator _factEnumerator;
 
-        public void Add(Tuple tuple, Fact fact)
+        public Enumerator(List<Tuple>.Enumerator tupleEnumerator, List<Fact>.Enumerator factEnumerator)
         {
-            _tuples.Add(tuple);
-            _facts.Add(fact);
+            _tupleEnumerator = tupleEnumerator;
+            _factEnumerator = factEnumerator;
         }
 
-        public struct Enumerator
+        public Tuple CurrentTuple => _tupleEnumerator.Current;
+        public Fact CurrentFact => _factEnumerator.Current;
+
+        public bool MoveNext()
         {
-            private List<Tuple>.Enumerator _tupleEnumerator;
-            private List<Fact>.Enumerator _factEnumerator;
-
-            public Enumerator(List<Tuple>.Enumerator tupleEnumerator, List<Fact>.Enumerator factEnumerator)
-            {
-                _tupleEnumerator = tupleEnumerator;
-                _factEnumerator = factEnumerator;
-            }
-
-            public Tuple CurrentTuple => _tupleEnumerator.Current;
-            public Fact CurrentFact => _factEnumerator.Current;
-
-            public bool MoveNext()
-            {
-                bool hasNextTuple = _tupleEnumerator.MoveNext();
-                bool hasNextFact = _factEnumerator.MoveNext();
-                return hasNextTuple && hasNextFact;
-            }
+            bool hasNextTuple = _tupleEnumerator.MoveNext();
+            bool hasNextFact = _factEnumerator.MoveNext();
+            return hasNextTuple && hasNextFact;
         }
+    }
 
-        public Enumerator GetEnumerator()
-        {
-            var tupleEnumerator = _tuples.GetEnumerator();
-            var factEnumerator = _facts.GetEnumerator();
-            return new Enumerator(tupleEnumerator, factEnumerator);
-        }
+    public Enumerator GetEnumerator()
+    {
+        var tupleEnumerator = _tuples.GetEnumerator();
+        var factEnumerator = _facts.GetEnumerator();
+        return new Enumerator(tupleEnumerator, factEnumerator);
     }
 }

--- a/src/NRules/NRules/Rete/TupleFactSet.cs
+++ b/src/NRules/NRules/Rete/TupleFactSet.cs
@@ -1,18 +1,17 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 
-namespace NRules.Rete
-{
-    [DebuggerDisplay("TupleFactSet Tuple({Tuple.Count}) Facts({Facts.Count})")]
-    internal class TupleFactSet
-    {
-        public Tuple Tuple { get; }
-        public List<Fact> Facts { get; }
+namespace NRules.Rete;
 
-        public TupleFactSet(Tuple tuple, List<Fact> facts)
-        {
-            Tuple = tuple;
-            Facts = facts;
-        }
+[DebuggerDisplay("TupleFactSet Tuple({Tuple.Count}) Facts({Facts.Count})")]
+internal class TupleFactSet
+{
+    public Tuple Tuple { get; }
+    public List<Fact> Facts { get; }
+
+    public TupleFactSet(Tuple tuple, List<Fact> facts)
+    {
+        Tuple = tuple;
+        Facts = facts;
     }
 }

--- a/src/NRules/NRules/Rete/TypeNode.cs
+++ b/src/NRules/NRules/Rete/TypeNode.cs
@@ -3,61 +3,60 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using NRules.Diagnostics;
 
-namespace NRules.Rete
+namespace NRules.Rete;
+
+[DebuggerDisplay("Type {FilterType.FullName,nq}")]
+internal class TypeNode : AlphaNode
 {
-    [DebuggerDisplay("Type {FilterType.FullName,nq}")]
-    internal class TypeNode : AlphaNode
+    public TypeNode(Type filterType)
     {
-        public TypeNode(Type filterType)
-        {
-            FilterType = filterType;
-        }
+        FilterType = filterType;
+    }
 
-        public Type FilterType { get; }
+    public Type FilterType { get; }
 
-        public override bool IsSatisfiedBy(IExecutionContext context, Fact fact)
-        {
-            bool isMatchingType = FilterType.IsAssignableFrom(fact.FactType);
-            return isMatchingType;
-        }
+    public override bool IsSatisfiedBy(IExecutionContext context, Fact fact)
+    {
+        bool isMatchingType = FilterType.IsAssignableFrom(fact.FactType);
+        return isMatchingType;
+    }
 
-        public override void PropagateUpdate(IExecutionContext context, List<Fact> facts)
+    public override void PropagateUpdate(IExecutionContext context, List<Fact> facts)
+    {
+        var toUpdate = new List<Fact>();
+        using (var counter = PerfCounter.Update(context, this))
         {
-            var toUpdate = new List<Fact>();
-            using (var counter = PerfCounter.Update(context, this))
+            foreach (var fact in facts)
             {
-                foreach (var fact in facts)
-                {
-                    if (IsSatisfiedBy(context, fact))
-                        toUpdate.Add(fact);
-                }
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(toUpdate.Count);
+                if (IsSatisfiedBy(context, fact))
+                    toUpdate.Add(fact);
             }
-
-            PropagateUpdateInternal(context, toUpdate);
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(toUpdate.Count);
         }
 
-        public override void PropagateRetract(IExecutionContext context, List<Fact> facts)
+        PropagateUpdateInternal(context, toUpdate);
+    }
+
+    public override void PropagateRetract(IExecutionContext context, List<Fact> facts)
+    {
+        var toRetract = new List<Fact>();
+        using (var counter = PerfCounter.Retract(context, this))
         {
-            var toRetract = new List<Fact>();
-            using (var counter = PerfCounter.Retract(context, this))
+            foreach (var fact in facts)
             {
-                foreach (var fact in facts)
-                {
-                    if (IsSatisfiedBy(context, fact))
-                        toRetract.Add(fact);
-                }
-                counter.AddInputs(facts.Count);
-                counter.AddOutputs(toRetract.Count);
+                if (IsSatisfiedBy(context, fact))
+                    toRetract.Add(fact);
             }
-
-            PropagateRetractInternal(context, toRetract);
+            counter.AddInputs(facts.Count);
+            counter.AddOutputs(toRetract.Count);
         }
 
-        public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
-        {
-            visitor.VisitTypeNode(context, this);
-        }
+        PropagateRetractInternal(context, toRetract);
+    }
+
+    public override void Accept<TContext>(TContext context, ReteNodeVisitor<TContext> visitor)
+    {
+        visitor.VisitTypeNode(context, this);
     }
 }

--- a/src/NRules/NRules/RuleAction.cs
+++ b/src/NRules/NRules/RuleAction.cs
@@ -5,121 +5,120 @@ using NRules.RuleModel;
 using NRules.Utilities;
 using Tuple = NRules.Rete.Tuple;
 
-namespace NRules
+namespace NRules;
+
+internal interface IRuleAction
 {
-    internal interface IRuleAction
+    Expression Expression { get; }
+    ActionTrigger Trigger { get; }
+    object[] GetArguments(IActionContext actionContext);
+    void Invoke(IExecutionContext executionContext, IActionContext actionContext);
+}
+
+internal class RuleAction : IRuleAction
+{
+    private readonly LambdaExpression _expression;
+    private readonly Action<IContext, Tuple> _compiledExpression;
+    private readonly IArgumentMap _argumentMap;
+
+    public RuleAction(LambdaExpression expression, Action<IContext, Tuple> compiledExpression,
+        IArgumentMap argumentMap, ActionTrigger actionTrigger)
     {
-        Expression Expression { get; }
-        ActionTrigger Trigger { get; }
-        object[] GetArguments(IActionContext actionContext);
-        void Invoke(IExecutionContext executionContext, IActionContext actionContext);
+        _expression = expression;
+        Trigger = actionTrigger;
+        _compiledExpression = compiledExpression;
+        _argumentMap = argumentMap;
     }
 
-    internal class RuleAction : IRuleAction
+    public Expression Expression => _expression;
+    public ActionTrigger Trigger { get; }
+
+    public object[] GetArguments(IActionContext actionContext)
     {
-        private readonly LambdaExpression _expression;
-        private readonly Action<IContext, Tuple> _compiledExpression;
-        private readonly IArgumentMap _argumentMap;
-
-        public RuleAction(LambdaExpression expression, Action<IContext, Tuple> compiledExpression,
-            IArgumentMap argumentMap, ActionTrigger actionTrigger)
-        {
-            _expression = expression;
-            Trigger = actionTrigger;
-            _compiledExpression = compiledExpression;
-            _argumentMap = argumentMap;
-        }
-
-        public Expression Expression => _expression;
-        public ActionTrigger Trigger { get; }
-
-        public object[] GetArguments(IActionContext actionContext)
-        {
-            var arguments = new ActivationExpressionArguments(_argumentMap, actionContext.Activation);
-            return arguments.GetValues();
-        }
-
-        public void Invoke(IExecutionContext executionContext, IActionContext actionContext)
-        {
-            var activation = actionContext.Activation;
-            var tuple = activation.Tuple;
-
-            Exception exception = null;
-            try
-            {
-                _compiledExpression.Invoke(actionContext, tuple);
-            }
-            catch (Exception e)
-            {
-                exception = e;
-                bool isHandled = false;
-                executionContext.EventAggregator.RaiseRhsExpressionFailed(executionContext.Session, e, _expression, _argumentMap, actionContext.Activation, ref isHandled);
-                if (!isHandled)
-                {
-                    throw;
-                }
-            }
-            finally
-            {
-                if (executionContext.EventAggregator.TraceEnabled)
-                    executionContext.EventAggregator.RaiseRhsExpressionEvaluated(executionContext.Session, exception, _expression, _argumentMap, actionContext.Activation);
-            }
-        }
+        var arguments = new ActivationExpressionArguments(_argumentMap, actionContext.Activation);
+        return arguments.GetValues();
     }
 
-    internal class RuleActionWithDependencies : IRuleAction
+    public void Invoke(IExecutionContext executionContext, IActionContext actionContext)
     {
-        private readonly LambdaExpression _expression;
-        private readonly Action<IContext, Tuple, IDependencyResolver, IResolutionContext> _compiledExpression;
-        private readonly IArgumentMap _argumentMap;
+        var activation = actionContext.Activation;
+        var tuple = activation.Tuple;
 
-        public RuleActionWithDependencies(LambdaExpression expression, Action<IContext, Tuple, IDependencyResolver, IResolutionContext> compiledExpression,
-            IArgumentMap argumentMap, ActionTrigger actionTrigger)
+        Exception exception = null;
+        try
         {
-            _expression = expression;
-            Trigger = actionTrigger;
-            _compiledExpression = compiledExpression;
-            _argumentMap = argumentMap;
+            _compiledExpression.Invoke(actionContext, tuple);
         }
-
-        public Expression Expression => _expression;
-        public ActionTrigger Trigger { get; }
-        
-        public object[] GetArguments(IActionContext actionContext)
+        catch (Exception e)
         {
-            var arguments = new ActivationExpressionArguments(_argumentMap, actionContext.Activation);
-            return arguments.GetValues();
+            exception = e;
+            bool isHandled = false;
+            executionContext.EventAggregator.RaiseRhsExpressionFailed(executionContext.Session, e, _expression, _argumentMap, actionContext.Activation, ref isHandled);
+            if (!isHandled)
+            {
+                throw;
+            }
         }
-
-        public void Invoke(IExecutionContext executionContext, IActionContext actionContext)
+        finally
         {
-            var compiledRule = actionContext.CompiledRule;
-            var activation = actionContext.Activation;
-            var tuple = activation.Tuple;
+            if (executionContext.EventAggregator.TraceEnabled)
+                executionContext.EventAggregator.RaiseRhsExpressionEvaluated(executionContext.Session, exception, _expression, _argumentMap, actionContext.Activation);
+        }
+    }
+}
 
-            var dependencyResolver = executionContext.Session.DependencyResolver;
-            var resolutionContext = new ResolutionContext(executionContext.Session, compiledRule.Definition);
+internal class RuleActionWithDependencies : IRuleAction
+{
+    private readonly LambdaExpression _expression;
+    private readonly Action<IContext, Tuple, IDependencyResolver, IResolutionContext> _compiledExpression;
+    private readonly IArgumentMap _argumentMap;
 
-            Exception exception = null;
-            try
+    public RuleActionWithDependencies(LambdaExpression expression, Action<IContext, Tuple, IDependencyResolver, IResolutionContext> compiledExpression,
+        IArgumentMap argumentMap, ActionTrigger actionTrigger)
+    {
+        _expression = expression;
+        Trigger = actionTrigger;
+        _compiledExpression = compiledExpression;
+        _argumentMap = argumentMap;
+    }
+
+    public Expression Expression => _expression;
+    public ActionTrigger Trigger { get; }
+    
+    public object[] GetArguments(IActionContext actionContext)
+    {
+        var arguments = new ActivationExpressionArguments(_argumentMap, actionContext.Activation);
+        return arguments.GetValues();
+    }
+
+    public void Invoke(IExecutionContext executionContext, IActionContext actionContext)
+    {
+        var compiledRule = actionContext.CompiledRule;
+        var activation = actionContext.Activation;
+        var tuple = activation.Tuple;
+
+        var dependencyResolver = executionContext.Session.DependencyResolver;
+        var resolutionContext = new ResolutionContext(executionContext.Session, compiledRule.Definition);
+
+        Exception exception = null;
+        try
+        {
+            _compiledExpression.Invoke(actionContext, tuple, dependencyResolver, resolutionContext);
+        }
+        catch (Exception e)
+        {
+            exception = e;
+            bool isHandled = false;
+            executionContext.EventAggregator.RaiseRhsExpressionFailed(executionContext.Session, e, _expression, _argumentMap, actionContext.Activation, ref isHandled);
+            if (!isHandled)
             {
-                _compiledExpression.Invoke(actionContext, tuple, dependencyResolver, resolutionContext);
+                throw;
             }
-            catch (Exception e)
-            {
-                exception = e;
-                bool isHandled = false;
-                executionContext.EventAggregator.RaiseRhsExpressionFailed(executionContext.Session, e, _expression, _argumentMap, actionContext.Activation, ref isHandled);
-                if (!isHandled)
-                {
-                    throw;
-                }
-            }
-            finally
-            {
-                if (executionContext.EventAggregator.TraceEnabled)
-                    executionContext.EventAggregator.RaiseRhsExpressionEvaluated(executionContext.Session, exception, _expression, _argumentMap, actionContext.Activation);
-            }
+        }
+        finally
+        {
+            if (executionContext.EventAggregator.TraceEnabled)
+                executionContext.EventAggregator.RaiseRhsExpressionEvaluated(executionContext.Session, exception, _expression, _argumentMap, actionContext.Activation);
         }
     }
 }

--- a/src/NRules/NRules/RuleCompilationException.cs
+++ b/src/NRules/NRules/RuleCompilationException.cs
@@ -1,53 +1,52 @@
 using System;
 
-namespace NRules
+namespace NRules;
+
+/// <summary>
+/// Represents errors that occur while compiling a rule.
+/// </summary>
+[Serializable]
+public class RuleCompilationException : Exception
 {
-    /// <summary>
-    /// Represents errors that occur while compiling a rule.
-    /// </summary>
-    [Serializable]
-    public class RuleCompilationException : Exception
+    internal RuleCompilationException(string message, string ruleName, Exception innerException)
+        : base(message, innerException)
     {
-        internal RuleCompilationException(string message, string ruleName, Exception innerException)
-            : base(message, innerException)
-        {
-            RuleName = ruleName;
-        }
-
-        [System.Security.SecuritySafeCritical]
-        protected RuleCompilationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
-        {
-            RuleName = info.GetString("RuleName");
-        }
-
-        [System.Security.SecurityCritical]
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-        {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
-            base.GetObjectData(info, context);
-            info.AddValue("RuleName", RuleName, typeof(string));
-        }
-
-        /// <summary>
-        /// Rule that caused exception.
-        /// </summary>
-        public string RuleName { get; }
-
-        public override string Message
-        {
-            get
-            {
-                string message = base.Message;
-                if (!string.IsNullOrEmpty(RuleName))
-                {
-                    return message + Environment.NewLine + RuleName;
-                }
-                return message;
-            }
-        } 
+        RuleName = ruleName;
     }
+
+    [System.Security.SecuritySafeCritical]
+    protected RuleCompilationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+        : base(info, context)
+    {
+        RuleName = info.GetString("RuleName");
+    }
+
+    [System.Security.SecurityCritical]
+    public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+    {
+        if (info == null)
+        {
+            throw new ArgumentNullException(nameof(info));
+        }
+        base.GetObjectData(info, context);
+        info.AddValue("RuleName", RuleName, typeof(string));
+    }
+
+    /// <summary>
+    /// Rule that caused exception.
+    /// </summary>
+    public string RuleName { get; }
+
+    public override string Message
+    {
+        get
+        {
+            string message = base.Message;
+            if (!string.IsNullOrEmpty(RuleName))
+            {
+                return message + Environment.NewLine + RuleName;
+            }
+            return message;
+        }
+    } 
 }

--- a/src/NRules/NRules/RuleCompiler.cs
+++ b/src/NRules/NRules/RuleCompiler.cs
@@ -10,185 +10,184 @@ using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 using NRules.Utilities;
 
-namespace NRules
+namespace NRules;
+
+/// <summary>
+/// Compiles rules in a canonical rule model form into an executable representation.
+/// </summary>
+public class RuleCompiler
 {
+    private readonly RuleCompilerOptions _options;
+    private readonly AggregatorRegistry _aggregatorRegistry = new();
+    private readonly IRuleExpressionCompiler _ruleExpressionCompiler = new RuleExpressionCompiler();
+
     /// <summary>
-    /// Compiles rules in a canonical rule model form into an executable representation.
+    /// Initializes a new instance of the <see cref="RuleCompiler"/> class
+    /// using the default <see cref="RuleCompilerOptions"/>.
     /// </summary>
-    public class RuleCompiler
+    public RuleCompiler()
+        : this(new RuleCompilerOptions())
     {
-        private readonly RuleCompilerOptions _options;
-        private readonly AggregatorRegistry _aggregatorRegistry = new();
-        private readonly IRuleExpressionCompiler _ruleExpressionCompiler = new RuleExpressionCompiler();
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RuleCompiler"/> class
-        /// using the default <see cref="RuleCompilerOptions"/>.
-        /// </summary>
-        public RuleCompiler()
-            : this(new RuleCompilerOptions())
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RuleCompiler"/> class
+    /// using the specified <see cref="RuleCompilerOptions"/>.
+    /// </summary>
+    /// <param name="options"></param>
+    public RuleCompiler(RuleCompilerOptions options)
+    {
+        _options = options;
+    }
+
+    /// <summary>
+    /// Registry of custom aggregator factories.
+    /// </summary>
+    public AggregatorRegistry AggregatorRegistry => _aggregatorRegistry;
+
+    /// <summary>
+    /// Compiles expressions used in rules conditions and actions into executable delegates.
+    /// Default implementation uses the built-in .NET expression compiler.
+    /// </summary>
+    public IExpressionCompiler ExpressionCompiler
+    {
+        get => _ruleExpressionCompiler.ExpressionCompiler;
+        set
         {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            _ruleExpressionCompiler.ExpressionCompiler = value;
         }
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RuleCompiler"/> class
-        /// using the specified <see cref="RuleCompilerOptions"/>.
-        /// </summary>
-        /// <param name="options"></param>
-        public RuleCompiler(RuleCompilerOptions options)
+    /// <summary>
+    /// Compiles a collection of rules into a session factory.
+    /// </summary>
+    /// <param name="ruleDefinitions">Rules to compile.</param>
+    /// <returns>Session factory.</returns>
+    /// <exception cref="RuleCompilationException">Any fatal error during rules compilation.</exception>
+    /// <seealso cref="IRuleRepository"/>
+    public ISessionFactory Compile(IEnumerable<IRuleDefinition> ruleDefinitions)
+    {
+        return Compile(ruleDefinitions, default);
+    }
+
+    /// <summary>
+    /// Compiles a collection of rules into a session factory.
+    /// </summary>
+    /// <param name="ruleDefinitions">Rules to compile.</param>
+    /// <param name="cancellationToken">Enables cooperative cancellation of the rules compilation.</param>
+    /// <returns>Session factory.</returns>
+    /// <exception cref="RuleCompilationException">Any fatal error during rules compilation.</exception>
+    /// <seealso cref="IRuleRepository"/>
+    public ISessionFactory Compile(IEnumerable<IRuleDefinition> ruleDefinitions, CancellationToken cancellationToken)
+    {
+        IReteBuilder reteBuilder = new ReteBuilder(_options, _aggregatorRegistry, _ruleExpressionCompiler);
+        var compiledRules = new List<ICompiledRule>();
+        foreach (var ruleDefinition in ruleDefinitions)
         {
-            _options = options;
-        }
-
-        /// <summary>
-        /// Registry of custom aggregator factories.
-        /// </summary>
-        public AggregatorRegistry AggregatorRegistry => _aggregatorRegistry;
-
-        /// <summary>
-        /// Compiles expressions used in rules conditions and actions into executable delegates.
-        /// Default implementation uses the built-in .NET expression compiler.
-        /// </summary>
-        public IExpressionCompiler ExpressionCompiler
-        {
-            get => _ruleExpressionCompiler.ExpressionCompiler;
-            set
+            try
             {
-                if (value == null) throw new ArgumentNullException(nameof(value));
-                _ruleExpressionCompiler.ExpressionCompiler = value;
+                var compiledRule = CompileRule(reteBuilder, ruleDefinition);
+                compiledRules.AddRange(compiledRule);
             }
-        }
-
-        /// <summary>
-        /// Compiles a collection of rules into a session factory.
-        /// </summary>
-        /// <param name="ruleDefinitions">Rules to compile.</param>
-        /// <returns>Session factory.</returns>
-        /// <exception cref="RuleCompilationException">Any fatal error during rules compilation.</exception>
-        /// <seealso cref="IRuleRepository"/>
-        public ISessionFactory Compile(IEnumerable<IRuleDefinition> ruleDefinitions)
-        {
-            return Compile(ruleDefinitions, default);
-        }
-
-        /// <summary>
-        /// Compiles a collection of rules into a session factory.
-        /// </summary>
-        /// <param name="ruleDefinitions">Rules to compile.</param>
-        /// <param name="cancellationToken">Enables cooperative cancellation of the rules compilation.</param>
-        /// <returns>Session factory.</returns>
-        /// <exception cref="RuleCompilationException">Any fatal error during rules compilation.</exception>
-        /// <seealso cref="IRuleRepository"/>
-        public ISessionFactory Compile(IEnumerable<IRuleDefinition> ruleDefinitions, CancellationToken cancellationToken)
-        {
-            IReteBuilder reteBuilder = new ReteBuilder(_options, _aggregatorRegistry, _ruleExpressionCompiler);
-            var compiledRules = new List<ICompiledRule>();
-            foreach (var ruleDefinition in ruleDefinitions)
+            catch (Exception e)
             {
-                try
-                {
-                    var compiledRule = CompileRule(reteBuilder, ruleDefinition);
-                    compiledRules.AddRange(compiledRule);
-                }
-                catch (Exception e)
-                {
-                    throw new RuleCompilationException("Failed to compile rule", ruleDefinition.Name, e);
-                }
-
-                if (cancellationToken.IsCancellationRequested) break;
+                throw new RuleCompilationException("Failed to compile rule", ruleDefinition.Name, e);
             }
 
-            INetwork network = reteBuilder.Build();
-            var factory = new SessionFactory(network, compiledRules);
-            return factory;
+            if (cancellationToken.IsCancellationRequested) break;
         }
 
-        /// <summary>
-        /// Compiles rules from rule sets into a session factory.
-        /// </summary>
-        /// <param name="ruleSets">Rule sets to compile.</param>
-        /// <returns>Session factory.</returns>
-        /// <exception cref="RuleCompilationException">Any fatal error during rules compilation.</exception>
-        public ISessionFactory Compile(IEnumerable<IRuleSet> ruleSets)
+        INetwork network = reteBuilder.Build();
+        var factory = new SessionFactory(network, compiledRules);
+        return factory;
+    }
+
+    /// <summary>
+    /// Compiles rules from rule sets into a session factory.
+    /// </summary>
+    /// <param name="ruleSets">Rule sets to compile.</param>
+    /// <returns>Session factory.</returns>
+    /// <exception cref="RuleCompilationException">Any fatal error during rules compilation.</exception>
+    public ISessionFactory Compile(IEnumerable<IRuleSet> ruleSets)
+    {
+        return Compile(ruleSets, default);
+    }
+
+    /// <summary>
+    /// Compiles rules from rule sets into a session factory.
+    /// </summary>
+    /// <param name="ruleSets">Rule sets to compile.</param>
+    /// <param name="cancellationToken">Enables cooperative cancellation of the rules compilation.</param>
+    /// <returns>Session factory.</returns>
+    /// <exception cref="RuleCompilationException">Any fatal error during rules compilation.</exception>
+    public ISessionFactory Compile(IEnumerable<IRuleSet> ruleSets, CancellationToken cancellationToken)
+    {
+        var rules = ruleSets.SelectMany(x => x.Rules);
+        return Compile(rules, cancellationToken);
+    }
+
+    private IEnumerable<ICompiledRule> CompileRule(IReteBuilder reteBuilder, IRuleDefinition ruleDefinition)
+    {
+        var rules = new List<ICompiledRule>();
+
+        var transformation = new RuleTransformation();
+        var transformedRule = transformation.Transform(ruleDefinition);
+        var ruleDeclarations = transformedRule.LeftHandSide.Exports.ToList();
+
+        var dependencies = transformedRule.DependencyGroup.Dependencies.ToList();
+        var terminals = reteBuilder.AddRule(transformedRule);
+
+        foreach (var terminal in terminals)
         {
-            return Compile(ruleSets, default);
-        }
+            IRuleFilter filter = CompileFilters(transformedRule, ruleDeclarations, terminal.FactMap);
 
-        /// <summary>
-        /// Compiles rules from rule sets into a session factory.
-        /// </summary>
-        /// <param name="ruleSets">Rule sets to compile.</param>
-        /// <param name="cancellationToken">Enables cooperative cancellation of the rules compilation.</param>
-        /// <returns>Session factory.</returns>
-        /// <exception cref="RuleCompilationException">Any fatal error during rules compilation.</exception>
-        public ISessionFactory Compile(IEnumerable<IRuleSet> ruleSets, CancellationToken cancellationToken)
-        {
-            var rules = ruleSets.SelectMany(x => x.Rules);
-            return Compile(rules, cancellationToken);
-        }
-
-        private IEnumerable<ICompiledRule> CompileRule(IReteBuilder reteBuilder, IRuleDefinition ruleDefinition)
-        {
-            var rules = new List<ICompiledRule>();
-
-            var transformation = new RuleTransformation();
-            var transformedRule = transformation.Transform(ruleDefinition);
-            var ruleDeclarations = transformedRule.LeftHandSide.Exports.ToList();
-
-            var dependencies = transformedRule.DependencyGroup.Dependencies.ToList();
-            var terminals = reteBuilder.AddRule(transformedRule);
-
-            foreach (var terminal in terminals)
+            var rightHandSide = transformedRule.RightHandSide;
+            var actions = new List<IRuleAction>();
+            foreach (var action in rightHandSide.Actions)
             {
-                IRuleFilter filter = CompileFilters(transformedRule, ruleDeclarations, terminal.FactMap);
-
-                var rightHandSide = transformedRule.RightHandSide;
-                var actions = new List<IRuleAction>();
-                foreach (var action in rightHandSide.Actions)
-                {
-                    var ruleAction = _ruleExpressionCompiler.CompileAction(action, ruleDeclarations, dependencies, terminal.FactMap);
-                    actions.Add(ruleAction);
-                }
-
-                var rule = new CompiledRule(ruleDefinition, ruleDeclarations, actions, filter, terminal.FactMap);
-                var ruleNode = BuildRuleNode(rule, terminal);
-                ruleNode.Id = reteBuilder.GetNodeId();
-                rules.Add(rule);
+                var ruleAction = _ruleExpressionCompiler.CompileAction(action, ruleDeclarations, dependencies, terminal.FactMap);
+                actions.Add(ruleAction);
             }
 
-            return rules;
+            var rule = new CompiledRule(ruleDefinition, ruleDeclarations, actions, filter, terminal.FactMap);
+            var ruleNode = BuildRuleNode(rule, terminal);
+            ruleNode.Id = reteBuilder.GetNodeId();
+            rules.Add(rule);
         }
 
-        private IRuleFilter CompileFilters(IRuleDefinition ruleDefinition, List<Declaration> ruleDeclarations, IndexMap tupleFactMap)
+        return rules;
+    }
+
+    private IRuleFilter CompileFilters(IRuleDefinition ruleDefinition, List<Declaration> ruleDeclarations, IndexMap tupleFactMap)
+    {
+        var conditions = new List<IActivationExpression<bool>>();
+        var keySelectors = new List<IActivationExpression<object>>();
+        foreach (var filter in ruleDefinition.FilterGroup.Filters)
         {
-            var conditions = new List<IActivationExpression<bool>>();
-            var keySelectors = new List<IActivationExpression<object>>();
-            foreach (var filter in ruleDefinition.FilterGroup.Filters)
+            switch (filter.FilterType)
             {
-                switch (filter.FilterType)
-                {
-                    case FilterType.Predicate:
-                        var condition = _ruleExpressionCompiler.CompileActivationExpression<bool>(filter, ruleDeclarations, tupleFactMap);
-                        conditions.Add(condition);
-                        break;
-                    case FilterType.KeyChange:
-                        var keySelector = _ruleExpressionCompiler.CompileActivationExpression<object>(filter, ruleDeclarations, tupleFactMap);
-                        keySelectors.Add(keySelector);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException($"Unrecognized filter type. FilterType={filter.FilterType}");
-                }
+                case FilterType.Predicate:
+                    var condition = _ruleExpressionCompiler.CompileActivationExpression<bool>(filter, ruleDeclarations, tupleFactMap);
+                    conditions.Add(condition);
+                    break;
+                case FilterType.KeyChange:
+                    var keySelector = _ruleExpressionCompiler.CompileActivationExpression<object>(filter, ruleDeclarations, tupleFactMap);
+                    keySelectors.Add(keySelector);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException($"Unrecognized filter type. FilterType={filter.FilterType}");
             }
-            var compiledFilter = new RuleFilter(conditions, keySelectors);
-            return compiledFilter;
         }
+        var compiledFilter = new RuleFilter(conditions, keySelectors);
+        return compiledFilter;
+    }
 
-        private RuleNode BuildRuleNode(ICompiledRule compiledRule, ITerminal terminal)
-        {
-            var ruleNode = new RuleNode(compiledRule);
-            ruleNode.NodeInfo.Add(compiledRule.Definition);
-            terminal.Source.Attach(ruleNode);
-            return ruleNode;
-        }
+    private RuleNode BuildRuleNode(ICompiledRule compiledRule, ITerminal terminal)
+    {
+        var ruleNode = new RuleNode(compiledRule);
+        ruleNode.NodeInfo.Add(compiledRule.Definition);
+        terminal.Source.Attach(ruleNode);
+        return ruleNode;
     }
 }

--- a/src/NRules/NRules/RuleCompilerOptions.cs
+++ b/src/NRules/NRules/RuleCompilerOptions.cs
@@ -1,33 +1,32 @@
-namespace NRules
+namespace NRules;
+
+/// <summary>
+/// Defines different modes of handling of unsupported types of lambda expressions
+/// when the compiler is comparing them for the purpose of node sharing in the Rete graph.
+/// </summary>
+public enum RuleCompilerUnsupportedExpressionsHandling
 {
     /// <summary>
-    /// Defines different modes of handling of unsupported types of lambda expressions
-    /// when the compiler is comparing them for the purpose of node sharing in the Rete graph.
+    /// Rule compilation fails when it finds an unsupported expression.
+    /// This is the default behavior.
     /// </summary>
-    public enum RuleCompilerUnsupportedExpressionsHandling
-    {
-        /// <summary>
-        /// Rule compilation fails when it finds an unsupported expression.
-        /// This is the default behavior.
-        /// </summary>
-        FailFast = 0,
-
-        /// <summary>
-        /// Rule compilation treats unsupported expressions as not equal, sacrificing efficiency
-        /// in favor of compatibility.
-        /// </summary>
-        TreatAsNotEqual = 1,
-    }
+    FailFast = 0,
 
     /// <summary>
-    /// Provides options to alter default behavior of <see cref="RuleCompiler"/>.
+    /// Rule compilation treats unsupported expressions as not equal, sacrificing efficiency
+    /// in favor of compatibility.
     /// </summary>
-    public class RuleCompilerOptions
-    {
-        /// <summary>
-        /// Determines compiler behavior when it finds an unsupported type of lambda expressions
-        /// while comparing them for the purpose of node sharing in the Rete graph.
-        /// </summary>
-        public RuleCompilerUnsupportedExpressionsHandling UnsupportedExpressionHandling { get; set; } = RuleCompilerUnsupportedExpressionsHandling.FailFast;
-    }
+    TreatAsNotEqual = 1,
+}
+
+/// <summary>
+/// Provides options to alter default behavior of <see cref="RuleCompiler"/>.
+/// </summary>
+public class RuleCompilerOptions
+{
+    /// <summary>
+    /// Determines compiler behavior when it finds an unsupported type of lambda expressions
+    /// while comparing them for the purpose of node sharing in the Rete graph.
+    /// </summary>
+    public RuleCompilerUnsupportedExpressionsHandling UnsupportedExpressionHandling { get; set; } = RuleCompilerUnsupportedExpressionsHandling.FailFast;
 }

--- a/src/NRules/NRules/RuleExecutionException.cs
+++ b/src/NRules/NRules/RuleExecutionException.cs
@@ -1,22 +1,21 @@
 using System;
 
-namespace NRules
-{
-    /// <summary>
-    /// Represents errors that occur during rules execution.
-    /// </summary>
-    [Serializable]
-    public class RuleExecutionException : Exception
-    {
-        internal RuleExecutionException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
+namespace NRules;
 
-        [System.Security.SecuritySafeCritical]
-        protected RuleExecutionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
-        {
-        }
+/// <summary>
+/// Represents errors that occur during rules execution.
+/// </summary>
+[Serializable]
+public class RuleExecutionException : Exception
+{
+    internal RuleExecutionException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    [System.Security.SecuritySafeCritical]
+    protected RuleExecutionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+        : base(info, context)
+    {
     }
 }

--- a/src/NRules/NRules/RuleExpressionEvaluationException.cs
+++ b/src/NRules/NRules/RuleExpressionEvaluationException.cs
@@ -1,53 +1,52 @@
 using System;
 
-namespace NRules
+namespace NRules;
+
+/// <summary>
+/// Represents errors that occur while evaluating expressions as part of rules execution.
+/// </summary>
+[Serializable]
+public abstract class RuleExpressionEvaluationException : RuleExecutionException
 {
-    /// <summary>
-    /// Represents errors that occur while evaluating expressions as part of rules execution.
-    /// </summary>
-    [Serializable]
-    public abstract class RuleExpressionEvaluationException : RuleExecutionException
+    internal RuleExpressionEvaluationException(string message, string expression, Exception innerException)
+        : base(message, innerException)
     {
-        internal RuleExpressionEvaluationException(string message, string expression, Exception innerException)
-            : base(message, innerException)
-        {
-            Expression = expression;
-        }
-
-        [System.Security.SecuritySafeCritical]
-        protected RuleExpressionEvaluationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
-        {
-            Expression = info.GetString("Expression");
-        }
-
-        [System.Security.SecurityCritical]
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-        {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
-            base.GetObjectData(info, context);
-            info.AddValue("Expression", Expression, typeof(string));
-        }
-
-        /// <summary>
-        /// Expression that caused exception.
-        /// </summary>
-        public string Expression { get; }
-
-        public override string Message
-        {
-            get
-            {
-                string message = base.Message;
-                if (!string.IsNullOrEmpty(Expression))
-                {
-                    return message + Environment.NewLine + Expression;
-                }
-                return message;
-            }
-        } 
+        Expression = expression;
     }
+
+    [System.Security.SecuritySafeCritical]
+    protected RuleExpressionEvaluationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+        : base(info, context)
+    {
+        Expression = info.GetString("Expression");
+    }
+
+    [System.Security.SecurityCritical]
+    public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+    {
+        if (info == null)
+        {
+            throw new ArgumentNullException(nameof(info));
+        }
+        base.GetObjectData(info, context);
+        info.AddValue("Expression", Expression, typeof(string));
+    }
+
+    /// <summary>
+    /// Expression that caused exception.
+    /// </summary>
+    public string Expression { get; }
+
+    public override string Message
+    {
+        get
+        {
+            string message = base.Message;
+            if (!string.IsNullOrEmpty(Expression))
+            {
+                return message + Environment.NewLine + Expression;
+            }
+            return message;
+        }
+    } 
 }

--- a/src/NRules/NRules/RuleFilter.cs
+++ b/src/NRules/NRules/RuleFilter.cs
@@ -1,26 +1,25 @@
 ﻿using System.Collections.Generic;
 using NRules.AgendaFilters;
 
-namespace NRules
+namespace NRules;
+
+internal interface IRuleFilter
 {
-    internal interface IRuleFilter
+    IEnumerable<IActivationExpression<bool>> Conditions { get; }
+    IEnumerable<IActivationExpression<object>> KeySelectors { get; }
+}
+
+internal class RuleFilter : IRuleFilter
+{
+    private readonly List<IActivationExpression<bool>> _conditions;
+    private readonly List<IActivationExpression<object>> _keySelectors;
+
+    public RuleFilter(IEnumerable<IActivationExpression<bool>> conditions, IEnumerable<IActivationExpression<object>> keySelectors)
     {
-        IEnumerable<IActivationExpression<bool>> Conditions { get; }
-        IEnumerable<IActivationExpression<object>> KeySelectors { get; }
+        _conditions = new List<IActivationExpression<bool>>(conditions);
+        _keySelectors = new List<IActivationExpression<object>>(keySelectors);
     }
 
-    internal class RuleFilter : IRuleFilter
-    {
-        private readonly List<IActivationExpression<bool>> _conditions;
-        private readonly List<IActivationExpression<object>> _keySelectors;
-
-        public RuleFilter(IEnumerable<IActivationExpression<bool>> conditions, IEnumerable<IActivationExpression<object>> keySelectors)
-        {
-            _conditions = new List<IActivationExpression<bool>>(conditions);
-            _keySelectors = new List<IActivationExpression<object>>(keySelectors);
-        }
-
-        public IEnumerable<IActivationExpression<bool>> Conditions => _conditions;
-        public IEnumerable<IActivationExpression<object>> KeySelectors => _keySelectors;
-    }
+    public IEnumerable<IActivationExpression<bool>> Conditions => _conditions;
+    public IEnumerable<IActivationExpression<object>> KeySelectors => _keySelectors;
 }

--- a/src/NRules/NRules/RuleLhsExpressionEvaluationException.cs
+++ b/src/NRules/NRules/RuleLhsExpressionEvaluationException.cs
@@ -1,22 +1,21 @@
 using System;
 
-namespace NRules
-{
-    /// <summary>
-    /// Represents errors that occur while evaluating rule left-hand side expression.
-    /// </summary>
-    [Serializable]
-    public class RuleLhsExpressionEvaluationException : RuleExpressionEvaluationException
-    {
-        internal RuleLhsExpressionEvaluationException(string message, string expression, Exception innerException)
-            : base(message, expression, innerException)
-        {
-        }
+namespace NRules;
 
-        [System.Security.SecuritySafeCritical]
-        protected RuleLhsExpressionEvaluationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
-        {
-        }
+/// <summary>
+/// Represents errors that occur while evaluating rule left-hand side expression.
+/// </summary>
+[Serializable]
+public class RuleLhsExpressionEvaluationException : RuleExpressionEvaluationException
+{
+    internal RuleLhsExpressionEvaluationException(string message, string expression, Exception innerException)
+        : base(message, expression, innerException)
+    {
+    }
+
+    [System.Security.SecuritySafeCritical]
+    protected RuleLhsExpressionEvaluationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+        : base(info, context)
+    {
     }
 }

--- a/src/NRules/NRules/RuleRepositoryExtensions.cs
+++ b/src/NRules/NRules/RuleRepositoryExtensions.cs
@@ -3,45 +3,44 @@ using System.Linq;
 using System.Threading;
 using NRules.RuleModel;
 
-namespace NRules
+namespace NRules;
+
+public static class RuleRepositoryExtensions
 {
-    public static class RuleRepositoryExtensions
+    /// <summary>
+    /// Retrieves all rules from all rule sets contained in the repository.
+    /// </summary>
+    /// <returns>Collection of rules from the repository.</returns>
+    public static IEnumerable<IRuleDefinition> GetRules(this IRuleRepository repository)
     {
-        /// <summary>
-        /// Retrieves all rules from all rule sets contained in the repository.
-        /// </summary>
-        /// <returns>Collection of rules from the repository.</returns>
-        public static IEnumerable<IRuleDefinition> GetRules(this IRuleRepository repository)
-        {
-            var ruleSets = repository.GetRuleSets();
-            return ruleSets.SelectMany(rs => rs.Rules);
-        }
+        var ruleSets = repository.GetRuleSets();
+        return ruleSets.SelectMany(rs => rs.Rules);
+    }
 
-        /// <summary>
-        /// Compiles all rules in the repository into a session factory.
-        /// Use <see cref="RuleCompiler"/> explicitly if only need to compile a subset of rules.
-        /// </summary>
-        /// <param name="repository">Rule repository.</param>
-        /// <returns>Session factory.</returns>
-        /// <seealso cref="RuleCompiler"/>
-        public static ISessionFactory Compile(this IRuleRepository repository)
-        {
-            return repository.Compile(default);
-        }
+    /// <summary>
+    /// Compiles all rules in the repository into a session factory.
+    /// Use <see cref="RuleCompiler"/> explicitly if only need to compile a subset of rules.
+    /// </summary>
+    /// <param name="repository">Rule repository.</param>
+    /// <returns>Session factory.</returns>
+    /// <seealso cref="RuleCompiler"/>
+    public static ISessionFactory Compile(this IRuleRepository repository)
+    {
+        return repository.Compile(default);
+    }
 
-        /// <summary>
-        /// Compiles all rules in the repository into a session factory.
-        /// Use <see cref="RuleCompiler"/> explicitly if only need to compile a subset of rules.
-        /// </summary>
-        /// <param name="repository">Rule repository.</param>
-        /// <param name="cancellationToken">Enables cooperative cancellation of the rules compilation.</param>
-        /// <returns>Session factory.</returns>
-        /// <seealso cref="RuleCompiler"/>
-        public static ISessionFactory Compile(this IRuleRepository repository, CancellationToken cancellationToken)
-        {
-            var compiler = new RuleCompiler();
-            ISessionFactory factory = compiler.Compile(repository.GetRules(), cancellationToken);
-            return factory;
-        }
+    /// <summary>
+    /// Compiles all rules in the repository into a session factory.
+    /// Use <see cref="RuleCompiler"/> explicitly if only need to compile a subset of rules.
+    /// </summary>
+    /// <param name="repository">Rule repository.</param>
+    /// <param name="cancellationToken">Enables cooperative cancellation of the rules compilation.</param>
+    /// <returns>Session factory.</returns>
+    /// <seealso cref="RuleCompiler"/>
+    public static ISessionFactory Compile(this IRuleRepository repository, CancellationToken cancellationToken)
+    {
+        var compiler = new RuleCompiler();
+        ISessionFactory factory = compiler.Compile(repository.GetRules(), cancellationToken);
+        return factory;
     }
 }

--- a/src/NRules/NRules/RuleRhsExpressionEvaluationException.cs
+++ b/src/NRules/NRules/RuleRhsExpressionEvaluationException.cs
@@ -1,53 +1,52 @@
 using System;
 
-namespace NRules
+namespace NRules;
+
+/// <summary>
+/// Represents errors that occur while evaluating rule right-hand side expression.
+/// </summary>
+[Serializable]
+public class RuleRhsExpressionEvaluationException : RuleExpressionEvaluationException
 {
-    /// <summary>
-    /// Represents errors that occur while evaluating rule right-hand side expression.
-    /// </summary>
-    [Serializable]
-    public class RuleRhsExpressionEvaluationException : RuleExpressionEvaluationException
+    internal RuleRhsExpressionEvaluationException(string message, string ruleName, string expression, Exception innerException)
+        : base(message, expression, innerException)
     {
-        internal RuleRhsExpressionEvaluationException(string message, string ruleName, string expression, Exception innerException)
-            : base(message, expression, innerException)
-        {
-            RuleName = ruleName;
-        }
+        RuleName = ruleName;
+    }
 
-        [System.Security.SecuritySafeCritical]
-        protected RuleRhsExpressionEvaluationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
-        {
-            RuleName = info.GetString("RuleName");
-        }
+    [System.Security.SecuritySafeCritical]
+    protected RuleRhsExpressionEvaluationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+        : base(info, context)
+    {
+        RuleName = info.GetString("RuleName");
+    }
 
-        [System.Security.SecurityCritical]
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+    [System.Security.SecurityCritical]
+    public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+    {
+        if (info == null)
         {
-            if (info == null)
+            throw new ArgumentNullException(nameof(info));
+        }
+        base.GetObjectData(info, context);
+        info.AddValue("RuleName", RuleName, typeof(string));
+    }
+
+    /// <summary>
+    /// Rule that caused exception.
+    /// </summary>
+    public string RuleName { get; }
+
+    public override string Message
+    {
+        get
+        {
+            string message = base.Message;
+            if (!string.IsNullOrEmpty(RuleName))
             {
-                throw new ArgumentNullException(nameof(info));
+                return message + Environment.NewLine + RuleName;
             }
-            base.GetObjectData(info, context);
-            info.AddValue("RuleName", RuleName, typeof(string));
-        }
-
-        /// <summary>
-        /// Rule that caused exception.
-        /// </summary>
-        public string RuleName { get; }
-
-        public override string Message
-        {
-            get
-            {
-                string message = base.Message;
-                if (!string.IsNullOrEmpty(RuleName))
-                {
-                    return message + Environment.NewLine + RuleName;
-                }
-                return message;
-            }
+            return message;
         }
     }
 }

--- a/src/NRules/NRules/Session.cs
+++ b/src/NRules/NRules/Session.cs
@@ -6,721 +6,720 @@ using NRules.Diagnostics;
 using NRules.Extensibility;
 using NRules.Rete;
 
-namespace NRules
+namespace NRules;
+
+/// <summary>
+/// Represents a rules engine session. Created by <see cref="ISessionFactory"/>.
+/// Each session has its own working memory, and exposes operations that 
+/// manipulate facts in it, as well as fire matching rules.
+/// </summary>
+/// <event cref="IEventProvider.FactInsertingEvent">Before processing fact insertion.</event>
+/// <event cref="IEventProvider.FactInsertedEvent">After processing fact insertion.</event>
+/// <event cref="IEventProvider.FactUpdatingEvent">Before processing fact update.</event>
+/// <event cref="IEventProvider.FactUpdatedEvent">After processing fact update.</event>
+/// <event cref="IEventProvider.FactRetractingEvent">Before processing fact retraction.</event>
+/// <event cref="IEventProvider.FactRetractedEvent">After processing fact retraction.</event>
+/// <event cref="IEventProvider.ActivationCreatedEvent">When a set of facts matches a rule.</event>
+/// <event cref="IEventProvider.ActivationUpdatedEvent">When a set of facts is updated and re-matches a rule.</event>
+/// <event cref="IEventProvider.ActivationDeletedEvent">When a set of facts no longer matches a rule.</event>
+/// <event cref="IEventProvider.RuleFiringEvent">Before rule's actions are executed.</event>
+/// <event cref="IEventProvider.RuleFiredEvent">After rule's actions are executed.</event>
+/// <event cref="IEventProvider.LhsExpressionEvaluatedEvent">When an left-hand side expression was evaluated.</event>
+/// <event cref="IEventProvider.LhsExpressionFailedEvent">When there is an error during left-hand side expression evaluation,
+/// before throwing exception to the client.</event>
+/// <event cref="IEventProvider.AgendaExpressionEvaluatedEvent">When an agenda expression was evaluated.</event>
+/// <event cref="IEventProvider.AgendaExpressionFailedEvent">When there is an error during agenda expression evaluation,
+/// before throwing exception to the client.</event>
+/// <event cref="IEventProvider.RhsExpressionEvaluatedEvent">When an right-hand side expression was evaluated.</event>
+/// <event cref="IEventProvider.RhsExpressionFailedEvent">When there is an error during right-hand side expression evaluation,
+/// before throwing exception to the client.</event>
+/// <exception cref="RuleLhsExpressionEvaluationException">Error while evaluating any of the rules' left-hand side expressons.
+/// This exception can also be observed as an event <see cref="IEventProvider.LhsExpressionEvaluatedEvent"/>.</exception>
+/// <exception cref="AgendaExpressionEvaluationException">Error while evaluating any of the agenda expressions.
+/// This exception can also be observed as an event <see cref="IEventProvider.AgendaExpressionFailedEvent"/>.</exception>
+/// <exception cref="RuleRhsExpressionEvaluationException">Error while evaluating any of the rules' right-hand side expressions.
+/// This exception can also be observed as an event <see cref="IEventProvider.RhsExpressionFailedEvent"/>.</exception>
+/// <seealso cref="ISessionFactory"/>
+/// <threadsafety instance="false" />
+public interface ISession : ISessionSchemaProvider
 {
     /// <summary>
-    /// Represents a rules engine session. Created by <see cref="ISessionFactory"/>.
-    /// Each session has its own working memory, and exposes operations that 
-    /// manipulate facts in it, as well as fire matching rules.
+    /// Controls how the engine propagates linked facts from rules that insert/update/retract linked facts in their actions.
+    /// By default, <see cref="AutoPropagateLinkedFacts"/> is <c>true</c> and the engine automatically
+    /// propagates linked facts at the end of the rule's actions.
+    /// If <see cref="AutoPropagateLinkedFacts"/> is <c>false</c>, linked facts are queued, and have to be
+    /// explicitly propagated by calling <see cref="PropagateLinked"/> method.
     /// </summary>
-    /// <event cref="IEventProvider.FactInsertingEvent">Before processing fact insertion.</event>
-    /// <event cref="IEventProvider.FactInsertedEvent">After processing fact insertion.</event>
-    /// <event cref="IEventProvider.FactUpdatingEvent">Before processing fact update.</event>
-    /// <event cref="IEventProvider.FactUpdatedEvent">After processing fact update.</event>
-    /// <event cref="IEventProvider.FactRetractingEvent">Before processing fact retraction.</event>
-    /// <event cref="IEventProvider.FactRetractedEvent">After processing fact retraction.</event>
-    /// <event cref="IEventProvider.ActivationCreatedEvent">When a set of facts matches a rule.</event>
-    /// <event cref="IEventProvider.ActivationUpdatedEvent">When a set of facts is updated and re-matches a rule.</event>
-    /// <event cref="IEventProvider.ActivationDeletedEvent">When a set of facts no longer matches a rule.</event>
-    /// <event cref="IEventProvider.RuleFiringEvent">Before rule's actions are executed.</event>
-    /// <event cref="IEventProvider.RuleFiredEvent">After rule's actions are executed.</event>
-    /// <event cref="IEventProvider.LhsExpressionEvaluatedEvent">When an left-hand side expression was evaluated.</event>
-    /// <event cref="IEventProvider.LhsExpressionFailedEvent">When there is an error during left-hand side expression evaluation,
-    /// before throwing exception to the client.</event>
-    /// <event cref="IEventProvider.AgendaExpressionEvaluatedEvent">When an agenda expression was evaluated.</event>
-    /// <event cref="IEventProvider.AgendaExpressionFailedEvent">When there is an error during agenda expression evaluation,
-    /// before throwing exception to the client.</event>
-    /// <event cref="IEventProvider.RhsExpressionEvaluatedEvent">When an right-hand side expression was evaluated.</event>
-    /// <event cref="IEventProvider.RhsExpressionFailedEvent">When there is an error during right-hand side expression evaluation,
-    /// before throwing exception to the client.</event>
-    /// <exception cref="RuleLhsExpressionEvaluationException">Error while evaluating any of the rules' left-hand side expressons.
-    /// This exception can also be observed as an event <see cref="IEventProvider.LhsExpressionEvaluatedEvent"/>.</exception>
-    /// <exception cref="AgendaExpressionEvaluationException">Error while evaluating any of the agenda expressions.
-    /// This exception can also be observed as an event <see cref="IEventProvider.AgendaExpressionFailedEvent"/>.</exception>
-    /// <exception cref="RuleRhsExpressionEvaluationException">Error while evaluating any of the rules' right-hand side expressions.
-    /// This exception can also be observed as an event <see cref="IEventProvider.RhsExpressionFailedEvent"/>.</exception>
-    /// <seealso cref="ISessionFactory"/>
-    /// <threadsafety instance="false" />
-    public interface ISession : ISessionSchemaProvider
+    bool AutoPropagateLinkedFacts { get; set; }
+
+    /// <summary>
+    /// Agenda, which represents a store for rule matches.
+    /// </summary>
+    IAgenda Agenda { get; }
+
+    /// <summary>
+    /// Provider of events from the current rule session.
+    /// Use it to subscribe to various rules engine lifecycle events.
+    /// </summary>
+    IEventProvider Events { get; }
+
+    /// <summary>
+    /// Provider of session performance metrics for the current rule session.
+    /// </summary>
+    IMetricsProvider Metrics { get; }
+
+    /// <summary>
+    /// Rules dependency resolver for the current rules session.
+    /// </summary>
+    IDependencyResolver DependencyResolver { get; set; }
+
+    /// <summary>
+    /// Action interceptor for the current rules session.
+    /// If provided, invocation of rule actions is delegated to the interceptor.
+    /// </summary>
+    IActionInterceptor ActionInterceptor { get; set; }
+
+    /// <summary>
+    /// Inserts new facts to the rules engine memory.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="facts">Facts to insert.</param>
+    /// <exception cref="ArgumentException">If any fact already exists in working memory.</exception>
+    void InsertAll(IEnumerable<object> facts);
+
+    /// <summary>
+    /// Inserts new facts to the rules engine memory if the facts don't exist.
+    /// If any of the facts exists in the engine, none of the facts are inserted.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="facts">Facts to insert.</param>
+    /// <returns>Result of facts insertion.</returns>
+    IFactResult TryInsertAll(IEnumerable<object> facts);
+
+    /// <summary>
+    /// Inserts new facts to the rules engine memory if the facts don't exist.
+    /// If any of the facts exists in the engine, the behavior is defined by <see cref="BatchOptions"/>.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="facts">Facts to insert.</param>
+    /// <param name="options">Options that define behavior of the batch operation.</param>
+    /// <returns>Result of facts insertion.</returns>
+    IFactResult TryInsertAll(IEnumerable<object> facts, BatchOptions options);
+
+    /// <summary>
+    /// Inserts new fact to the rules engine memory.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="fact">Facts to insert.</param>
+    /// <exception cref="ArgumentException">If fact already exists in working memory.</exception>
+    void Insert(object fact);
+
+    /// <summary>
+    /// Inserts a fact to the rules engine memory if the fact does not exist.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="fact">Fact to insert.</param>
+    /// <returns>Whether the fact was inserted or not.</returns>
+    bool TryInsert(object fact);
+
+    /// <summary>
+    /// Updates existing facts in the rules engine memory.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="facts">Facts to update.</param>
+    /// <exception cref="ArgumentException">If any fact does not exist in working memory.</exception>
+    void UpdateAll(IEnumerable<object> facts);
+
+    /// <summary>
+    /// Updates existing facts in the rules engine memory if the facts exist.
+    /// If any of the facts don't exist in the engine, none of the facts are updated.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="facts">Facts to update.</param>
+    /// <returns>Result of facts update.</returns>
+    IFactResult TryUpdateAll(IEnumerable<object> facts);
+
+    /// <summary>
+    /// Updates existing facts in the rules engine memory if the facts exist.
+    /// If any of the facts don't exist in the engine, the behavior is defined by <see cref="BatchOptions"/>.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="facts">Facts to update.</param>
+    /// <param name="options">Options that define behavior of the batch operation.</param>
+    /// <returns>Result of facts update.</returns>
+    IFactResult TryUpdateAll(IEnumerable<object> facts, BatchOptions options);
+
+    /// <summary>
+    /// Updates existing fact in the rules engine memory.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="fact">Fact to update.</param>
+    /// <exception cref="ArgumentException">If fact does not exist in working memory.</exception>
+    void Update(object fact);
+
+    /// <summary>
+    /// Updates a fact in the rules engine memory if the fact exists.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="fact">Fact to update.</param>
+    /// <returns>Whether the fact was updated or not.</returns>
+    bool TryUpdate(object fact);
+
+    /// <summary>
+    /// Removes existing facts from the rules engine memory.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="facts">Facts to remove.</param>
+    /// <exception cref="ArgumentException">If any fact does not exist in working memory.</exception>
+    void RetractAll(IEnumerable<object> facts);
+
+    /// <summary>
+    /// Removes existing facts from the rules engine memory if the facts exist.
+    /// If any of the facts don't exist in the engine, none of the facts are removed.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="facts">Facts to remove.</param>
+    /// <returns>Result of facts removal.</returns>
+    IFactResult TryRetractAll(IEnumerable<object> facts);
+
+    /// <summary>
+    /// Removes existing facts from the rules engine memory if the facts exist.
+    /// If any of the facts don't exist in the engine, the behavior is defined by <see cref="BatchOptions"/>.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="facts">Facts to remove.</param>
+    /// <param name="options">Options that define behavior of the batch operation.</param>
+    /// <returns>Result of facts removal.</returns>
+    IFactResult TryRetractAll(IEnumerable<object> facts, BatchOptions options);
+
+    /// <summary>
+    /// Removes existing fact from the rules engine memory.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="fact">Fact to remove.</param>
+    /// <exception cref="ArgumentException">If fact does not exist in working memory.</exception>
+    void Retract(object fact);
+
+    /// <summary>
+    /// Removes a fact from the rules engine memory if the fact exists.
+    /// </summary>
+    /// <remarks>
+    /// Bulk session operations are more performant than individual operations on a set of facts.
+    /// </remarks>
+    /// <param name="facts">Fact to remove.</param>
+    /// <returns>Whether the fact was retracted or not.</returns>
+    bool TryRetract(object facts);
+
+    /// <summary>
+    /// Propagates all queued linked facts.
+    /// </summary>
+    /// <returns>Collection of propagated sets of linked facts.</returns>
+    IEnumerable<ILinkedFactSet> PropagateLinked();
+
+    /// <summary>
+    /// Starts rules execution cycle.
+    /// This method blocks until there are no more rules to fire.
+    /// </summary>
+    /// <returns>Number of rules that fired.</returns>
+    int Fire();
+
+    /// <summary>
+    /// Starts rules execution cycle.
+    /// This method blocks until there are no more rules to fire or cancellation is requested.
+    /// </summary>
+    /// <param name="cancellationToken">Enables cooperative cancellation of the rules execution cycle.</param>
+    /// <returns>Number of rules that fired.</returns>
+    int Fire(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Starts rules execution cycle.
+    /// This method blocks until maximum number of rules fired or there are no more rules to fire.
+    /// </summary>
+    /// <param name="maxRulesNumber">Maximum number of rules to fire.</param>
+    /// <returns>Number of rules that fired.</returns>
+    int Fire(int maxRulesNumber);
+
+    /// <summary>
+    /// Starts rules execution cycle.
+    /// This method blocks until maximum number of rules fired, cancellation is requested or there are no more rules to fire.
+    /// </summary>
+    /// <param name="maxRulesNumber">Maximum number of rules to fire.</param>
+    /// <param name="cancellationToken">Enables cooperative cancellation of the rules execution cycle.</param>
+    /// <returns>Number of rules that fired.</returns>
+    int Fire(int maxRulesNumber, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates a LINQ query to retrieve facts of a given type from the rules engine's memory.
+    /// </summary>
+    /// <typeparam name="TFact">Type of facts to query. Use <see cref="object"/> to query all facts.</typeparam>
+    /// <returns>Queryable working memory of the rules engine.</returns>
+    IQueryable<TFact> Query<TFact>();
+}
+
+internal interface ISessionInternal : ISession
+{
+    new IAgendaInternal Agenda { get; }
+
+    IEnumerable<object> GetLinkedKeys(Activation activation);
+    object GetLinked(Activation activation, object key);
+    void QueueInsertLinked(Activation activation, IEnumerable<KeyValuePair<object, object>> keyedFacts);
+    void QueueUpdateLinked(Activation activation, IEnumerable<KeyValuePair<object, object>> keyedFacts);
+    void QueueRetractLinked(Activation activation, IEnumerable<KeyValuePair<object, object>> keyedFacts);
+    void QueueRetractLinked(Activation activation);
+}
+
+internal sealed class Session : ISessionInternal
+{
+    private static readonly ILinkedFactSet[] EmptyLinkedFactResult = Array.Empty<ILinkedFactSet>();
+
+    private readonly IAgendaInternal _agenda;
+    private readonly INetwork _network;
+    private readonly IWorkingMemory _workingMemory;
+    private readonly IEventAggregator _eventAggregator;
+    private readonly IMetricsAggregator _metricsAggregator;
+    private readonly IActionExecutor _actionExecutor;
+    private readonly IExecutionContext _executionContext;
+    private readonly Queue<LinkedFactSet> _linkedFacts = new();
+
+    internal Session(
+        INetwork network,
+        IAgendaInternal agenda,
+        IWorkingMemory workingMemory,
+        IEventAggregator eventAggregator,
+        IMetricsAggregator metricsAggregator,
+        IActionExecutor actionExecutor,
+        IIdGenerator idGenerator,
+        IDependencyResolver dependencyResolver,
+        IActionInterceptor actionInterceptor)
     {
-        /// <summary>
-        /// Controls how the engine propagates linked facts from rules that insert/update/retract linked facts in their actions.
-        /// By default, <see cref="AutoPropagateLinkedFacts"/> is <c>true</c> and the engine automatically
-        /// propagates linked facts at the end of the rule's actions.
-        /// If <see cref="AutoPropagateLinkedFacts"/> is <c>false</c>, linked facts are queued, and have to be
-        /// explicitly propagated by calling <see cref="PropagateLinked"/> method.
-        /// </summary>
-        bool AutoPropagateLinkedFacts { get; set; }
-
-        /// <summary>
-        /// Agenda, which represents a store for rule matches.
-        /// </summary>
-        IAgenda Agenda { get; }
-
-        /// <summary>
-        /// Provider of events from the current rule session.
-        /// Use it to subscribe to various rules engine lifecycle events.
-        /// </summary>
-        IEventProvider Events { get; }
-
-        /// <summary>
-        /// Provider of session performance metrics for the current rule session.
-        /// </summary>
-        IMetricsProvider Metrics { get; }
-
-        /// <summary>
-        /// Rules dependency resolver for the current rules session.
-        /// </summary>
-        IDependencyResolver DependencyResolver { get; set; }
-
-        /// <summary>
-        /// Action interceptor for the current rules session.
-        /// If provided, invocation of rule actions is delegated to the interceptor.
-        /// </summary>
-        IActionInterceptor ActionInterceptor { get; set; }
-
-        /// <summary>
-        /// Inserts new facts to the rules engine memory.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="facts">Facts to insert.</param>
-        /// <exception cref="ArgumentException">If any fact already exists in working memory.</exception>
-        void InsertAll(IEnumerable<object> facts);
-
-        /// <summary>
-        /// Inserts new facts to the rules engine memory if the facts don't exist.
-        /// If any of the facts exists in the engine, none of the facts are inserted.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="facts">Facts to insert.</param>
-        /// <returns>Result of facts insertion.</returns>
-        IFactResult TryInsertAll(IEnumerable<object> facts);
-
-        /// <summary>
-        /// Inserts new facts to the rules engine memory if the facts don't exist.
-        /// If any of the facts exists in the engine, the behavior is defined by <see cref="BatchOptions"/>.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="facts">Facts to insert.</param>
-        /// <param name="options">Options that define behavior of the batch operation.</param>
-        /// <returns>Result of facts insertion.</returns>
-        IFactResult TryInsertAll(IEnumerable<object> facts, BatchOptions options);
-
-        /// <summary>
-        /// Inserts new fact to the rules engine memory.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="fact">Facts to insert.</param>
-        /// <exception cref="ArgumentException">If fact already exists in working memory.</exception>
-        void Insert(object fact);
-
-        /// <summary>
-        /// Inserts a fact to the rules engine memory if the fact does not exist.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="fact">Fact to insert.</param>
-        /// <returns>Whether the fact was inserted or not.</returns>
-        bool TryInsert(object fact);
-
-        /// <summary>
-        /// Updates existing facts in the rules engine memory.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="facts">Facts to update.</param>
-        /// <exception cref="ArgumentException">If any fact does not exist in working memory.</exception>
-        void UpdateAll(IEnumerable<object> facts);
-
-        /// <summary>
-        /// Updates existing facts in the rules engine memory if the facts exist.
-        /// If any of the facts don't exist in the engine, none of the facts are updated.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="facts">Facts to update.</param>
-        /// <returns>Result of facts update.</returns>
-        IFactResult TryUpdateAll(IEnumerable<object> facts);
-
-        /// <summary>
-        /// Updates existing facts in the rules engine memory if the facts exist.
-        /// If any of the facts don't exist in the engine, the behavior is defined by <see cref="BatchOptions"/>.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="facts">Facts to update.</param>
-        /// <param name="options">Options that define behavior of the batch operation.</param>
-        /// <returns>Result of facts update.</returns>
-        IFactResult TryUpdateAll(IEnumerable<object> facts, BatchOptions options);
-
-        /// <summary>
-        /// Updates existing fact in the rules engine memory.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="fact">Fact to update.</param>
-        /// <exception cref="ArgumentException">If fact does not exist in working memory.</exception>
-        void Update(object fact);
-
-        /// <summary>
-        /// Updates a fact in the rules engine memory if the fact exists.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="fact">Fact to update.</param>
-        /// <returns>Whether the fact was updated or not.</returns>
-        bool TryUpdate(object fact);
-
-        /// <summary>
-        /// Removes existing facts from the rules engine memory.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="facts">Facts to remove.</param>
-        /// <exception cref="ArgumentException">If any fact does not exist in working memory.</exception>
-        void RetractAll(IEnumerable<object> facts);
-
-        /// <summary>
-        /// Removes existing facts from the rules engine memory if the facts exist.
-        /// If any of the facts don't exist in the engine, none of the facts are removed.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="facts">Facts to remove.</param>
-        /// <returns>Result of facts removal.</returns>
-        IFactResult TryRetractAll(IEnumerable<object> facts);
-
-        /// <summary>
-        /// Removes existing facts from the rules engine memory if the facts exist.
-        /// If any of the facts don't exist in the engine, the behavior is defined by <see cref="BatchOptions"/>.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="facts">Facts to remove.</param>
-        /// <param name="options">Options that define behavior of the batch operation.</param>
-        /// <returns>Result of facts removal.</returns>
-        IFactResult TryRetractAll(IEnumerable<object> facts, BatchOptions options);
-
-        /// <summary>
-        /// Removes existing fact from the rules engine memory.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="fact">Fact to remove.</param>
-        /// <exception cref="ArgumentException">If fact does not exist in working memory.</exception>
-        void Retract(object fact);
-
-        /// <summary>
-        /// Removes a fact from the rules engine memory if the fact exists.
-        /// </summary>
-        /// <remarks>
-        /// Bulk session operations are more performant than individual operations on a set of facts.
-        /// </remarks>
-        /// <param name="facts">Fact to remove.</param>
-        /// <returns>Whether the fact was retracted or not.</returns>
-        bool TryRetract(object facts);
-
-        /// <summary>
-        /// Propagates all queued linked facts.
-        /// </summary>
-        /// <returns>Collection of propagated sets of linked facts.</returns>
-        IEnumerable<ILinkedFactSet> PropagateLinked();
-
-        /// <summary>
-        /// Starts rules execution cycle.
-        /// This method blocks until there are no more rules to fire.
-        /// </summary>
-        /// <returns>Number of rules that fired.</returns>
-        int Fire();
-
-        /// <summary>
-        /// Starts rules execution cycle.
-        /// This method blocks until there are no more rules to fire or cancellation is requested.
-        /// </summary>
-        /// <param name="cancellationToken">Enables cooperative cancellation of the rules execution cycle.</param>
-        /// <returns>Number of rules that fired.</returns>
-        int Fire(CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Starts rules execution cycle.
-        /// This method blocks until maximum number of rules fired or there are no more rules to fire.
-        /// </summary>
-        /// <param name="maxRulesNumber">Maximum number of rules to fire.</param>
-        /// <returns>Number of rules that fired.</returns>
-        int Fire(int maxRulesNumber);
-
-        /// <summary>
-        /// Starts rules execution cycle.
-        /// This method blocks until maximum number of rules fired, cancellation is requested or there are no more rules to fire.
-        /// </summary>
-        /// <param name="maxRulesNumber">Maximum number of rules to fire.</param>
-        /// <param name="cancellationToken">Enables cooperative cancellation of the rules execution cycle.</param>
-        /// <returns>Number of rules that fired.</returns>
-        int Fire(int maxRulesNumber, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Creates a LINQ query to retrieve facts of a given type from the rules engine's memory.
-        /// </summary>
-        /// <typeparam name="TFact">Type of facts to query. Use <see cref="object"/> to query all facts.</typeparam>
-        /// <returns>Queryable working memory of the rules engine.</returns>
-        IQueryable<TFact> Query<TFact>();
+        _network = network;
+        _workingMemory = workingMemory;
+        _agenda = agenda;
+        _eventAggregator = eventAggregator;
+        _metricsAggregator = metricsAggregator;
+        _actionExecutor = actionExecutor;
+        _executionContext = new ExecutionContext(this, _workingMemory, _agenda, _eventAggregator, _metricsAggregator, idGenerator);
+        DependencyResolver = dependencyResolver;
+        ActionInterceptor = actionInterceptor;
+        AutoPropagateLinkedFacts = true;
     }
 
-    internal interface ISessionInternal : ISession
-    {
-        new IAgendaInternal Agenda { get; }
+    public bool AutoPropagateLinkedFacts { get; set; }
+    public IAgenda Agenda => _agenda;
+    public IEventProvider Events => _eventAggregator;
+    public IMetricsProvider Metrics => _metricsAggregator;
+    public IDependencyResolver DependencyResolver { get; set; }
+    public IActionInterceptor ActionInterceptor { get; set; }
 
-        IEnumerable<object> GetLinkedKeys(Activation activation);
-        object GetLinked(Activation activation, object key);
-        void QueueInsertLinked(Activation activation, IEnumerable<KeyValuePair<object, object>> keyedFacts);
-        void QueueUpdateLinked(Activation activation, IEnumerable<KeyValuePair<object, object>> keyedFacts);
-        void QueueRetractLinked(Activation activation, IEnumerable<KeyValuePair<object, object>> keyedFacts);
-        void QueueRetractLinked(Activation activation);
+    IAgendaInternal ISessionInternal.Agenda => _agenda;
+
+    internal void Activate()
+    {
+        _agenda.Initialize(_executionContext);
+        _network.Activate(_executionContext);
     }
 
-    internal sealed class Session : ISessionInternal
+    public void InsertAll(IEnumerable<object> facts)
     {
-        private static readonly ILinkedFactSet[] EmptyLinkedFactResult = Array.Empty<ILinkedFactSet>();
+        var result = TryInsertAll(facts);
+        if (result.FailedCount > 0)
+            throw new ArgumentException("Facts for insert already exist", nameof(facts));
+    }
 
-        private readonly IAgendaInternal _agenda;
-        private readonly INetwork _network;
-        private readonly IWorkingMemory _workingMemory;
-        private readonly IEventAggregator _eventAggregator;
-        private readonly IMetricsAggregator _metricsAggregator;
-        private readonly IActionExecutor _actionExecutor;
-        private readonly IExecutionContext _executionContext;
-        private readonly Queue<LinkedFactSet> _linkedFacts = new();
+    public IFactResult TryInsertAll(IEnumerable<object> facts)
+    {
+        return TryInsertAll(facts, BatchOptions.AllOrNothing);
+    }
 
-        internal Session(
-            INetwork network,
-            IAgendaInternal agenda,
-            IWorkingMemory workingMemory,
-            IEventAggregator eventAggregator,
-            IMetricsAggregator metricsAggregator,
-            IActionExecutor actionExecutor,
-            IIdGenerator idGenerator,
-            IDependencyResolver dependencyResolver,
-            IActionInterceptor actionInterceptor)
+    public IFactResult TryInsertAll(IEnumerable<object> facts, BatchOptions options)
+    {
+        if (facts == null)
+            throw new ArgumentNullException(nameof(facts));
+
+        var failed = new List<object>();
+        var toPropagate = new List<Fact>();
+        foreach (var factObject in facts)
         {
-            _network = network;
-            _workingMemory = workingMemory;
-            _agenda = agenda;
-            _eventAggregator = eventAggregator;
-            _metricsAggregator = metricsAggregator;
-            _actionExecutor = actionExecutor;
-            _executionContext = new ExecutionContext(this, _workingMemory, _agenda, _eventAggregator, _metricsAggregator, idGenerator);
-            DependencyResolver = dependencyResolver;
-            ActionInterceptor = actionInterceptor;
-            AutoPropagateLinkedFacts = true;
-        }
-
-        public bool AutoPropagateLinkedFacts { get; set; }
-        public IAgenda Agenda => _agenda;
-        public IEventProvider Events => _eventAggregator;
-        public IMetricsProvider Metrics => _metricsAggregator;
-        public IDependencyResolver DependencyResolver { get; set; }
-        public IActionInterceptor ActionInterceptor { get; set; }
-
-        IAgendaInternal ISessionInternal.Agenda => _agenda;
-
-        internal void Activate()
-        {
-            _agenda.Initialize(_executionContext);
-            _network.Activate(_executionContext);
-        }
-
-        public void InsertAll(IEnumerable<object> facts)
-        {
-            var result = TryInsertAll(facts);
-            if (result.FailedCount > 0)
-                throw new ArgumentException("Facts for insert already exist", nameof(facts));
-        }
-
-        public IFactResult TryInsertAll(IEnumerable<object> facts)
-        {
-            return TryInsertAll(facts, BatchOptions.AllOrNothing);
-        }
-
-        public IFactResult TryInsertAll(IEnumerable<object> facts, BatchOptions options)
-        {
-            if (facts == null)
-                throw new ArgumentNullException(nameof(facts));
-
-            var failed = new List<object>();
-            var toPropagate = new List<Fact>();
-            foreach (var factObject in facts)
+            var factWrapper = _workingMemory.GetFact(factObject);
+            if (factWrapper == null)
             {
-                var factWrapper = _workingMemory.GetFact(factObject);
-                if (factWrapper == null)
-                {
-                    factWrapper = new Fact(factObject);
-                    toPropagate.Add(factWrapper);
-                }
-                else
-                {
-                    failed.Add(factObject);
-                }
+                factWrapper = new Fact(factObject);
+                toPropagate.Add(factWrapper);
+            }
+            else
+            {
+                failed.Add(factObject);
+            }
+        }
+
+        var result = new FactResult(failed);
+        if (result.FailedCount == 0 || options == BatchOptions.SkipFailed)
+        {
+            foreach (var fact in toPropagate)
+            {
+                _workingMemory.AddFact(fact);
             }
 
-            var result = new FactResult(failed);
-            if (result.FailedCount == 0 || options == BatchOptions.SkipFailed)
+            _network.PropagateAssert(_executionContext, toPropagate);
+
+            PropagateLinked();
+        }
+        return result;
+    }
+
+    public void Insert(object fact)
+    {
+        InsertAll(new[] { fact });
+    }
+
+    public bool TryInsert(object fact)
+    {
+        var result = TryInsertAll(new[] {fact});
+        return result.FailedCount == 0;
+    }
+
+    public void UpdateAll(IEnumerable<object> facts)
+    {
+        var result = TryUpdateAll(facts);
+        if (result.FailedCount > 0)
+            throw new ArgumentException("Facts for update do not exist", nameof(facts));
+    }
+
+    public IFactResult TryUpdateAll(IEnumerable<object> facts)
+    {
+        return TryUpdateAll(facts, BatchOptions.AllOrNothing);
+    }
+
+    public IFactResult TryUpdateAll(IEnumerable<object> facts, BatchOptions options)
+    {
+        if (facts == null)
+            throw new ArgumentNullException(nameof(facts));
+
+        var failed = new List<object>();
+        var toPropagate = new List<Fact>();
+        foreach (var fact in facts)
+        {
+            var factWrapper = _workingMemory.GetFact(fact);
+            if (factWrapper != null && factWrapper.Source == null)
             {
-                foreach (var fact in toPropagate)
-                {
-                    _workingMemory.AddFact(fact);
-                }
-
-                _network.PropagateAssert(_executionContext, toPropagate);
-
-                PropagateLinked();
+                UpdateFact(factWrapper, fact);
+                toPropagate.Add(factWrapper);
             }
-            return result;
-        }
-
-        public void Insert(object fact)
-        {
-            InsertAll(new[] { fact });
-        }
-
-        public bool TryInsert(object fact)
-        {
-            var result = TryInsertAll(new[] {fact});
-            return result.FailedCount == 0;
-        }
-
-        public void UpdateAll(IEnumerable<object> facts)
-        {
-            var result = TryUpdateAll(facts);
-            if (result.FailedCount > 0)
-                throw new ArgumentException("Facts for update do not exist", nameof(facts));
-        }
-
-        public IFactResult TryUpdateAll(IEnumerable<object> facts)
-        {
-            return TryUpdateAll(facts, BatchOptions.AllOrNothing);
-        }
-
-        public IFactResult TryUpdateAll(IEnumerable<object> facts, BatchOptions options)
-        {
-            if (facts == null)
-                throw new ArgumentNullException(nameof(facts));
-
-            var failed = new List<object>();
-            var toPropagate = new List<Fact>();
-            foreach (var fact in facts)
+            else
             {
-                var factWrapper = _workingMemory.GetFact(fact);
-                if (factWrapper != null && factWrapper.Source == null)
-                {
-                    UpdateFact(factWrapper, fact);
-                    toPropagate.Add(factWrapper);
-                }
-                else
-                {
-                    failed.Add(fact);
-                }
+                failed.Add(fact);
             }
+        }
 
-            var result = new FactResult(failed);
-            if (result.FailedCount == 0 || options == BatchOptions.SkipFailed)
+        var result = new FactResult(failed);
+        if (result.FailedCount == 0 || options == BatchOptions.SkipFailed)
+        {
+            foreach (var fact in toPropagate)
             {
-                foreach (var fact in toPropagate)
-                {
-                    _workingMemory.UpdateFact(fact);
-                }
-
-                _network.PropagateUpdate(_executionContext, toPropagate);
-
-                PropagateLinked();
-            }
-            return result;
-        }
-
-        public void Update(object fact)
-        {
-            UpdateAll(new[] {fact});
-        }
-
-        public bool TryUpdate(object fact)
-        {
-            var result = TryUpdateAll(new[] {fact});
-            return result.FailedCount == 0;
-        }
-
-        public void RetractAll(IEnumerable<object> facts)
-        {
-            var result = TryRetractAll(facts);
-            if (result.FailedCount > 0)
-                throw new ArgumentException("Facts for retract do not exist", nameof(facts));
-        }
-
-        public IFactResult TryRetractAll(IEnumerable<object> facts)
-        {
-            return TryRetractAll(facts, BatchOptions.AllOrNothing);
-        }
-
-        public IFactResult TryRetractAll(IEnumerable<object> facts, BatchOptions options)
-        {
-            if (facts == null)
-                throw new ArgumentNullException(nameof(facts));
-
-            var failed = new List<object>();
-            var toPropagate = new List<Fact>();
-            foreach (var fact in facts)
-            {
-                var factWrapper = _workingMemory.GetFact(fact);
-                if (factWrapper != null && factWrapper.Source == null)
-                {
-                    toPropagate.Add(factWrapper);
-                }
-                else
-                {
-                    failed.Add(fact);
-                }
+                _workingMemory.UpdateFact(fact);
             }
 
-            var result = new FactResult(failed);
-            if (result.FailedCount == 0 || options == BatchOptions.SkipFailed)
+            _network.PropagateUpdate(_executionContext, toPropagate);
+
+            PropagateLinked();
+        }
+        return result;
+    }
+
+    public void Update(object fact)
+    {
+        UpdateAll(new[] {fact});
+    }
+
+    public bool TryUpdate(object fact)
+    {
+        var result = TryUpdateAll(new[] {fact});
+        return result.FailedCount == 0;
+    }
+
+    public void RetractAll(IEnumerable<object> facts)
+    {
+        var result = TryRetractAll(facts);
+        if (result.FailedCount > 0)
+            throw new ArgumentException("Facts for retract do not exist", nameof(facts));
+    }
+
+    public IFactResult TryRetractAll(IEnumerable<object> facts)
+    {
+        return TryRetractAll(facts, BatchOptions.AllOrNothing);
+    }
+
+    public IFactResult TryRetractAll(IEnumerable<object> facts, BatchOptions options)
+    {
+        if (facts == null)
+            throw new ArgumentNullException(nameof(facts));
+
+        var failed = new List<object>();
+        var toPropagate = new List<Fact>();
+        foreach (var fact in facts)
+        {
+            var factWrapper = _workingMemory.GetFact(fact);
+            if (factWrapper != null && factWrapper.Source == null)
             {
-                _network.PropagateRetract(_executionContext, toPropagate);
-
-                foreach (var fact in toPropagate)
-                {
-                    _workingMemory.RemoveFact(fact);
-                }
-
-                PropagateLinked();
+                toPropagate.Add(factWrapper);
             }
-            return result;
-        }
-
-        public void Retract(object fact)
-        {
-            RetractAll(new[] {fact});
-        }
-
-        public bool TryRetract(object fact)
-        {
-            var result = TryRetractAll(new[] {fact});
-            return result.FailedCount == 0;
-        }
-
-        public IEnumerable<ILinkedFactSet> PropagateLinked()
-        {
-            if (_linkedFacts.Count == 0)
-                return EmptyLinkedFactResult;
-
-            var factSets = new List<ILinkedFactSet>(_linkedFacts.Count);
-            while (_linkedFacts.Count > 0)
+            else
             {
-                var item = _linkedFacts.Dequeue();
-                factSets.Add(item);
-                switch (item.Action)
-                {
-                    case LinkedFactAction.Insert:
-                        _network.PropagateAssert(_executionContext, item.Facts);
-                        break;
-                    case LinkedFactAction.Update:
-                        _network.PropagateUpdate(_executionContext, item.Facts);
-                        break;
-                    case LinkedFactAction.Retract:
-                        _network.PropagateRetract(_executionContext, item.Facts);
-                        foreach (var fact in item.Facts)
-                        {
-                            _workingMemory.RemoveFact(fact);
-                        }
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException($"Unrecognized linked fact action. Action={item.Action}");
-                }
+                failed.Add(fact);
+            }
+        }
+
+        var result = new FactResult(failed);
+        if (result.FailedCount == 0 || options == BatchOptions.SkipFailed)
+        {
+            _network.PropagateRetract(_executionContext, toPropagate);
+
+            foreach (var fact in toPropagate)
+            {
+                _workingMemory.RemoveFact(fact);
             }
 
-            return factSets;
+            PropagateLinked();
+        }
+        return result;
+    }
+
+    public void Retract(object fact)
+    {
+        RetractAll(new[] {fact});
+    }
+
+    public bool TryRetract(object fact)
+    {
+        var result = TryRetractAll(new[] {fact});
+        return result.FailedCount == 0;
+    }
+
+    public IEnumerable<ILinkedFactSet> PropagateLinked()
+    {
+        if (_linkedFacts.Count == 0)
+            return EmptyLinkedFactResult;
+
+        var factSets = new List<ILinkedFactSet>(_linkedFacts.Count);
+        while (_linkedFacts.Count > 0)
+        {
+            var item = _linkedFacts.Dequeue();
+            factSets.Add(item);
+            switch (item.Action)
+            {
+                case LinkedFactAction.Insert:
+                    _network.PropagateAssert(_executionContext, item.Facts);
+                    break;
+                case LinkedFactAction.Update:
+                    _network.PropagateUpdate(_executionContext, item.Facts);
+                    break;
+                case LinkedFactAction.Retract:
+                    _network.PropagateRetract(_executionContext, item.Facts);
+                    foreach (var fact in item.Facts)
+                    {
+                        _workingMemory.RemoveFact(fact);
+                    }
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException($"Unrecognized linked fact action. Action={item.Action}");
+            }
         }
 
-        public IEnumerable<object> GetLinkedKeys(Activation activation)
-        {
-            var keys = _workingMemory.GetLinkedKeys(activation);
-            return keys;
-        }
+        return factSets;
+    }
 
-        public object GetLinked(Activation activation, object key)
+    public IEnumerable<object> GetLinkedKeys(Activation activation)
+    {
+        var keys = _workingMemory.GetLinkedKeys(activation);
+        return keys;
+    }
+
+    public object GetLinked(Activation activation, object key)
+    {
+        var factWrapper = _workingMemory.GetLinkedFact(activation, key);
+        return factWrapper?.Object;
+    }
+
+    public void QueueInsertLinked(Activation activation, IEnumerable<KeyValuePair<object, object>> keyedFacts)
+    {
+        var toAdd = new List<Tuple<object, Fact>>();
+        var toPropagate = new List<Fact>();
+        foreach (var keyedFact in keyedFacts)
         {
+            var key = keyedFact.Key;
             var factWrapper = _workingMemory.GetLinkedFact(activation, key);
-            return factWrapper?.Object;
+            if (factWrapper != null)
+            {
+                throw new ArgumentException($"Linked fact already exists. Key={key}");
+            }
+            factWrapper = new SyntheticFact(keyedFact.Value);
+            factWrapper.Source = new LinkedFactSource(activation);
+            toAdd.Add(System.Tuple.Create(key, factWrapper));
+            toPropagate.Add(factWrapper);
         }
-
-        public void QueueInsertLinked(Activation activation, IEnumerable<KeyValuePair<object, object>> keyedFacts)
+        foreach (var item in toAdd)
         {
-            var toAdd = new List<Tuple<object, Fact>>();
-            var toPropagate = new List<Fact>();
-            foreach (var keyedFact in keyedFacts)
-            {
-                var key = keyedFact.Key;
-                var factWrapper = _workingMemory.GetLinkedFact(activation, key);
-                if (factWrapper != null)
-                {
-                    throw new ArgumentException($"Linked fact already exists. Key={key}");
-                }
-                factWrapper = new SyntheticFact(keyedFact.Value);
-                factWrapper.Source = new LinkedFactSource(activation);
-                toAdd.Add(System.Tuple.Create(key, factWrapper));
-                toPropagate.Add(factWrapper);
-            }
-            foreach (var item in toAdd)
-            {
-                _workingMemory.AddLinkedFact(activation, item.Item1, item.Item2);
-            }
-
-            LinkedFactSet current;
-            if (_linkedFacts.Count == 0 || (current = _linkedFacts.Peek()).Action != LinkedFactAction.Insert)
-            {
-                current = new LinkedFactSet(LinkedFactAction.Insert);
-                _linkedFacts.Enqueue(current);
-            }
-            current.Facts.AddRange(toPropagate);
+            _workingMemory.AddLinkedFact(activation, item.Item1, item.Item2);
         }
 
-        public void QueueUpdateLinked(Activation activation, IEnumerable<KeyValuePair<object, object>> keyedFacts)
+        LinkedFactSet current;
+        if (_linkedFacts.Count == 0 || (current = _linkedFacts.Peek()).Action != LinkedFactAction.Insert)
         {
-            var toUpdate = new List<Tuple<object, Fact, object>>();
-            var toPropagate = new List<Fact>();
-            foreach (var keyedFact in keyedFacts)
-            {
-                var key = keyedFact.Key;
-                var factWrapper = _workingMemory.GetLinkedFact(activation, key);
-                if (factWrapper == null)
-                {
-                    throw new ArgumentException($"Linked fact does not exist. Key={key}");
-                }
-                factWrapper.Source = new LinkedFactSource(activation);
-                toUpdate.Add(System.Tuple.Create(key, factWrapper, keyedFact.Value));
-                toPropagate.Add(factWrapper);
-            }
-            foreach (var item in toUpdate)
-            {
-                _workingMemory.UpdateLinkedFact(activation, item.Item1, item.Item2, item.Item3);
-            }
-
-            LinkedFactSet current;
-            if (_linkedFacts.Count == 0 || (current = _linkedFacts.Peek()).Action != LinkedFactAction.Update)
-            {
-                current = new LinkedFactSet(LinkedFactAction.Update);
-                _linkedFacts.Enqueue(current);
-            }
-            current.Facts.AddRange(toPropagate);
+            current = new LinkedFactSet(LinkedFactAction.Insert);
+            _linkedFacts.Enqueue(current);
         }
-
-        public void QueueRetractLinked(Activation activation, IEnumerable<KeyValuePair<object, object>> keyedFacts)
-        {
-            var toRemove = new List<Tuple<object, Fact>>();
-            var toPropagate = new List<Fact>();
-            foreach (var keyedFact in keyedFacts)
-            {
-                var key = keyedFact.Key;
-                var factWrapper = _workingMemory.GetFact(keyedFact.Value);
-                if (factWrapper == null)
-                {
-                    throw new ArgumentException($"Linked fact does not exist. Key={key}");
-                }
-                factWrapper.Source = new LinkedFactSource(activation);
-                toRemove.Add(System.Tuple.Create(key, factWrapper));
-                toPropagate.Add(factWrapper);
-            }
-            foreach (var item in toRemove)
-            {
-                _workingMemory.RemoveLinkedFact(activation, item.Item1, item.Item2);
-                item.Item2.Source = null;
-            }
-
-            LinkedFactSet current;
-            if (_linkedFacts.Count == 0 || (current = _linkedFacts.Peek()).Action != LinkedFactAction.Retract)
-            {
-                current = new LinkedFactSet(LinkedFactAction.Retract);
-                _linkedFacts.Enqueue(current);
-            }
-            current.Facts.AddRange(toPropagate);
-        }
-
-        public void QueueRetractLinked(Activation activation)
-        {
-            var linkedKeys = GetLinkedKeys(activation);
-            var keyedFacts = new List<KeyValuePair<object, object>>();
-            foreach (var key in linkedKeys)
-            {
-                var linkedFact = GetLinked(activation, key);
-                keyedFacts.Add(new KeyValuePair<object, object>(key, linkedFact));
-            }
-            QueueRetractLinked(activation, keyedFacts);
-        }
-
-        public int Fire()
-        {
-            return Fire(default(CancellationToken));
-        }
-
-        public int Fire(CancellationToken cancellationToken)
-        {
-            return Fire(Int32.MaxValue, cancellationToken);
-        }
-
-        public int Fire(int maxRulesNumber)
-        {
-            return Fire(maxRulesNumber, default);
-        }
-
-        public int Fire(int maxRulesNumber, CancellationToken cancellationToken)
-        {
-            int ruleFiredCount = 0;
-            while (!_agenda.IsEmpty && ruleFiredCount < maxRulesNumber)
-            {
-                Activation activation = _agenda.Pop();
-                IActionContext actionContext = new ActionContext(this, activation, cancellationToken);
-
-                try
-                {
-                    _actionExecutor.Execute(_executionContext, actionContext);
-                }
-                finally
-                {
-                    ruleFiredCount++;
-                    if (AutoPropagateLinkedFacts) PropagateLinked();
-                }
-
-                if (actionContext.IsHalted || cancellationToken.IsCancellationRequested) break;
-            }
-            return ruleFiredCount;
-        }
-
-        public IQueryable<TFact> Query<TFact>()
-        {
-            return _workingMemory.Facts.Select(x => x.Object).OfType<TFact>().AsQueryable();
-        }
-
-        private static void UpdateFact(Fact fact, object factObject)
-        {
-            if (ReferenceEquals(fact.RawObject, factObject)) return;
-            fact.RawObject = factObject;
-        }
-
-        ReteGraph ISessionSchemaProvider.GetSchema() => _network.GetSchema();
+        current.Facts.AddRange(toPropagate);
     }
+
+    public void QueueUpdateLinked(Activation activation, IEnumerable<KeyValuePair<object, object>> keyedFacts)
+    {
+        var toUpdate = new List<Tuple<object, Fact, object>>();
+        var toPropagate = new List<Fact>();
+        foreach (var keyedFact in keyedFacts)
+        {
+            var key = keyedFact.Key;
+            var factWrapper = _workingMemory.GetLinkedFact(activation, key);
+            if (factWrapper == null)
+            {
+                throw new ArgumentException($"Linked fact does not exist. Key={key}");
+            }
+            factWrapper.Source = new LinkedFactSource(activation);
+            toUpdate.Add(System.Tuple.Create(key, factWrapper, keyedFact.Value));
+            toPropagate.Add(factWrapper);
+        }
+        foreach (var item in toUpdate)
+        {
+            _workingMemory.UpdateLinkedFact(activation, item.Item1, item.Item2, item.Item3);
+        }
+
+        LinkedFactSet current;
+        if (_linkedFacts.Count == 0 || (current = _linkedFacts.Peek()).Action != LinkedFactAction.Update)
+        {
+            current = new LinkedFactSet(LinkedFactAction.Update);
+            _linkedFacts.Enqueue(current);
+        }
+        current.Facts.AddRange(toPropagate);
+    }
+
+    public void QueueRetractLinked(Activation activation, IEnumerable<KeyValuePair<object, object>> keyedFacts)
+    {
+        var toRemove = new List<Tuple<object, Fact>>();
+        var toPropagate = new List<Fact>();
+        foreach (var keyedFact in keyedFacts)
+        {
+            var key = keyedFact.Key;
+            var factWrapper = _workingMemory.GetFact(keyedFact.Value);
+            if (factWrapper == null)
+            {
+                throw new ArgumentException($"Linked fact does not exist. Key={key}");
+            }
+            factWrapper.Source = new LinkedFactSource(activation);
+            toRemove.Add(System.Tuple.Create(key, factWrapper));
+            toPropagate.Add(factWrapper);
+        }
+        foreach (var item in toRemove)
+        {
+            _workingMemory.RemoveLinkedFact(activation, item.Item1, item.Item2);
+            item.Item2.Source = null;
+        }
+
+        LinkedFactSet current;
+        if (_linkedFacts.Count == 0 || (current = _linkedFacts.Peek()).Action != LinkedFactAction.Retract)
+        {
+            current = new LinkedFactSet(LinkedFactAction.Retract);
+            _linkedFacts.Enqueue(current);
+        }
+        current.Facts.AddRange(toPropagate);
+    }
+
+    public void QueueRetractLinked(Activation activation)
+    {
+        var linkedKeys = GetLinkedKeys(activation);
+        var keyedFacts = new List<KeyValuePair<object, object>>();
+        foreach (var key in linkedKeys)
+        {
+            var linkedFact = GetLinked(activation, key);
+            keyedFacts.Add(new KeyValuePair<object, object>(key, linkedFact));
+        }
+        QueueRetractLinked(activation, keyedFacts);
+    }
+
+    public int Fire()
+    {
+        return Fire(default(CancellationToken));
+    }
+
+    public int Fire(CancellationToken cancellationToken)
+    {
+        return Fire(Int32.MaxValue, cancellationToken);
+    }
+
+    public int Fire(int maxRulesNumber)
+    {
+        return Fire(maxRulesNumber, default);
+    }
+
+    public int Fire(int maxRulesNumber, CancellationToken cancellationToken)
+    {
+        int ruleFiredCount = 0;
+        while (!_agenda.IsEmpty && ruleFiredCount < maxRulesNumber)
+        {
+            Activation activation = _agenda.Pop();
+            IActionContext actionContext = new ActionContext(this, activation, cancellationToken);
+
+            try
+            {
+                _actionExecutor.Execute(_executionContext, actionContext);
+            }
+            finally
+            {
+                ruleFiredCount++;
+                if (AutoPropagateLinkedFacts) PropagateLinked();
+            }
+
+            if (actionContext.IsHalted || cancellationToken.IsCancellationRequested) break;
+        }
+        return ruleFiredCount;
+    }
+
+    public IQueryable<TFact> Query<TFact>()
+    {
+        return _workingMemory.Facts.Select(x => x.Object).OfType<TFact>().AsQueryable();
+    }
+
+    private static void UpdateFact(Fact fact, object factObject)
+    {
+        if (ReferenceEquals(fact.RawObject, factObject)) return;
+        fact.RawObject = factObject;
+    }
+
+    ReteGraph ISessionSchemaProvider.GetSchema() => _network.GetSchema();
 }

--- a/src/NRules/NRules/SessionFactory.cs
+++ b/src/NRules/NRules/SessionFactory.cs
@@ -6,141 +6,140 @@ using NRules.Diagnostics;
 using NRules.Extensibility;
 using NRules.Rete;
 
-namespace NRules
+namespace NRules;
+
+/// <summary>
+/// Represents compiled production rules that can be used to create rules sessions.
+/// Created by <see cref="RuleCompiler"/> by compiling rule model into an executable form.
+/// </summary>
+/// <remarks>
+/// Session factory is expensive to create (because rules need to be compiled into an executable form).
+/// Therefore there needs to be only a single instance of session factory for a given set of rules for the lifetime of the application.
+/// If repeatedly running rules for different sets of facts, don't create a new session factory for each rules run.
+/// Instead, have a single session factory and create a new rules session for each independent universe of facts.
+/// </remarks>
+/// <event cref="IEventProvider.FactInsertingEvent">Before processing fact insertion.</event>
+/// <event cref="IEventProvider.FactInsertedEvent">After processing fact insertion.</event>
+/// <event cref="IEventProvider.FactUpdatingEvent">Before processing fact update.</event>
+/// <event cref="IEventProvider.FactUpdatedEvent">After processing fact update.</event>
+/// <event cref="IEventProvider.FactRetractingEvent">Before processing fact retraction.</event>
+/// <event cref="IEventProvider.FactRetractedEvent">After processing fact retraction.</event>
+/// <event cref="IEventProvider.ActivationCreatedEvent">When a set of facts matches a rule.</event>
+/// <event cref="IEventProvider.ActivationUpdatedEvent">When a set of facts is updated and re-matches a rule.</event>
+/// <event cref="IEventProvider.ActivationDeletedEvent">When a set of facts no longer matches a rule.</event>
+/// <event cref="IEventProvider.RuleFiringEvent">Before rule's actions are executed.</event>
+/// <event cref="IEventProvider.RuleFiredEvent">After rule's actions are executed.</event>
+/// <event cref="IEventProvider.LhsExpressionEvaluatedEvent">When an left-hand side expression was evaluated.</event>
+/// <event cref="IEventProvider.LhsExpressionFailedEvent">When there is an error during left-hand side expression evaluation,
+/// before throwing exception to the client.</event>
+/// <event cref="IEventProvider.AgendaExpressionEvaluatedEvent">When an agenda expression was evaluated.</event>
+/// <event cref="IEventProvider.AgendaExpressionFailedEvent">When there is an error during agenda expression evaluation,
+/// before throwing exception to the client.</event>
+/// <event cref="IEventProvider.RhsExpressionEvaluatedEvent">When an right-hand side expression was evaluated.</event>
+/// <event cref="IEventProvider.RhsExpressionFailedEvent">When there is an error during right-hand side expression evaluation,
+/// before throwing exception to the client.</event>
+/// <seealso cref="ISession"/>
+/// <seealso cref="RuleCompiler"/>
+/// <threadsafety instance="true" />
+public interface ISessionFactory : ISessionSchemaProvider
 {
     /// <summary>
-    /// Represents compiled production rules that can be used to create rules sessions.
-    /// Created by <see cref="RuleCompiler"/> by compiling rule model into an executable form.
+    /// Provider of events aggregated across all rule sessions. 
+    /// Event sender is used to convey the session instance responsible for the event.
+    /// Use it to subscribe to various rules engine lifecycle events.
     /// </summary>
-    /// <remarks>
-    /// Session factory is expensive to create (because rules need to be compiled into an executable form).
-    /// Therefore there needs to be only a single instance of session factory for a given set of rules for the lifetime of the application.
-    /// If repeatedly running rules for different sets of facts, don't create a new session factory for each rules run.
-    /// Instead, have a single session factory and create a new rules session for each independent universe of facts.
-    /// </remarks>
-    /// <event cref="IEventProvider.FactInsertingEvent">Before processing fact insertion.</event>
-    /// <event cref="IEventProvider.FactInsertedEvent">After processing fact insertion.</event>
-    /// <event cref="IEventProvider.FactUpdatingEvent">Before processing fact update.</event>
-    /// <event cref="IEventProvider.FactUpdatedEvent">After processing fact update.</event>
-    /// <event cref="IEventProvider.FactRetractingEvent">Before processing fact retraction.</event>
-    /// <event cref="IEventProvider.FactRetractedEvent">After processing fact retraction.</event>
-    /// <event cref="IEventProvider.ActivationCreatedEvent">When a set of facts matches a rule.</event>
-    /// <event cref="IEventProvider.ActivationUpdatedEvent">When a set of facts is updated and re-matches a rule.</event>
-    /// <event cref="IEventProvider.ActivationDeletedEvent">When a set of facts no longer matches a rule.</event>
-    /// <event cref="IEventProvider.RuleFiringEvent">Before rule's actions are executed.</event>
-    /// <event cref="IEventProvider.RuleFiredEvent">After rule's actions are executed.</event>
-    /// <event cref="IEventProvider.LhsExpressionEvaluatedEvent">When an left-hand side expression was evaluated.</event>
-    /// <event cref="IEventProvider.LhsExpressionFailedEvent">When there is an error during left-hand side expression evaluation,
-    /// before throwing exception to the client.</event>
-    /// <event cref="IEventProvider.AgendaExpressionEvaluatedEvent">When an agenda expression was evaluated.</event>
-    /// <event cref="IEventProvider.AgendaExpressionFailedEvent">When there is an error during agenda expression evaluation,
-    /// before throwing exception to the client.</event>
-    /// <event cref="IEventProvider.RhsExpressionEvaluatedEvent">When an right-hand side expression was evaluated.</event>
-    /// <event cref="IEventProvider.RhsExpressionFailedEvent">When there is an error during right-hand side expression evaluation,
-    /// before throwing exception to the client.</event>
-    /// <seealso cref="ISession"/>
-    /// <seealso cref="RuleCompiler"/>
-    /// <threadsafety instance="true" />
-    public interface ISessionFactory : ISessionSchemaProvider
+    IEventProvider Events { get; }
+
+    /// <summary>
+    /// Rules dependency resolver for all rules sessions.
+    /// </summary>
+    IDependencyResolver DependencyResolver { get; set; }
+
+    /// <summary>
+    /// Action interceptor for all rules sessions.
+    /// If provided, invocation of rule actions is delegated to the interceptor.
+    /// </summary>
+    IActionInterceptor ActionInterceptor { get; set; }
+
+    /// <summary>
+    /// Creates a new rules session.
+    /// </summary>
+    /// <returns>New rules session.</returns>
+    ISession CreateSession();
+
+    /// <summary>
+    /// Creates a new rules session.
+    /// </summary>
+    /// <param name="initializationAction">Action invoked on the newly created session, before the session is activated (which could result in rule matches placed on the agenda).</param>
+    /// <returns>New rules session.</returns>
+    ISession CreateSession(Action<ISession> initializationAction);
+}
+
+internal sealed class SessionFactory : ISessionFactory
+{
+    private readonly INetwork _network;
+    private readonly List<ICompiledRule> _compiledRules;
+    private readonly IEventAggregator _eventAggregator = new EventAggregator();
+
+    public SessionFactory(INetwork network, IEnumerable<ICompiledRule> compiledRules)
     {
-        /// <summary>
-        /// Provider of events aggregated across all rule sessions. 
-        /// Event sender is used to convey the session instance responsible for the event.
-        /// Use it to subscribe to various rules engine lifecycle events.
-        /// </summary>
-        IEventProvider Events { get; }
-
-        /// <summary>
-        /// Rules dependency resolver for all rules sessions.
-        /// </summary>
-        IDependencyResolver DependencyResolver { get; set; }
-
-        /// <summary>
-        /// Action interceptor for all rules sessions.
-        /// If provided, invocation of rule actions is delegated to the interceptor.
-        /// </summary>
-        IActionInterceptor ActionInterceptor { get; set; }
-
-        /// <summary>
-        /// Creates a new rules session.
-        /// </summary>
-        /// <returns>New rules session.</returns>
-        ISession CreateSession();
-
-        /// <summary>
-        /// Creates a new rules session.
-        /// </summary>
-        /// <param name="initializationAction">Action invoked on the newly created session, before the session is activated (which could result in rule matches placed on the agenda).</param>
-        /// <returns>New rules session.</returns>
-        ISession CreateSession(Action<ISession> initializationAction);
+        _network = network;
+        _compiledRules = new List<ICompiledRule>(compiledRules);
+        DependencyResolver = new DependencyResolver();
     }
 
-    internal sealed class SessionFactory : ISessionFactory
+    public IEventProvider Events => _eventAggregator;
+    public IDependencyResolver DependencyResolver { get; set; }
+    public IActionInterceptor ActionInterceptor { get; set; }
+
+    public ISession CreateSession()
     {
-        private readonly INetwork _network;
-        private readonly List<ICompiledRule> _compiledRules;
-        private readonly IEventAggregator _eventAggregator = new EventAggregator();
-
-        public SessionFactory(INetwork network, IEnumerable<ICompiledRule> compiledRules)
-        {
-            _network = network;
-            _compiledRules = new List<ICompiledRule>(compiledRules);
-            DependencyResolver = new DependencyResolver();
-        }
-
-        public IEventProvider Events => _eventAggregator;
-        public IDependencyResolver DependencyResolver { get; set; }
-        public IActionInterceptor ActionInterceptor { get; set; }
-
-        public ISession CreateSession()
-        {
-            return CreateSession(null);
-        }
-
-        public ISession CreateSession(Action<ISession> initializationAction)
-        {
-            var agenda = CreateAgenda();
-            var workingMemory = new WorkingMemory();
-            var eventAggregator = new EventAggregator(_eventAggregator);
-            var metricsAggregator = new MetricsAggregator();
-            var actionExecutor = new ActionExecutor();
-            var idGenerator = new IdGenerator();
-            var session = new Session(_network, agenda, workingMemory, eventAggregator, metricsAggregator, actionExecutor, idGenerator, DependencyResolver, ActionInterceptor);
-            initializationAction?.Invoke(session);
-            session.Activate();
-            return session;
-        }
-
-        private IAgendaInternal CreateAgenda()
-        {
-            var agenda = new Agenda();
-            foreach (var compiledRule in _compiledRules)
-            {
-                var ruleFilters = CreateRuleFilters(compiledRule).ToArray();
-                foreach (var filter in ruleFilters)
-                {
-                    agenda.AddFilter(compiledRule.Definition, filter);
-                }
-            }
-            return agenda;
-        }
-
-        private static IEnumerable<IAgendaFilter> CreateRuleFilters(ICompiledRule compiledRule)
-        {
-            var filterConditions = compiledRule.Filter.Conditions.ToList();
-            if (filterConditions.Any())
-            {
-                var filter = new PredicateAgendaFilter(filterConditions);
-                yield return filter;
-            }
-            var filterKeySelectors = compiledRule.Filter.KeySelectors.ToList();
-            if (filterKeySelectors.Any())
-            {
-                var filter = new KeyChangeAgendaFilter(filterKeySelectors);
-                yield return filter;
-            }
-        }
-
-        ReteGraph ISessionSchemaProvider.GetSchema() => _network.GetSchema();
+        return CreateSession(null);
     }
+
+    public ISession CreateSession(Action<ISession> initializationAction)
+    {
+        var agenda = CreateAgenda();
+        var workingMemory = new WorkingMemory();
+        var eventAggregator = new EventAggregator(_eventAggregator);
+        var metricsAggregator = new MetricsAggregator();
+        var actionExecutor = new ActionExecutor();
+        var idGenerator = new IdGenerator();
+        var session = new Session(_network, agenda, workingMemory, eventAggregator, metricsAggregator, actionExecutor, idGenerator, DependencyResolver, ActionInterceptor);
+        initializationAction?.Invoke(session);
+        session.Activate();
+        return session;
+    }
+
+    private IAgendaInternal CreateAgenda()
+    {
+        var agenda = new Agenda();
+        foreach (var compiledRule in _compiledRules)
+        {
+            var ruleFilters = CreateRuleFilters(compiledRule).ToArray();
+            foreach (var filter in ruleFilters)
+            {
+                agenda.AddFilter(compiledRule.Definition, filter);
+            }
+        }
+        return agenda;
+    }
+
+    private static IEnumerable<IAgendaFilter> CreateRuleFilters(ICompiledRule compiledRule)
+    {
+        var filterConditions = compiledRule.Filter.Conditions.ToList();
+        if (filterConditions.Any())
+        {
+            var filter = new PredicateAgendaFilter(filterConditions);
+            yield return filter;
+        }
+        var filterKeySelectors = compiledRule.Filter.KeySelectors.ToList();
+        if (filterKeySelectors.Any())
+        {
+            var filter = new KeyChangeAgendaFilter(filterKeySelectors);
+            yield return filter;
+        }
+    }
+
+    ReteGraph ISessionSchemaProvider.GetSchema() => _network.GetSchema();
 }

--- a/src/NRules/NRules/Utilities/ArgumentMap.cs
+++ b/src/NRules/NRules/Utilities/ArgumentMap.cs
@@ -1,22 +1,21 @@
 using NRules.Rete;
 
-namespace NRules.Utilities
+namespace NRules.Utilities;
+
+internal interface IArgumentMap
 {
-    internal interface IArgumentMap
+    IndexMap FactMap { get; }
+    int Count { get; }
+}
+
+internal class ArgumentMap : IArgumentMap
+{
+    public ArgumentMap(IndexMap factMap, int count)
     {
-        IndexMap FactMap { get; }
-        int Count { get; }
+        FactMap = factMap;
+        Count = count;
     }
 
-    internal class ArgumentMap : IArgumentMap
-    {
-        public ArgumentMap(IndexMap factMap, int count)
-        {
-            FactMap = factMap;
-            Count = count;
-        }
-
-        public IndexMap FactMap { get; }
-        public int Count { get; }
-    }
+    public IndexMap FactMap { get; }
+    public int Count { get; }
 }

--- a/src/NRules/NRules/Utilities/Arguments.cs
+++ b/src/NRules/NRules/Utilities/Arguments.cs
@@ -1,71 +1,33 @@
 ﻿using NRules.Rete;
 
-namespace NRules.Utilities
+namespace NRules.Utilities;
+
+internal interface IArguments
 {
-    internal interface IArguments
+    object[] GetValues();
+}
+
+internal class LhsExpressionArguments : IArguments
+{
+    private readonly IArgumentMap _argumentMap;
+    private readonly Tuple _tuple;
+    private readonly Fact _fact;
+
+    public LhsExpressionArguments(IArgumentMap argumentMap, Tuple tuple, Fact fact)
     {
-        object[] GetValues();
+        _argumentMap = argumentMap;
+        _tuple = tuple;
+        _fact = fact;
     }
 
-    internal class LhsExpressionArguments : IArguments
+    public object[] GetValues()
     {
-        private readonly IArgumentMap _argumentMap;
-        private readonly Tuple _tuple;
-        private readonly Fact _fact;
+        var args = new object[_argumentMap.Count];
 
-        public LhsExpressionArguments(IArgumentMap argumentMap, Tuple tuple, Fact fact)
+        if (_tuple != null)
         {
-            _argumentMap = argumentMap;
-            _tuple = tuple;
-            _fact = fact;
-        }
-
-        public object[] GetValues()
-        {
-            var args = new object[_argumentMap.Count];
-
-            if (_tuple != null)
-            {
-                var index = _tuple.Count - 1;
-                var enumerable = _tuple.GetEnumerator();
-                while (enumerable.MoveNext())
-                {
-                    var mappedIndex = _argumentMap.FactMap[index];
-                    if (mappedIndex >= 0)
-                        args[mappedIndex] = enumerable.Current.Object;
-
-                    index--;
-                }
-            }
-
-            if (_fact != null)
-            {
-                var mappedIndex = _argumentMap.FactMap[_argumentMap.Count - 1];
-                if (mappedIndex >= 0)
-                    args[mappedIndex] = _fact.Object;
-            }
-
-            return args;
-        }
-    }
-
-    internal class ActivationExpressionArguments : IArguments
-    {
-        private readonly IArgumentMap _argumentMap;
-        private readonly Activation _activation;
-
-        public ActivationExpressionArguments(IArgumentMap argumentMap, Activation activation)
-        {
-            _argumentMap = argumentMap;
-            _activation = activation;
-        }
-
-        public object[] GetValues()
-        {
-            var args = new object[_argumentMap.Count];
-
-            var index = _activation.Tuple.Count - 1;
-            var enumerable = _activation.Tuple.GetEnumerator();
+            var index = _tuple.Count - 1;
+            var enumerable = _tuple.GetEnumerator();
             while (enumerable.MoveNext())
             {
                 var mappedIndex = _argumentMap.FactMap[index];
@@ -74,8 +36,45 @@ namespace NRules.Utilities
 
                 index--;
             }
-
-            return args;
         }
+
+        if (_fact != null)
+        {
+            var mappedIndex = _argumentMap.FactMap[_argumentMap.Count - 1];
+            if (mappedIndex >= 0)
+                args[mappedIndex] = _fact.Object;
+        }
+
+        return args;
+    }
+}
+
+internal class ActivationExpressionArguments : IArguments
+{
+    private readonly IArgumentMap _argumentMap;
+    private readonly Activation _activation;
+
+    public ActivationExpressionArguments(IArgumentMap argumentMap, Activation activation)
+    {
+        _argumentMap = argumentMap;
+        _activation = activation;
+    }
+
+    public object[] GetValues()
+    {
+        var args = new object[_argumentMap.Count];
+
+        var index = _activation.Tuple.Count - 1;
+        var enumerable = _activation.Tuple.GetEnumerator();
+        while (enumerable.MoveNext())
+        {
+            var mappedIndex = _argumentMap.FactMap[index];
+            if (mappedIndex >= 0)
+                args[mappedIndex] = enumerable.Current.Object;
+
+            index--;
+        }
+
+        return args;
     }
 }

--- a/src/NRules/NRules/Utilities/EnumerableExtensions.cs
+++ b/src/NRules/NRules/Utilities/EnumerableExtensions.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace NRules.Utilities
+namespace NRules.Utilities;
+
+internal static class EnumerableExtensions
 {
-    internal static class EnumerableExtensions
+    public static IEnumerable<T> Concat<T>(this IEnumerable<T> source, T element)
     {
-        public static IEnumerable<T> Concat<T>(this IEnumerable<T> source, T element)
-        {
-            return source.Concat(Enumerable.Repeat(element, 1));
-        }
+        return source.Concat(Enumerable.Repeat(element, 1));
     }
 }

--- a/src/NRules/NRules/Utilities/ExpressionComparer.cs
+++ b/src/NRules/NRules/Utilities/ExpressionComparer.cs
@@ -4,233 +4,232 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace NRules.Utilities
+namespace NRules.Utilities;
+
+internal class ExpressionComparer
 {
-    internal class ExpressionComparer
+    private readonly RuleCompilerOptions _compilerOptions;
+
+    public ExpressionComparer(RuleCompilerOptions compilerOptions)
     {
-        private readonly RuleCompilerOptions _compilerOptions;
+        _compilerOptions = compilerOptions;
+    }
 
-        public ExpressionComparer(RuleCompilerOptions compilerOptions)
+    public bool AreEqual(Expression x, Expression y)
+    {
+        return ExpressionEqual(x, y, null, null);
+    }
+
+    private bool ExpressionEqual(Expression x, Expression y, LambdaExpression rootX, LambdaExpression rootY)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x == null || y == null) return false;
+        if (x.NodeType != y.NodeType || x.Type != y.Type) return false;
+
+        switch (x)
         {
-            _compilerOptions = compilerOptions;
-        }
-
-        public bool AreEqual(Expression x, Expression y)
-        {
-            return ExpressionEqual(x, y, null, null);
-        }
-
-        private bool ExpressionEqual(Expression x, Expression y, LambdaExpression rootX, LambdaExpression rootY)
-        {
-            if (ReferenceEquals(x, y)) return true;
-            if (x == null || y == null) return false;
-            if (x.NodeType != y.NodeType || x.Type != y.Type) return false;
-
-            switch (x)
+            case LambdaExpression lx:
             {
-                case LambdaExpression lx:
-                {
-                    var ly = (LambdaExpression)y;
-                    var paramsX = lx.Parameters;
-                    var paramsY = ly.Parameters;
-                    return CollectionsEqual(paramsX, paramsY, lx, ly) && ExpressionEqual(lx.Body, ly.Body, lx, ly);
-                }
-                case MemberExpression mex:
-                {
-                    var mey = (MemberExpression)y;
-                    return MemberExpressionsEqual(mex, mey, rootX, rootY);
-                }
-                case BinaryExpression bx:
-                {
-                    var by = (BinaryExpression)y;
-                    return bx.Method == @by.Method && ExpressionEqual(bx.Left, @by.Left, rootX, rootY) &&
-                           ExpressionEqual(bx.Right, @by.Right, rootX, rootY);
-                }
-                case UnaryExpression ux:
-                {
-                    var uy = (UnaryExpression)y;
-                    return ux.Method == uy.Method && ExpressionEqual(ux.Operand, uy.Operand, rootX, rootY);
-                }
-                case ParameterExpression px:
-                {
-                    var py = (ParameterExpression)y;
-                    return rootX.Parameters.IndexOf(px) == rootY.Parameters.IndexOf(py);
-                }
-                case MethodCallExpression cx:
-                {
-                    var cy = (MethodCallExpression)y;
-                    return cx.Method == cy.Method
-                           && ExpressionEqual(cx.Object, cy.Object, rootX, rootY)
-                           && CollectionsEqual(cx.Arguments, cy.Arguments, rootX, rootY);
-                }
-                case InvocationExpression ix:
-                {
-                    var iy = (InvocationExpression)y;
-                    return ExpressionEqual(ix.Expression, iy.Expression, rootX, rootY)
-                           && CollectionsEqual(ix.Arguments, iy.Arguments, rootX, rootY);
-                }
-                case NewExpression nx:
-                {
-                    var ny = (NewExpression)y;
-                    return nx.Constructor == ny.Constructor
-                           && CollectionsEqual(nx.Arguments, ny.Arguments, rootX, rootY);
-                }
-                case MemberInitExpression mix:
-                {
-                    var miy = (MemberInitExpression)y;
-                    return ExpressionEqual(mix.NewExpression, miy.NewExpression, rootX, rootY)
-                           && MemberBindingCollectionsEqual(mix.Bindings, miy.Bindings, rootX, rootY);
-                }
-                case ListInitExpression lix:
-                {
-                    var liy = (ListInitExpression)y;
-                    return ExpressionEqual(lix.NewExpression, liy.NewExpression, rootX, rootY)
-                           && ElementInitCollectionsEqual(lix.Initializers, liy.Initializers, rootX, rootY);
-                }
-                case ConstantExpression cx:
-                {
-                    var cy = (ConstantExpression)y;
-                    return Equals(cx.Value, cy.Value);
-                }
-                case TypeBinaryExpression tbx:
-                {
-                    var tby = (TypeBinaryExpression)y;
-                    return tbx.TypeOperand == tby.TypeOperand;
-                }
-                case ConditionalExpression cx:
-                {
-                    var cy = (ConditionalExpression)y;
-                    return ExpressionEqual(cx.Test, cy.Test, rootX, rootY)
-                           && ExpressionEqual(cx.IfTrue, cy.IfTrue, rootX, rootY)
-                           && ExpressionEqual(cx.IfFalse, cy.IfFalse, rootX, rootY);
-                }
-                case NewArrayExpression ax:
-                {
-                    var ay = (NewArrayExpression) y;
-                    return ax.Type == ay.Type && CollectionsEqual(ax.Expressions, ay.Expressions, rootX, rootY);
-                }
-                case DefaultExpression dx:
-                {
-                    var dy = (DefaultExpression) y;
-                    return dx.Type == dy.Type;
-                }
-                default:
-                    return HandleUnsupportedExpression(x.ToString());
+                var ly = (LambdaExpression)y;
+                var paramsX = lx.Parameters;
+                var paramsY = ly.Parameters;
+                return CollectionsEqual(paramsX, paramsY, lx, ly) && ExpressionEqual(lx.Body, ly.Body, lx, ly);
             }
+            case MemberExpression mex:
+            {
+                var mey = (MemberExpression)y;
+                return MemberExpressionsEqual(mex, mey, rootX, rootY);
+            }
+            case BinaryExpression bx:
+            {
+                var by = (BinaryExpression)y;
+                return bx.Method == @by.Method && ExpressionEqual(bx.Left, @by.Left, rootX, rootY) &&
+                       ExpressionEqual(bx.Right, @by.Right, rootX, rootY);
+            }
+            case UnaryExpression ux:
+            {
+                var uy = (UnaryExpression)y;
+                return ux.Method == uy.Method && ExpressionEqual(ux.Operand, uy.Operand, rootX, rootY);
+            }
+            case ParameterExpression px:
+            {
+                var py = (ParameterExpression)y;
+                return rootX.Parameters.IndexOf(px) == rootY.Parameters.IndexOf(py);
+            }
+            case MethodCallExpression cx:
+            {
+                var cy = (MethodCallExpression)y;
+                return cx.Method == cy.Method
+                       && ExpressionEqual(cx.Object, cy.Object, rootX, rootY)
+                       && CollectionsEqual(cx.Arguments, cy.Arguments, rootX, rootY);
+            }
+            case InvocationExpression ix:
+            {
+                var iy = (InvocationExpression)y;
+                return ExpressionEqual(ix.Expression, iy.Expression, rootX, rootY)
+                       && CollectionsEqual(ix.Arguments, iy.Arguments, rootX, rootY);
+            }
+            case NewExpression nx:
+            {
+                var ny = (NewExpression)y;
+                return nx.Constructor == ny.Constructor
+                       && CollectionsEqual(nx.Arguments, ny.Arguments, rootX, rootY);
+            }
+            case MemberInitExpression mix:
+            {
+                var miy = (MemberInitExpression)y;
+                return ExpressionEqual(mix.NewExpression, miy.NewExpression, rootX, rootY)
+                       && MemberBindingCollectionsEqual(mix.Bindings, miy.Bindings, rootX, rootY);
+            }
+            case ListInitExpression lix:
+            {
+                var liy = (ListInitExpression)y;
+                return ExpressionEqual(lix.NewExpression, liy.NewExpression, rootX, rootY)
+                       && ElementInitCollectionsEqual(lix.Initializers, liy.Initializers, rootX, rootY);
+            }
+            case ConstantExpression cx:
+            {
+                var cy = (ConstantExpression)y;
+                return Equals(cx.Value, cy.Value);
+            }
+            case TypeBinaryExpression tbx:
+            {
+                var tby = (TypeBinaryExpression)y;
+                return tbx.TypeOperand == tby.TypeOperand;
+            }
+            case ConditionalExpression cx:
+            {
+                var cy = (ConditionalExpression)y;
+                return ExpressionEqual(cx.Test, cy.Test, rootX, rootY)
+                       && ExpressionEqual(cx.IfTrue, cy.IfTrue, rootX, rootY)
+                       && ExpressionEqual(cx.IfFalse, cy.IfFalse, rootX, rootY);
+            }
+            case NewArrayExpression ax:
+            {
+                var ay = (NewArrayExpression) y;
+                return ax.Type == ay.Type && CollectionsEqual(ax.Expressions, ay.Expressions, rootX, rootY);
+            }
+            case DefaultExpression dx:
+            {
+                var dy = (DefaultExpression) y;
+                return dx.Type == dy.Type;
+            }
+            default:
+                return HandleUnsupportedExpression(x.ToString());
         }
+    }
 
-        private bool MemberBindingCollectionsEqual(IReadOnlyCollection<MemberBinding> x, IReadOnlyCollection<MemberBinding> y,
-            LambdaExpression rootX, LambdaExpression rootY)
+    private bool MemberBindingCollectionsEqual(IReadOnlyCollection<MemberBinding> x, IReadOnlyCollection<MemberBinding> y,
+        LambdaExpression rootX, LambdaExpression rootY)
+    {
+        return x.Count == y.Count
+               && x.Zip(y, (first, second) => new {X = first, Y = second})
+                   .All(o => MemberBindingsEqual(o.X, o.Y, rootX, rootY));
+    }
+
+    private bool ElementInitCollectionsEqual(IReadOnlyCollection<ElementInit> x, IReadOnlyCollection<ElementInit> y,
+        LambdaExpression rootX, LambdaExpression rootY)
+    {
+        return x.Count == y.Count
+               && x.Zip(y, (first, second) => new {X = first, Y = second})
+                   .All(o => ElementInitsEqual(o.X, o.Y, rootX, rootY));
+    }
+
+    private bool CollectionsEqual(IReadOnlyCollection<Expression> x, IReadOnlyCollection<Expression> y,
+        LambdaExpression rootX, LambdaExpression rootY)
+    {
+        return x.Count == y.Count
+               && x.Zip(y, (first, second) => new {X = first, Y = second})
+                   .All(o => ExpressionEqual(o.X, o.Y, rootX, rootY));
+    }
+
+    private bool ElementInitsEqual(ElementInit x, ElementInit y, LambdaExpression rootX,
+        LambdaExpression rootY)
+    {
+        return Equals(x.AddMethod, y.AddMethod)
+               && CollectionsEqual(x.Arguments, y.Arguments, rootX, rootY);
+    }
+
+    private bool MemberBindingsEqual(MemberBinding x, MemberBinding y, LambdaExpression rootX,
+        LambdaExpression rootY)
+    {
+        if (x.BindingType != y.BindingType)
+            return false;
+
+        switch (x.BindingType)
         {
-            return x.Count == y.Count
-                   && x.Zip(y, (first, second) => new {X = first, Y = second})
-                       .All(o => MemberBindingsEqual(o.X, o.Y, rootX, rootY));
+            case MemberBindingType.Assignment:
+                var max = (MemberAssignment)x;
+                var may = (MemberAssignment)y;
+                return ExpressionEqual(max.Expression, may.Expression, rootX, rootY);
+            case MemberBindingType.MemberBinding:
+                var mmbx = (MemberMemberBinding)x;
+                var mmby = (MemberMemberBinding)y;
+                return MemberBindingCollectionsEqual(mmbx.Bindings, mmby.Bindings, rootX, rootY);
+            case MemberBindingType.ListBinding:
+                var mlbx = (MemberListBinding)x;
+                var mlby = (MemberListBinding)y;
+                return ElementInitCollectionsEqual(mlbx.Initializers, mlby.Initializers, rootX, rootY);
+            default:
+                return HandleUnsupportedExpression($"Unsupported binding type. BindingType={x.BindingType}");
         }
+    }
 
-        private bool ElementInitCollectionsEqual(IReadOnlyCollection<ElementInit> x, IReadOnlyCollection<ElementInit> y,
-            LambdaExpression rootX, LambdaExpression rootY)
+    private bool MemberExpressionsEqual(MemberExpression x, MemberExpression y, LambdaExpression rootX, LambdaExpression rootY)
+    {
+        if (x.Expression == null || y.Expression == null)
+            return Equals(x.Member, y.Member);
+
+        if (x.Expression.NodeType != y.Expression.NodeType)
+            return false;
+
+        switch (x.Expression.NodeType)
         {
-            return x.Count == y.Count
-                   && x.Zip(y, (first, second) => new {X = first, Y = second})
-                       .All(o => ElementInitsEqual(o.X, o.Y, rootX, rootY));
+            case ExpressionType.Constant:
+                var cx = GetValueOfConstantExpression(x);
+                var cy = GetValueOfConstantExpression(y);
+                return Equals(cx, cy);
+            case ExpressionType.Parameter:
+            case ExpressionType.MemberAccess:
+            case ExpressionType.Convert:
+            case ExpressionType.Add:
+            case ExpressionType.AddChecked:
+            case ExpressionType.Subtract:
+            case ExpressionType.SubtractChecked:
+            case ExpressionType.Multiply:
+            case ExpressionType.MultiplyChecked:
+            case ExpressionType.Divide:
+            case ExpressionType.Modulo:
+            case ExpressionType.Power:
+            case ExpressionType.Conditional:
+                return Equals(x.Member, y.Member) && ExpressionEqual(x.Expression, y.Expression, rootX, rootY);
+            case ExpressionType.New:
+            case ExpressionType.Call:
+                return ExpressionEqual(x.Expression, y.Expression, rootX, rootY);
+            default:
+                return HandleUnsupportedExpression(x.ToString());
         }
+    }
 
-        private bool CollectionsEqual(IReadOnlyCollection<Expression> x, IReadOnlyCollection<Expression> y,
-            LambdaExpression rootX, LambdaExpression rootY)
+    private static object GetValueOfConstantExpression(MemberExpression mex)
+    {
+        var o = ((ConstantExpression)mex.Expression).Value;
+        return mex.Member switch
         {
-            return x.Count == y.Count
-                   && x.Zip(y, (first, second) => new {X = first, Y = second})
-                       .All(o => ExpressionEqual(o.X, o.Y, rootX, rootY));
-        }
+            FieldInfo fi => fi.GetValue(o),
+            PropertyInfo pi => pi.GetValue(o, null),
+            _ => throw new ArgumentException($"Unsupported member type. MemberType={mex.Member.GetType()}")
+        };
+    }
 
-        private bool ElementInitsEqual(ElementInit x, ElementInit y, LambdaExpression rootX,
-            LambdaExpression rootY)
+    private bool HandleUnsupportedExpression(string message)
+    {
+        switch (_compilerOptions.UnsupportedExpressionHandling)
         {
-            return Equals(x.AddMethod, y.AddMethod)
-                   && CollectionsEqual(x.Arguments, y.Arguments, rootX, rootY);
-        }
-
-        private bool MemberBindingsEqual(MemberBinding x, MemberBinding y, LambdaExpression rootX,
-            LambdaExpression rootY)
-        {
-            if (x.BindingType != y.BindingType)
+            case RuleCompilerUnsupportedExpressionsHandling.FailFast:
+                throw new NotImplementedException(message);
+            default:
                 return false;
-
-            switch (x.BindingType)
-            {
-                case MemberBindingType.Assignment:
-                    var max = (MemberAssignment)x;
-                    var may = (MemberAssignment)y;
-                    return ExpressionEqual(max.Expression, may.Expression, rootX, rootY);
-                case MemberBindingType.MemberBinding:
-                    var mmbx = (MemberMemberBinding)x;
-                    var mmby = (MemberMemberBinding)y;
-                    return MemberBindingCollectionsEqual(mmbx.Bindings, mmby.Bindings, rootX, rootY);
-                case MemberBindingType.ListBinding:
-                    var mlbx = (MemberListBinding)x;
-                    var mlby = (MemberListBinding)y;
-                    return ElementInitCollectionsEqual(mlbx.Initializers, mlby.Initializers, rootX, rootY);
-                default:
-                    return HandleUnsupportedExpression($"Unsupported binding type. BindingType={x.BindingType}");
-            }
-        }
-
-        private bool MemberExpressionsEqual(MemberExpression x, MemberExpression y, LambdaExpression rootX, LambdaExpression rootY)
-        {
-            if (x.Expression == null || y.Expression == null)
-                return Equals(x.Member, y.Member);
-
-            if (x.Expression.NodeType != y.Expression.NodeType)
-                return false;
-
-            switch (x.Expression.NodeType)
-            {
-                case ExpressionType.Constant:
-                    var cx = GetValueOfConstantExpression(x);
-                    var cy = GetValueOfConstantExpression(y);
-                    return Equals(cx, cy);
-                case ExpressionType.Parameter:
-                case ExpressionType.MemberAccess:
-                case ExpressionType.Convert:
-                case ExpressionType.Add:
-                case ExpressionType.AddChecked:
-                case ExpressionType.Subtract:
-                case ExpressionType.SubtractChecked:
-                case ExpressionType.Multiply:
-                case ExpressionType.MultiplyChecked:
-                case ExpressionType.Divide:
-                case ExpressionType.Modulo:
-                case ExpressionType.Power:
-                case ExpressionType.Conditional:
-                    return Equals(x.Member, y.Member) && ExpressionEqual(x.Expression, y.Expression, rootX, rootY);
-                case ExpressionType.New:
-                case ExpressionType.Call:
-                    return ExpressionEqual(x.Expression, y.Expression, rootX, rootY);
-                default:
-                    return HandleUnsupportedExpression(x.ToString());
-            }
-        }
-
-        private static object GetValueOfConstantExpression(MemberExpression mex)
-        {
-            var o = ((ConstantExpression)mex.Expression).Value;
-            return mex.Member switch
-            {
-                FieldInfo fi => fi.GetValue(o),
-                PropertyInfo pi => pi.GetValue(o, null),
-                _ => throw new ArgumentException($"Unsupported member type. MemberType={mex.Member.GetType()}")
-            };
-        }
-
-        private bool HandleUnsupportedExpression(string message)
-        {
-            switch (_compilerOptions.UnsupportedExpressionHandling)
-            {
-                case RuleCompilerUnsupportedExpressionsHandling.FailFast:
-                    throw new NotImplementedException(message);
-                default:
-                    return false;
-            }
         }
     }
 }

--- a/src/NRules/NRules/Utilities/ExpressionElementComparer.cs
+++ b/src/NRules/NRules/Utilities/ExpressionElementComparer.cs
@@ -3,80 +3,79 @@ using System.Linq;
 using NRules.Rete;
 using NRules.RuleModel;
 
-namespace NRules.Utilities
+namespace NRules.Utilities;
+
+internal class ExpressionElementComparer
 {
-    internal class ExpressionElementComparer
+    private readonly ExpressionComparer _expressionComparer;
+
+    public ExpressionElementComparer(RuleCompilerOptions compilerOptions)
     {
-        private readonly ExpressionComparer _expressionComparer;
+        _expressionComparer = new ExpressionComparer(compilerOptions);
+    }
 
-        public ExpressionElementComparer(RuleCompilerOptions compilerOptions)
-        {
-            _expressionComparer = new ExpressionComparer(compilerOptions);
-        }
+    public bool AreEqual(NamedExpressionElement first, NamedExpressionElement second)
+    {
+        if (!Equals(first.Name, second.Name))
+            return false;
+        return _expressionComparer.AreEqual(first.Expression, second.Expression);
+    }
+    
+    public bool AreEqual(ExpressionElement first, ExpressionElement second)
+    {
+        return _expressionComparer.AreEqual(first.Expression, second.Expression);
+    }
 
-        public bool AreEqual(NamedExpressionElement first, NamedExpressionElement second)
-        {
-            if (!Equals(first.Name, second.Name))
-                return false;
-            return _expressionComparer.AreEqual(first.Expression, second.Expression);
-        }
-        
-        public bool AreEqual(ExpressionElement first, ExpressionElement second)
-        {
-            return _expressionComparer.AreEqual(first.Expression, second.Expression);
-        }
+    public bool AreEqual(
+        List<Declaration> firstDeclarations, IEnumerable<NamedExpressionElement> first, 
+        List<Declaration> secondDeclarations, IEnumerable<NamedExpressionElement> second)
+    {
+        using var enumerator1 = first.GetEnumerator();
+        using var enumerator2 = second.GetEnumerator();
 
-        public bool AreEqual(
-            List<Declaration> firstDeclarations, IEnumerable<NamedExpressionElement> first, 
-            List<Declaration> secondDeclarations, IEnumerable<NamedExpressionElement> second)
+        while (true)
         {
-            using var enumerator1 = first.GetEnumerator();
-            using var enumerator2 = second.GetEnumerator();
+            var hasNext1 = enumerator1.MoveNext();
+            var hasNext2 = enumerator2.MoveNext();
 
-            while (true)
+            if (hasNext1 && hasNext2)
             {
-                var hasNext1 = enumerator1.MoveNext();
-                var hasNext2 = enumerator2.MoveNext();
-
-                if (hasNext1 && hasNext2)
-                {
-                    if (!AreParameterPositionsEqual(firstDeclarations, enumerator1.Current, secondDeclarations, enumerator2.Current))
-                        return false;
-                    if (!AreEqual(enumerator1.Current, enumerator2.Current))
-                        return false;
-                }
-                else if (hasNext1 || hasNext2)
-                {
+                if (!AreParameterPositionsEqual(firstDeclarations, enumerator1.Current, secondDeclarations, enumerator2.Current))
                     return false;
-                }
-                else
-                {
-                    break;
-                }
+                if (!AreEqual(enumerator1.Current, enumerator2.Current))
+                    return false;
             }
-            
-            return true;
+            else if (hasNext1 || hasNext2)
+            {
+                return false;
+            }
+            else
+            {
+                break;
+            }
         }
         
-        public bool AreEqual(
-            List<Declaration> firstDeclarations, IEnumerable<ExpressionElement> x,
-            List<Declaration> secondDeclarations, IEnumerable<ExpressionElement> y)
-        {
-            return x.Count() == y.Count()
-                   && x.Zip(y, (first, second) => new {X = first, Y = second})
-                       .All(o => 
-                           AreParameterPositionsEqual(firstDeclarations, o.X, secondDeclarations, o.Y) && 
-                           AreEqual(o.X, o.Y));
-        }
+        return true;
+    }
+    
+    public bool AreEqual(
+        List<Declaration> firstDeclarations, IEnumerable<ExpressionElement> x,
+        List<Declaration> secondDeclarations, IEnumerable<ExpressionElement> y)
+    {
+        return x.Count() == y.Count()
+               && x.Zip(y, (first, second) => new {X = first, Y = second})
+                   .All(o => 
+                       AreParameterPositionsEqual(firstDeclarations, o.X, secondDeclarations, o.Y) && 
+                       AreEqual(o.X, o.Y));
+    }
 
-        private bool AreParameterPositionsEqual(
-            List<Declaration> firstDeclarations, ExpressionElement firstElement, 
-            List<Declaration> secondDeclarations, ExpressionElement secondElement)
-        {
-            var parameterMap1 = IndexMap.CreateMap(firstElement.Imports, firstDeclarations);
-            var parameterMap2 = IndexMap.CreateMap(secondElement.Imports, secondDeclarations);
+    private bool AreParameterPositionsEqual(
+        List<Declaration> firstDeclarations, ExpressionElement firstElement, 
+        List<Declaration> secondDeclarations, ExpressionElement secondElement)
+    {
+        var parameterMap1 = IndexMap.CreateMap(firstElement.Imports, firstDeclarations);
+        var parameterMap2 = IndexMap.CreateMap(secondElement.Imports, secondDeclarations);
 
-            return Equals(parameterMap1, parameterMap2);
-        }
+        return Equals(parameterMap1, parameterMap2);
     }
 }

--- a/src/NRules/NRules/Utilities/ExpressionOptimizer.cs
+++ b/src/NRules/NRules/Utilities/ExpressionOptimizer.cs
@@ -8,176 +8,175 @@ using NRules.Rete;
 using NRules.RuleModel;
 using Tuple = NRules.Rete.Tuple;
 
-namespace NRules.Utilities
+namespace NRules.Utilities;
+
+internal static class ExpressionOptimizer
 {
-    internal static class ExpressionOptimizer
+    private static readonly MethodInfo GetEnumeratorMethod;
+    private static readonly MethodInfo MoveNextMethod;
+    private static readonly PropertyInfo CurrentProperty;
+    private static readonly PropertyInfo FactValueProperty;
+    private static readonly MethodInfo ResolveMethod;
+
+    static ExpressionOptimizer()
     {
-        private static readonly MethodInfo GetEnumeratorMethod;
-        private static readonly MethodInfo MoveNextMethod;
-        private static readonly PropertyInfo CurrentProperty;
-        private static readonly PropertyInfo FactValueProperty;
-        private static readonly MethodInfo ResolveMethod;
+        GetEnumeratorMethod = typeof(Tuple)
+            .GetMethod(nameof(Tuple.GetEnumerator));
+        MoveNextMethod = typeof(Tuple.Enumerator)
+            .GetMethod(nameof(Tuple.Enumerator.MoveNext));
+        CurrentProperty = typeof(Tuple.Enumerator)
+            .GetProperty(nameof(Tuple.Enumerator.Current));
+        FactValueProperty = typeof(Fact)
+            .GetProperty(nameof(Fact.Object));
+        ResolveMethod = typeof(IDependencyResolver)
+            .GetMethod(nameof(IDependencyResolver.Resolve));
+    }
 
-        static ExpressionOptimizer()
+    public static Expression<TDelegate> Optimize<TDelegate>(LambdaExpression expression,
+        IndexMap indexMap, bool tupleInput, bool factInput)
+    {
+        return Optimize<TDelegate>(expression, 0, indexMap, tupleInput, factInput);
+    }
+
+    public static Expression<TDelegate> Optimize<TDelegate>(LambdaExpression expression,
+        int startIndex, IndexMap indexMap, bool tupleInput, bool factInput)
+    {
+        var parts = new ExpressionParts(expression, startIndex);
+
+        if (tupleInput)
+            UnwrapTuple(parts, indexMap, factInput ? indexMap.Length - 1 : indexMap.Length);
+
+        if (factInput)
+            UnwrapFact(parts, indexMap);
+
+        var invocation = EnsureReturnType(expression.Body, typeof(TDelegate));
+        parts.Body.Add(invocation);
+
+        var optimizedLambda = Expression.Lambda<TDelegate>(
+            Expression.Block(parts.BodyParameters, parts.Body),
+            parts.InputParameters);
+        return optimizedLambda;
+    }
+
+    public static Expression<TDelegate> Optimize<TDelegate>(LambdaExpression expression,
+        IndexMap factIndexMap, List<DependencyElement> dependencies, IndexMap dependencyIndexMap)
+    {
+        var parts = new ExpressionParts(expression, 1);
+        
+        UnwrapTuple(parts, factIndexMap, factIndexMap.Length);
+        ResolveDependencies(parts, dependencies, dependencyIndexMap);
+
+        var invocation = EnsureReturnType(expression.Body, typeof(TDelegate));
+        parts.Body.Add(invocation);
+
+        var optimizedLambda = Expression.Lambda<TDelegate>(
+            Expression.Block(parts.BodyParameters, parts.Body),
+            parts.InputParameters);
+        return optimizedLambda;
+    }
+
+    private static void UnwrapFact(ExpressionParts parts, IndexMap indexMap)
+    {
+        var factParameter = Expression.Parameter(typeof(Fact), "<fact>");
+        parts.InputParameters.Add(factParameter);
+
+        var parameterIndex = indexMap[indexMap.Length - 1];
+        if (parameterIndex >= 0)
         {
-            GetEnumeratorMethod = typeof(Tuple)
-                .GetMethod(nameof(Tuple.GetEnumerator));
-            MoveNextMethod = typeof(Tuple.Enumerator)
-                .GetMethod(nameof(Tuple.Enumerator.MoveNext));
-            CurrentProperty = typeof(Tuple.Enumerator)
-                .GetProperty(nameof(Tuple.Enumerator.Current));
-            FactValueProperty = typeof(Fact)
-                .GetProperty(nameof(Fact.Object));
-            ResolveMethod = typeof(IDependencyResolver)
-                .GetMethod(nameof(IDependencyResolver.Resolve));
-        }
-
-        public static Expression<TDelegate> Optimize<TDelegate>(LambdaExpression expression,
-            IndexMap indexMap, bool tupleInput, bool factInput)
-        {
-            return Optimize<TDelegate>(expression, 0, indexMap, tupleInput, factInput);
-        }
-
-        public static Expression<TDelegate> Optimize<TDelegate>(LambdaExpression expression,
-            int startIndex, IndexMap indexMap, bool tupleInput, bool factInput)
-        {
-            var parts = new ExpressionParts(expression, startIndex);
-
-            if (tupleInput)
-                UnwrapTuple(parts, indexMap, factInput ? indexMap.Length - 1 : indexMap.Length);
-
-            if (factInput)
-                UnwrapFact(parts, indexMap);
-
-            var invocation = EnsureReturnType(expression.Body, typeof(TDelegate));
-            parts.Body.Add(invocation);
-
-            var optimizedLambda = Expression.Lambda<TDelegate>(
-                Expression.Block(parts.BodyParameters, parts.Body),
-                parts.InputParameters);
-            return optimizedLambda;
-        }
-
-        public static Expression<TDelegate> Optimize<TDelegate>(LambdaExpression expression,
-            IndexMap factIndexMap, List<DependencyElement> dependencies, IndexMap dependencyIndexMap)
-        {
-            var parts = new ExpressionParts(expression, 1);
-            
-            UnwrapTuple(parts, factIndexMap, factIndexMap.Length);
-            ResolveDependencies(parts, dependencies, dependencyIndexMap);
-
-            var invocation = EnsureReturnType(expression.Body, typeof(TDelegate));
-            parts.Body.Add(invocation);
-
-            var optimizedLambda = Expression.Lambda<TDelegate>(
-                Expression.Block(parts.BodyParameters, parts.Body),
-                parts.InputParameters);
-            return optimizedLambda;
-        }
-
-        private static void UnwrapFact(ExpressionParts parts, IndexMap indexMap)
-        {
-            var factParameter = Expression.Parameter(typeof(Fact), "<fact>");
-            parts.InputParameters.Add(factParameter);
-
-            var parameterIndex = indexMap[indexMap.Length - 1];
-            if (parameterIndex >= 0)
-            {
-                var bodyParameter = parts.BodyParameters[parameterIndex];
-
-                parts.Body.Add(
-                    AssignFactValue(factParameter, bodyParameter));
-            }
-        }
-
-        private static void UnwrapTuple(ExpressionParts parts, IndexMap indexMap, int tupleSize)
-        {
-            var tupleParameter = Expression.Parameter(typeof(Tuple), "<tuple>");
-            parts.InputParameters.Add(tupleParameter);
-
-            if (tupleSize <= 0) return;
-
-            var enumerator = Expression.Variable(typeof(Tuple.Enumerator), "<enumerator>");
-            parts.BodyParameters.Add(enumerator);
+            var bodyParameter = parts.BodyParameters[parameterIndex];
 
             parts.Body.Add(
-                Expression.Assign(enumerator, Expression.Call(tupleParameter, GetEnumeratorMethod)));
+                AssignFactValue(factParameter, bodyParameter));
+        }
+    }
 
-            var intermediateParts = new List<Expression>(tupleSize);
-            for (int i = tupleSize - 1; i >= 0; i--)
+    private static void UnwrapTuple(ExpressionParts parts, IndexMap indexMap, int tupleSize)
+    {
+        var tupleParameter = Expression.Parameter(typeof(Tuple), "<tuple>");
+        parts.InputParameters.Add(tupleParameter);
+
+        if (tupleSize <= 0) return;
+
+        var enumerator = Expression.Variable(typeof(Tuple.Enumerator), "<enumerator>");
+        parts.BodyParameters.Add(enumerator);
+
+        parts.Body.Add(
+            Expression.Assign(enumerator, Expression.Call(tupleParameter, GetEnumeratorMethod)));
+
+        var intermediateParts = new List<Expression>(tupleSize);
+        for (int i = tupleSize - 1; i >= 0; i--)
+        {
+            intermediateParts.Add(
+                Expression.Call(enumerator, MoveNextMethod));
+
+            var parameterIndex = indexMap[i];
+            if (parameterIndex >= 0)
             {
-                intermediateParts.Add(
-                    Expression.Call(enumerator, MoveNextMethod));
+                parts.Body.AddRange(intermediateParts);
+                intermediateParts.Clear();
 
-                var parameterIndex = indexMap[i];
-                if (parameterIndex >= 0)
-                {
-                    parts.Body.AddRange(intermediateParts);
-                    intermediateParts.Clear();
+                var bodyParameter = parts.BodyParameters[parameterIndex];
 
-                    var bodyParameter = parts.BodyParameters[parameterIndex];
-
-                    var currentFact = Expression.Property(enumerator, CurrentProperty);
-                    parts.Body.Add(
-                        AssignFactValue(currentFact, bodyParameter));
-                }
+                var currentFact = Expression.Property(enumerator, CurrentProperty);
+                parts.Body.Add(
+                    AssignFactValue(currentFact, bodyParameter));
             }
         }
+    }
 
-        private static void ResolveDependencies(ExpressionParts parts, 
-            List<DependencyElement> dependencies, IndexMap indexMap)
+    private static void ResolveDependencies(ExpressionParts parts, 
+        List<DependencyElement> dependencies, IndexMap indexMap)
+    {
+        var resolverParameter = Expression.Parameter(typeof(IDependencyResolver), "<resolver>");
+        parts.InputParameters.Add(resolverParameter);
+        var resolutionContextParameter = Expression.Parameter(typeof(IResolutionContext), "<resolutionContext>");
+        parts.InputParameters.Add(resolutionContextParameter);
+
+        for (int i = 0; i <= indexMap.Length; i++)
         {
-            var resolverParameter = Expression.Parameter(typeof(IDependencyResolver), "<resolver>");
-            parts.InputParameters.Add(resolverParameter);
-            var resolutionContextParameter = Expression.Parameter(typeof(IResolutionContext), "<resolutionContext>");
-            parts.InputParameters.Add(resolutionContextParameter);
-
-            for (int i = 0; i <= indexMap.Length; i++)
+            var parameterIndex = indexMap[i];
+            if (parameterIndex >= 0)
             {
-                var parameterIndex = indexMap[i];
-                if (parameterIndex >= 0)
-                {
-                    var parameter = parts.BodyParameters[parameterIndex];
-                    var parameterType = dependencies[i].ServiceType;
-                    var resolveDependency = Expression.Call(
-                        resolverParameter, ResolveMethod, resolutionContextParameter, Expression.Constant(parameterType));
-                    parts.Body.Add(
-                        Expression.Assign(parameter, Expression.Convert(resolveDependency, parameterType)));
-                }
+                var parameter = parts.BodyParameters[parameterIndex];
+                var parameterType = dependencies[i].ServiceType;
+                var resolveDependency = Expression.Call(
+                    resolverParameter, ResolveMethod, resolutionContextParameter, Expression.Constant(parameterType));
+                parts.Body.Add(
+                    Expression.Assign(parameter, Expression.Convert(resolveDependency, parameterType)));
             }
         }
+    }
 
-        private static BinaryExpression AssignFactValue(Expression fact, ParameterExpression parameter)
+    private static BinaryExpression AssignFactValue(Expression fact, ParameterExpression parameter)
+    {
+        var factValue = Expression.Property(fact, FactValueProperty);
+        return Expression.Assign(parameter, Expression.Convert(factValue, parameter.Type));
+    }
+
+    private static Expression EnsureReturnType(Expression expression, Type delegateType)
+    {
+        var invokeMethod = delegateType.GetMethod(nameof(Action.Invoke));
+        if (invokeMethod == null) return expression;
+
+        var returnType = invokeMethod.ReturnType;
+        if (returnType == typeof(void)) return expression;
+        if (expression.Type == returnType) return expression;
+        
+        var convertedExpression = Expression.Convert(expression, returnType);
+        return convertedExpression;
+    }
+
+    private readonly ref struct ExpressionParts
+    {
+        public ExpressionParts(LambdaExpression expression, int startIndex)
         {
-            var factValue = Expression.Property(fact, FactValueProperty);
-            return Expression.Assign(parameter, Expression.Convert(factValue, parameter.Type));
+            InputParameters = expression.Parameters.Take(startIndex).ToList();
+            BodyParameters = expression.Parameters.Skip(startIndex).ToList();
+            Body = new List<Expression>(2 + 2 * BodyParameters.Count);
         }
 
-        private static Expression EnsureReturnType(Expression expression, Type delegateType)
-        {
-            var invokeMethod = delegateType.GetMethod(nameof(Action.Invoke));
-            if (invokeMethod == null) return expression;
-
-            var returnType = invokeMethod.ReturnType;
-            if (returnType == typeof(void)) return expression;
-            if (expression.Type == returnType) return expression;
-            
-            var convertedExpression = Expression.Convert(expression, returnType);
-            return convertedExpression;
-        }
-
-        private readonly ref struct ExpressionParts
-        {
-            public ExpressionParts(LambdaExpression expression, int startIndex)
-            {
-                InputParameters = expression.Parameters.Take(startIndex).ToList();
-                BodyParameters = expression.Parameters.Skip(startIndex).ToList();
-                Body = new List<Expression>(2 + 2 * BodyParameters.Count);
-            }
-
-            public readonly List<ParameterExpression> InputParameters;
-            public readonly List<ParameterExpression> BodyParameters;
-            public readonly List<Expression> Body;
-        }
+        public readonly List<ParameterExpression> InputParameters;
+        public readonly List<ParameterExpression> BodyParameters;
+        public readonly List<Expression> Body;
     }
 }

--- a/src/NRules/NRules/Utilities/IndexMapExtensions.cs
+++ b/src/NRules/NRules/Utilities/IndexMapExtensions.cs
@@ -1,35 +1,34 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace NRules.Utilities
-{
-    internal static class IndexMapExtensions
-    {
-        /// <summary>
-        /// Converts sequence to an index lookup map.
-        /// </summary>
-        /// <typeparam name="TElement">Type of element in the sequence.</typeparam>
-        /// <param name="sequence">Sequence to convert.</param>
-        /// <returns>Index lookup dictionary.</returns>
-        public static Dictionary<TElement, int> ToIndexMap<TElement>(this IEnumerable<TElement> sequence)
-        {
-            return sequence.Select((value, index) => new {value, index}).ToDictionary(x => x.value, x => x.index);
-        }
+namespace NRules.Utilities;
 
-        /// <summary>
-        /// Returns element's index or -1.
-        /// </summary>
-        /// <typeparam name="TElement">Type of element in the index map.</typeparam>
-        /// <param name="indexMap">Index map.</param>
-        /// <param name="element">Element to lookup.</param>
-        /// <returns></returns>
-        public static int IndexOrDefault<TElement>(this Dictionary<TElement, int> indexMap, TElement element)
+internal static class IndexMapExtensions
+{
+    /// <summary>
+    /// Converts sequence to an index lookup map.
+    /// </summary>
+    /// <typeparam name="TElement">Type of element in the sequence.</typeparam>
+    /// <param name="sequence">Sequence to convert.</param>
+    /// <returns>Index lookup dictionary.</returns>
+    public static Dictionary<TElement, int> ToIndexMap<TElement>(this IEnumerable<TElement> sequence)
+    {
+        return sequence.Select((value, index) => new {value, index}).ToDictionary(x => x.value, x => x.index);
+    }
+
+    /// <summary>
+    /// Returns element's index or -1.
+    /// </summary>
+    /// <typeparam name="TElement">Type of element in the index map.</typeparam>
+    /// <param name="indexMap">Index map.</param>
+    /// <param name="element">Element to lookup.</param>
+    /// <returns></returns>
+    public static int IndexOrDefault<TElement>(this Dictionary<TElement, int> indexMap, TElement element)
+    {
+        if (indexMap.TryGetValue(element, out var index))
         {
-            if (indexMap.TryGetValue(element, out var index))
-            {
-                return index;
-            }
-            return -1;
+            return index;
         }
+        return -1;
     }
 }

--- a/src/NRules/NRules/Utilities/ReverseComparer.cs
+++ b/src/NRules/NRules/Utilities/ReverseComparer.cs
@@ -1,19 +1,18 @@
 ﻿using System.Collections.Generic;
 
-namespace NRules.Utilities
+namespace NRules.Utilities;
+
+internal class ReverseComparer<T> : IComparer<T>
 {
-    internal class ReverseComparer<T> : IComparer<T>
+    private readonly IComparer<T> _comparer;
+
+    internal ReverseComparer(IComparer<T> comparer)
     {
-        private readonly IComparer<T> _comparer;
+        _comparer = comparer;
+    }
 
-        internal ReverseComparer(IComparer<T> comparer)
-        {
-            _comparer = comparer;
-        }
-
-        public int Compare(T x, T y)
-        {
-            return _comparer.Compare(y, x);
-        }
+    public int Compare(T x, T y)
+    {
+        return _comparer.Compare(y, x);
     }
 }

--- a/src/NRules/NRules/Utilities/RuleExpressionCompiler.cs
+++ b/src/NRules/NRules/Utilities/RuleExpressionCompiler.cs
@@ -8,113 +8,112 @@ using NRules.Rete;
 using NRules.RuleModel;
 using Tuple = NRules.Rete.Tuple;
 
-namespace NRules.Utilities
+namespace NRules.Utilities;
+
+internal interface IRuleExpressionCompiler
 {
-    internal interface IRuleExpressionCompiler
+    IExpressionCompiler ExpressionCompiler { get; set; }
+    ILhsExpression<TResult> CompileLhsExpression<TResult>(ExpressionElement element, List<Declaration> declarations);
+    ILhsFactExpression<TResult> CompileLhsFactExpression<TResult>(ExpressionElement element);
+    ILhsTupleExpression<TResult> CompileLhsTupleExpression<TResult>(ExpressionElement element, List<Declaration> declarations);
+    IActivationExpression<TResult> CompileActivationExpression<TResult>(ExpressionElement element,
+        List<Declaration> declarations, IndexMap tupleFactMap);
+    IRuleAction CompileAction(ActionElement element, List<Declaration> declarations,
+        List<DependencyElement> dependencies, IndexMap tupleFactMap);
+    IAggregateExpression CompileAggregateExpression(NamedExpressionElement element, List<Declaration> declarations);
+}
+
+internal class RuleExpressionCompiler : IRuleExpressionCompiler
+{
+    public IExpressionCompiler ExpressionCompiler { get; set; } = new ExpressionCompiler();
+
+    public ILhsExpression<TResult> CompileLhsExpression<TResult>(ExpressionElement element, List<Declaration> declarations)
     {
-        IExpressionCompiler ExpressionCompiler { get; set; }
-        ILhsExpression<TResult> CompileLhsExpression<TResult>(ExpressionElement element, List<Declaration> declarations);
-        ILhsFactExpression<TResult> CompileLhsFactExpression<TResult>(ExpressionElement element);
-        ILhsTupleExpression<TResult> CompileLhsTupleExpression<TResult>(ExpressionElement element, List<Declaration> declarations);
-        IActivationExpression<TResult> CompileActivationExpression<TResult>(ExpressionElement element,
-            List<Declaration> declarations, IndexMap tupleFactMap);
-        IRuleAction CompileAction(ActionElement element, List<Declaration> declarations,
-            List<DependencyElement> dependencies, IndexMap tupleFactMap);
-        IAggregateExpression CompileAggregateExpression(NamedExpressionElement element, List<Declaration> declarations);
+        if (element.Imports.Count() == 1 &&
+            Equals(element.Imports.Single(), declarations.Last()))
+        {
+            return CompileLhsFactExpression<TResult>(element);
+        }
+        return CompileLhsTupleFactExpression<TResult>(element, declarations);
     }
 
-    internal class RuleExpressionCompiler : IRuleExpressionCompiler
+    public ILhsFactExpression<TResult> CompileLhsFactExpression<TResult>(ExpressionElement element)
     {
-        public IExpressionCompiler ExpressionCompiler { get; set; } = new ExpressionCompiler();
+        var optimizedExpression = ExpressionOptimizer.Optimize<Func<Fact, TResult>>(
+            element.Expression, IndexMap.Unit, tupleInput: false, factInput: true);
+        var @delegate = optimizedExpression.Compile();
+        var argumentMap = new ArgumentMap(IndexMap.Unit, 1);
+        var expression = new LhsFactExpression<TResult>(element.Expression, @delegate, argumentMap);
+        return expression;
+    }
 
-        public ILhsExpression<TResult> CompileLhsExpression<TResult>(ExpressionElement element, List<Declaration> declarations)
-        {
-            if (element.Imports.Count() == 1 &&
-                Equals(element.Imports.Single(), declarations.Last()))
-            {
-                return CompileLhsFactExpression<TResult>(element);
-            }
-            return CompileLhsTupleFactExpression<TResult>(element, declarations);
-        }
+    public ILhsTupleExpression<TResult> CompileLhsTupleExpression<TResult>(ExpressionElement element, List<Declaration> declarations)
+    {
+        var factMap = IndexMap.CreateMap(element.Imports, declarations);
+        var optimizedExpression = ExpressionOptimizer.Optimize<Func<Tuple, TResult>>(
+            element.Expression, factMap, tupleInput: true, factInput: false);
+        var @delegate = ExpressionCompiler.Compile(optimizedExpression);
+        var argumentMap = new ArgumentMap(factMap, element.Expression.Parameters.Count);
+        var expression = new LhsTupleExpression<TResult>(element.Expression, @delegate, argumentMap);
+        return expression;
+    }
 
-        public ILhsFactExpression<TResult> CompileLhsFactExpression<TResult>(ExpressionElement element)
-        {
-            var optimizedExpression = ExpressionOptimizer.Optimize<Func<Fact, TResult>>(
-                element.Expression, IndexMap.Unit, tupleInput: false, factInput: true);
-            var @delegate = optimizedExpression.Compile();
-            var argumentMap = new ArgumentMap(IndexMap.Unit, 1);
-            var expression = new LhsFactExpression<TResult>(element.Expression, @delegate, argumentMap);
-            return expression;
-        }
+    public ILhsExpression<TResult> CompileLhsTupleFactExpression<TResult>(ExpressionElement element, List<Declaration> declarations)
+    {
+        var factMap = IndexMap.CreateMap(element.Imports, declarations);
+        var optimizedExpression = ExpressionOptimizer.Optimize<Func<Tuple, Fact, TResult>>(
+            element.Expression, factMap, tupleInput: true, factInput: true);
+        var @delegate = ExpressionCompiler.Compile(optimizedExpression);
+        var argumentMap = new ArgumentMap(factMap, element.Expression.Parameters.Count);
+        var expression = new LhsExpression<TResult>(element.Expression, @delegate, argumentMap);
+        return expression;
+    }
 
-        public ILhsTupleExpression<TResult> CompileLhsTupleExpression<TResult>(ExpressionElement element, List<Declaration> declarations)
+    public IActivationExpression<TResult> CompileActivationExpression<TResult>(ExpressionElement element,
+        List<Declaration> declarations, IndexMap tupleFactMap)
+    {
+        var activationFactMap = IndexMap.CreateMap(element.Imports, declarations);
+        var factMap = IndexMap.Compose(tupleFactMap, activationFactMap);
+        var optimizedExpression = ExpressionOptimizer.Optimize<Func<Tuple, TResult>>(
+            element.Expression, factMap, tupleInput: true, factInput: false);
+        var @delegate = ExpressionCompiler.Compile(optimizedExpression);
+        var argumentMap = new ArgumentMap(factMap, element.Expression.Parameters.Count);
+        var expression = new ActivationExpression<TResult>(element.Expression, @delegate, argumentMap);
+        return expression;
+    }
+
+    public IRuleAction CompileAction(ActionElement element, List<Declaration> declarations,
+        List<DependencyElement> dependencies, IndexMap tupleFactMap)
+    {
+        var activationFactMap = IndexMap.CreateMap(element.Imports, declarations);
+        var factMap = IndexMap.Compose(tupleFactMap, activationFactMap);
+
+        var dependencyIndexMap = IndexMap.CreateMap(element.Imports, dependencies.Select(x => x.Declaration));
+        if (dependencyIndexMap.HasData)
         {
-            var factMap = IndexMap.CreateMap(element.Imports, declarations);
-            var optimizedExpression = ExpressionOptimizer.Optimize<Func<Tuple, TResult>>(
-                element.Expression, factMap, tupleInput: true, factInput: false);
+            var optimizedExpression = ExpressionOptimizer
+                .Optimize<Action<IContext, Tuple, IDependencyResolver, IResolutionContext>>(
+                    element.Expression, factMap, dependencies, dependencyIndexMap);
             var @delegate = ExpressionCompiler.Compile(optimizedExpression);
-            var argumentMap = new ArgumentMap(factMap, element.Expression.Parameters.Count);
-            var expression = new LhsTupleExpression<TResult>(element.Expression, @delegate, argumentMap);
-            return expression;
+            var argumentMap = new ArgumentMap(factMap, element.Expression.Parameters.Count - 1);
+            var action = new RuleActionWithDependencies(element.Expression, @delegate, argumentMap, element.ActionTrigger);
+            return action;
         }
-
-        public ILhsExpression<TResult> CompileLhsTupleFactExpression<TResult>(ExpressionElement element, List<Declaration> declarations)
+        else
         {
-            var factMap = IndexMap.CreateMap(element.Imports, declarations);
-            var optimizedExpression = ExpressionOptimizer.Optimize<Func<Tuple, Fact, TResult>>(
-                element.Expression, factMap, tupleInput: true, factInput: true);
+            var optimizedExpression = ExpressionOptimizer.Optimize<Action<IContext, Tuple>>(
+                element.Expression, 1, factMap, tupleInput: true, factInput: false);
             var @delegate = ExpressionCompiler.Compile(optimizedExpression);
-            var argumentMap = new ArgumentMap(factMap, element.Expression.Parameters.Count);
-            var expression = new LhsExpression<TResult>(element.Expression, @delegate, argumentMap);
-            return expression;
+            var argumentMap = new ArgumentMap(factMap, element.Expression.Parameters.Count - 1);
+            var action = new RuleAction(element.Expression, @delegate, argumentMap, element.ActionTrigger);
+            return action;
         }
-
-        public IActivationExpression<TResult> CompileActivationExpression<TResult>(ExpressionElement element,
-            List<Declaration> declarations, IndexMap tupleFactMap)
-        {
-            var activationFactMap = IndexMap.CreateMap(element.Imports, declarations);
-            var factMap = IndexMap.Compose(tupleFactMap, activationFactMap);
-            var optimizedExpression = ExpressionOptimizer.Optimize<Func<Tuple, TResult>>(
-                element.Expression, factMap, tupleInput: true, factInput: false);
-            var @delegate = ExpressionCompiler.Compile(optimizedExpression);
-            var argumentMap = new ArgumentMap(factMap, element.Expression.Parameters.Count);
-            var expression = new ActivationExpression<TResult>(element.Expression, @delegate, argumentMap);
-            return expression;
-        }
-
-        public IRuleAction CompileAction(ActionElement element, List<Declaration> declarations,
-            List<DependencyElement> dependencies, IndexMap tupleFactMap)
-        {
-            var activationFactMap = IndexMap.CreateMap(element.Imports, declarations);
-            var factMap = IndexMap.Compose(tupleFactMap, activationFactMap);
-
-            var dependencyIndexMap = IndexMap.CreateMap(element.Imports, dependencies.Select(x => x.Declaration));
-            if (dependencyIndexMap.HasData)
-            {
-                var optimizedExpression = ExpressionOptimizer
-                    .Optimize<Action<IContext, Tuple, IDependencyResolver, IResolutionContext>>(
-                        element.Expression, factMap, dependencies, dependencyIndexMap);
-                var @delegate = ExpressionCompiler.Compile(optimizedExpression);
-                var argumentMap = new ArgumentMap(factMap, element.Expression.Parameters.Count - 1);
-                var action = new RuleActionWithDependencies(element.Expression, @delegate, argumentMap, element.ActionTrigger);
-                return action;
-            }
-            else
-            {
-                var optimizedExpression = ExpressionOptimizer.Optimize<Action<IContext, Tuple>>(
-                    element.Expression, 1, factMap, tupleInput: true, factInput: false);
-                var @delegate = ExpressionCompiler.Compile(optimizedExpression);
-                var argumentMap = new ArgumentMap(factMap, element.Expression.Parameters.Count - 1);
-                var action = new RuleAction(element.Expression, @delegate, argumentMap, element.ActionTrigger);
-                return action;
-            }
-        }
-        
-        public IAggregateExpression CompileAggregateExpression(NamedExpressionElement element, List<Declaration> declarations)
-        {
-            var compiledExpression = CompileLhsExpression<object>(element, declarations);
-            var expression = new AggregateExpression(element.Name, compiledExpression);
-            return expression;
-        }
+    }
+    
+    public IAggregateExpression CompileAggregateExpression(NamedExpressionElement element, List<Declaration> declarations)
+    {
+        var compiledExpression = CompileLhsExpression<object>(element, declarations);
+        var expression = new AggregateExpression(element.Name, compiledExpression);
+        return expression;
     }
 }

--- a/src/NRules/NRules/Utilities/TriggerExtensions.cs
+++ b/src/NRules/NRules/Utilities/TriggerExtensions.cs
@@ -1,12 +1,11 @@
 ﻿using NRules.RuleModel;
 
-namespace NRules.Utilities
+namespace NRules.Utilities;
+
+internal static class TriggerExtensions
 {
-    internal static class TriggerExtensions
+    public static bool Matches(this MatchTrigger matchTrigger, ActionTrigger actionTrigger)
     {
-        public static bool Matches(this MatchTrigger matchTrigger, ActionTrigger actionTrigger)
-        {
-            return ((int)actionTrigger & (int)matchTrigger) != 0;
-        }
+        return ((int)actionTrigger & (int)matchTrigger) != 0;
     }
 }

--- a/src/NRules/NRules/WorkingMemory.cs
+++ b/src/NRules/NRules/WorkingMemory.cs
@@ -3,221 +3,220 @@ using System.Collections.Generic;
 using NRules.Rete;
 using Tuple = NRules.Rete.Tuple;
 
-namespace NRules
+namespace NRules;
+
+internal interface IWorkingMemory
 {
-    internal interface IWorkingMemory
+    IEnumerable<Fact> Facts { get; }
+
+    Fact GetFact(object factObject);
+    void AddFact(Fact fact);
+    void UpdateFact(Fact fact);
+    void RemoveFact(Fact fact);
+
+    IEnumerable<object> GetLinkedKeys(Activation activation);
+    Fact GetLinkedFact(Activation activation, object key);
+    void AddLinkedFact(Activation activation, object key, Fact fact);
+    void UpdateLinkedFact(Activation activation, object key, Fact fact, object factObject);
+    void RemoveLinkedFact(Activation activation, object key, Fact fact);
+
+    IAlphaMemory GetNodeMemory(IAlphaMemoryNode node);
+    IBetaMemory GetNodeMemory(IBetaMemoryNode node);
+
+    T GetState<T>(INode node, Tuple tuple);
+    T GetStateOrThrow<T>(INode node, Tuple tuple);
+    T RemoveState<T>(INode node, Tuple tuple);
+    T RemoveStateOrThrow<T>(INode node, Tuple tuple);
+    void SetState(INode node, Tuple tuple, object value);
+}
+
+internal class WorkingMemory : IWorkingMemory
+{
+    private readonly Dictionary<object, Fact> _factMap = new();
+    private readonly Dictionary<Activation, Dictionary<object, Fact>> _linkedFactMap = new();
+    private readonly Dictionary<TupleStateKey, object> _tupleStateMap = new();
+
+    private readonly Dictionary<IAlphaMemoryNode, IAlphaMemory> _alphaMap = new();
+
+    private readonly Dictionary<IBetaMemoryNode, IBetaMemory> _betaMap = new();
+
+    private static readonly object[] EmptyObjectList = Array.Empty<object>();
+
+    public IEnumerable<Fact> Facts => _factMap.Values;
+
+    public Fact GetFact(object factObject)
     {
-        IEnumerable<Fact> Facts { get; }
-
-        Fact GetFact(object factObject);
-        void AddFact(Fact fact);
-        void UpdateFact(Fact fact);
-        void RemoveFact(Fact fact);
-
-        IEnumerable<object> GetLinkedKeys(Activation activation);
-        Fact GetLinkedFact(Activation activation, object key);
-        void AddLinkedFact(Activation activation, object key, Fact fact);
-        void UpdateLinkedFact(Activation activation, object key, Fact fact, object factObject);
-        void RemoveLinkedFact(Activation activation, object key, Fact fact);
-
-        IAlphaMemory GetNodeMemory(IAlphaMemoryNode node);
-        IBetaMemory GetNodeMemory(IBetaMemoryNode node);
-
-        T GetState<T>(INode node, Tuple tuple);
-        T GetStateOrThrow<T>(INode node, Tuple tuple);
-        T RemoveState<T>(INode node, Tuple tuple);
-        T RemoveStateOrThrow<T>(INode node, Tuple tuple);
-        void SetState(INode node, Tuple tuple, object value);
+        _factMap.TryGetValue(factObject, out var fact);
+        return fact;
     }
 
-    internal class WorkingMemory : IWorkingMemory
+    public void AddFact(Fact fact)
     {
-        private readonly Dictionary<object, Fact> _factMap = new();
-        private readonly Dictionary<Activation, Dictionary<object, Fact>> _linkedFactMap = new();
-        private readonly Dictionary<TupleStateKey, object> _tupleStateMap = new();
+        _factMap.Add(fact.RawObject, fact);
+    }
 
-        private readonly Dictionary<IAlphaMemoryNode, IAlphaMemory> _alphaMap = new();
+    public void UpdateFact(Fact fact)
+    {
+        RemoveFact(fact);
+        AddFact(fact);
+    }
 
-        private readonly Dictionary<IBetaMemoryNode, IBetaMemory> _betaMap = new();
+    public void RemoveFact(Fact fact)
+    {
+        if (!_factMap.Remove(fact.RawObject))
+            throw new ArgumentException("Element does not exist", nameof(fact));
+    }
 
-        private static readonly object[] EmptyObjectList = Array.Empty<object>();
+    public IEnumerable<object> GetLinkedKeys(Activation activation)
+    {
+        if (!_linkedFactMap.TryGetValue(activation, out var factMap)) return EmptyObjectList;
+        return factMap.Keys;
+    }
 
-        public IEnumerable<Fact> Facts => _factMap.Values;
+    public Fact GetLinkedFact(Activation activation, object key)
+    {
+        if (!_linkedFactMap.TryGetValue(activation, out var factMap)) return null;
 
-        public Fact GetFact(object factObject)
+        factMap.TryGetValue(key, out var fact);
+        return fact;
+    }
+
+    public void AddLinkedFact(Activation activation, object key, Fact fact)
+    {
+        AddFact(fact);
+
+        if (!_linkedFactMap.TryGetValue(activation, out var factMap))
         {
-            _factMap.TryGetValue(factObject, out var fact);
-            return fact;
+            factMap = new Dictionary<object, Fact>();
+            _linkedFactMap[activation] = factMap;
         }
 
-        public void AddFact(Fact fact)
-        {
-            _factMap.Add(fact.RawObject, fact);
-        }
+        factMap.Add(key, fact);
+    }
 
-        public void UpdateFact(Fact fact)
+    public void UpdateLinkedFact(Activation activation, object key, Fact fact, object factObject)
+    {
+        if (!ReferenceEquals(fact.RawObject, factObject))
         {
             RemoveFact(fact);
+            fact.RawObject = factObject;
             AddFact(fact);
         }
 
-        public void RemoveFact(Fact fact)
+        if (!_linkedFactMap.TryGetValue(activation, out var factMap))
         {
-            if (!_factMap.Remove(fact.RawObject))
-                throw new ArgumentException("Element does not exist", nameof(fact));
+            factMap = new Dictionary<object, Fact>();
+            _linkedFactMap[activation] = factMap;
         }
 
-        public IEnumerable<object> GetLinkedKeys(Activation activation)
+        factMap.Remove(key);
+        factMap.Add(key, fact);
+    }
+
+    public void RemoveLinkedFact(Activation activation, object key, Fact fact)
+    {
+        if (!_linkedFactMap.TryGetValue(activation, out var factMap)) return;
+
+        factMap.Remove(key);
+        if (factMap.Count == 0) _linkedFactMap.Remove(activation);
+    }
+
+    public IAlphaMemory GetNodeMemory(IAlphaMemoryNode node)
+    {
+        if (!_alphaMap.TryGetValue(node, out var memory))
         {
-            if (!_linkedFactMap.TryGetValue(activation, out var factMap)) return EmptyObjectList;
-            return factMap.Keys;
+            memory = new AlphaMemory();
+            _alphaMap[node] = memory;
+        }
+        return memory;
+    }
+
+    public IBetaMemory GetNodeMemory(IBetaMemoryNode node)
+    {
+        if (!_betaMap.TryGetValue(node, out var memory))
+        {
+            memory = new BetaMemory();
+            _betaMap[node] = memory;
+        }
+        return memory;
+    }
+
+    public T GetState<T>(INode node, Tuple tuple)
+    {
+        var key = new TupleStateKey(node, tuple);
+        if (_tupleStateMap.TryGetValue(key, out var value))
+        {
+            return (T) value;
+        }
+        return default;
+    }
+    
+    public T GetStateOrThrow<T>(INode node, Tuple tuple)
+    {
+        var key = new TupleStateKey(node, tuple);
+        if (_tupleStateMap.TryGetValue(key, out var value))
+        {
+            return (T) value;
+        }
+        throw new ArgumentException($"Tuple state not found. NodeType={node.GetType()}, StateType={typeof(T)}");
+    }
+
+    public T RemoveState<T>(INode node, Tuple tuple)
+    {
+        var key = new TupleStateKey(node, tuple);
+        if (_tupleStateMap.TryGetValue(key, out var value))
+        {
+            var state = (T)value;
+            _tupleStateMap.Remove(key);
+            return state;
+        }
+        return default;
+    }
+
+    public T RemoveStateOrThrow<T>(INode node, Tuple tuple)
+    {
+        var key = new TupleStateKey(node, tuple);
+        if (_tupleStateMap.TryGetValue(key, out var value))
+        {
+            var state = (T)value;
+            _tupleStateMap.Remove(key);
+            return state;
+        }
+        throw new ArgumentException($"Tuple state not found. NodeType={node.GetType()}, StateType={typeof(T)}");
+    }
+
+    public void SetState(INode node, Tuple tuple, object value)
+    {
+        var key = new TupleStateKey(node, tuple);
+        _tupleStateMap[key] = value;
+    }
+
+    private readonly struct TupleStateKey : IEquatable<TupleStateKey>
+    {
+        private readonly INode _node;
+        private readonly Tuple _tuple;
+
+        public TupleStateKey(INode node, Tuple tuple)
+        {
+            _node = node;
+            _tuple = tuple;
         }
 
-        public Fact GetLinkedFact(Activation activation, object key)
+        public bool Equals(TupleStateKey other)
         {
-            if (!_linkedFactMap.TryGetValue(activation, out var factMap)) return null;
-
-            factMap.TryGetValue(key, out var fact);
-            return fact;
+            return _node.Equals(other._node) && _tuple.Equals(other._tuple);
         }
 
-        public void AddLinkedFact(Activation activation, object key, Fact fact)
+        public override bool Equals(object obj)
         {
-            AddFact(fact);
-
-            if (!_linkedFactMap.TryGetValue(activation, out var factMap))
-            {
-                factMap = new Dictionary<object, Fact>();
-                _linkedFactMap[activation] = factMap;
-            }
-
-            factMap.Add(key, fact);
+            return obj is TupleStateKey other && Equals(other);
         }
 
-        public void UpdateLinkedFact(Activation activation, object key, Fact fact, object factObject)
+        public override int GetHashCode()
         {
-            if (!ReferenceEquals(fact.RawObject, factObject))
+            unchecked
             {
-                RemoveFact(fact);
-                fact.RawObject = factObject;
-                AddFact(fact);
-            }
-
-            if (!_linkedFactMap.TryGetValue(activation, out var factMap))
-            {
-                factMap = new Dictionary<object, Fact>();
-                _linkedFactMap[activation] = factMap;
-            }
-
-            factMap.Remove(key);
-            factMap.Add(key, fact);
-        }
-
-        public void RemoveLinkedFact(Activation activation, object key, Fact fact)
-        {
-            if (!_linkedFactMap.TryGetValue(activation, out var factMap)) return;
-
-            factMap.Remove(key);
-            if (factMap.Count == 0) _linkedFactMap.Remove(activation);
-        }
-
-        public IAlphaMemory GetNodeMemory(IAlphaMemoryNode node)
-        {
-            if (!_alphaMap.TryGetValue(node, out var memory))
-            {
-                memory = new AlphaMemory();
-                _alphaMap[node] = memory;
-            }
-            return memory;
-        }
-
-        public IBetaMemory GetNodeMemory(IBetaMemoryNode node)
-        {
-            if (!_betaMap.TryGetValue(node, out var memory))
-            {
-                memory = new BetaMemory();
-                _betaMap[node] = memory;
-            }
-            return memory;
-        }
-
-        public T GetState<T>(INode node, Tuple tuple)
-        {
-            var key = new TupleStateKey(node, tuple);
-            if (_tupleStateMap.TryGetValue(key, out var value))
-            {
-                return (T) value;
-            }
-            return default;
-        }
-        
-        public T GetStateOrThrow<T>(INode node, Tuple tuple)
-        {
-            var key = new TupleStateKey(node, tuple);
-            if (_tupleStateMap.TryGetValue(key, out var value))
-            {
-                return (T) value;
-            }
-            throw new ArgumentException($"Tuple state not found. NodeType={node.GetType()}, StateType={typeof(T)}");
-        }
-
-        public T RemoveState<T>(INode node, Tuple tuple)
-        {
-            var key = new TupleStateKey(node, tuple);
-            if (_tupleStateMap.TryGetValue(key, out var value))
-            {
-                var state = (T)value;
-                _tupleStateMap.Remove(key);
-                return state;
-            }
-            return default;
-        }
-
-        public T RemoveStateOrThrow<T>(INode node, Tuple tuple)
-        {
-            var key = new TupleStateKey(node, tuple);
-            if (_tupleStateMap.TryGetValue(key, out var value))
-            {
-                var state = (T)value;
-                _tupleStateMap.Remove(key);
-                return state;
-            }
-            throw new ArgumentException($"Tuple state not found. NodeType={node.GetType()}, StateType={typeof(T)}");
-        }
-
-        public void SetState(INode node, Tuple tuple, object value)
-        {
-            var key = new TupleStateKey(node, tuple);
-            _tupleStateMap[key] = value;
-        }
-
-        private readonly struct TupleStateKey : IEquatable<TupleStateKey>
-        {
-            private readonly INode _node;
-            private readonly Tuple _tuple;
-
-            public TupleStateKey(INode node, Tuple tuple)
-            {
-                _node = node;
-                _tuple = tuple;
-            }
-
-            public bool Equals(TupleStateKey other)
-            {
-                return _node.Equals(other._node) && _tuple.Equals(other._tuple);
-            }
-
-            public override bool Equals(object obj)
-            {
-                return obj is TupleStateKey other && Equals(other);
-            }
-
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    return (_node.GetHashCode() * 397) ^ _tuple.GetHashCode();
-                }
+                return (_node.GetHashCode() * 397) ^ _tuple.GetHashCode();
             }
         }
     }

--- a/src/NRules/Tests/NRules.IntegrationTests/ActionInterceptorTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/ActionInterceptorTest.cs
@@ -6,148 +6,147 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class ActionInterceptorTest : BaseRuleTestFixture
 {
-    public class ActionInterceptorTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_ConditionsMatchNoInterceptor_ExecutesAction()
     {
-        [Fact]
-        public void Fire_ConditionsMatchNoInterceptor_ExecutesAction()
+        //Arrange
+        var fact1 = new FactType1();
+        var fact2 = new FactType2();
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        bool actionExecuted = false;
+        GetRuleInstance<TestRule>().Action = () => { actionExecuted = true; };
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.True(actionExecuted);
+    }
+
+    [Fact]
+    public void Fire_ConditionsMatchInterceptorInvokes_ExecutesAction()
+    {
+        //Arrange
+        Session.ActionInterceptor = new ActionInterceptor(invoke: true);
+
+        var fact1 = new FactType1();
+        var fact2 = new FactType2();
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        bool actionExecuted = false;
+        GetRuleInstance<TestRule>().Action = () => { actionExecuted = true; };
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.True(actionExecuted);
+    }
+
+    [Fact]
+    public void Fire_InterceptorInvokesActionThatThrows_ExceptionNotWrapped()
+    {
+        //Arrange
+        Session.ActionInterceptor = new ActionInterceptor(invoke: true);
+
+        var fact1 = new FactType1();
+        var fact2 = new FactType2();
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        GetRuleInstance<TestRule>().Action = () => { throw new InvalidOperationException("Test"); };
+
+        //Act - Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => Session.Fire());
+        Assert.Equal("Test", ex.Message);
+    }
+
+    [Fact]
+    public void Fire_ConditionsMatchInterceptorDoesNotInvoke_DoesNotExecuteAction()
+    {
+        //Arrange
+        Session.ActionInterceptor = new ActionInterceptor(invoke: false);
+
+        var fact1 = new FactType1();
+        var fact2 = new FactType2();
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        bool actionExecuted = false;
+        GetRuleInstance<TestRule>().Action = () => { actionExecuted = true; };
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.False(actionExecuted);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    private class ActionInterceptor : IActionInterceptor
+    {
+        private readonly bool _invoke;
+
+        public ActionInterceptor(bool invoke)
         {
-            //Arrange
-            var fact1 = new FactType1();
-            var fact2 = new FactType2();
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            bool actionExecuted = false;
-            GetRuleInstance<TestRule>().Action = () => { actionExecuted = true; };
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.True(actionExecuted);
+            _invoke = invoke;
         }
 
-        [Fact]
-        public void Fire_ConditionsMatchInterceptorInvokes_ExecutesAction()
+        public void Intercept(IContext context, IEnumerable<IActionInvocation> actions)
         {
-            //Arrange
-            Session.ActionInterceptor = new ActionInterceptor(invoke: true);
-
-            var fact1 = new FactType1();
-            var fact2 = new FactType2();
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            bool actionExecuted = false;
-            GetRuleInstance<TestRule>().Action = () => { actionExecuted = true; };
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.True(actionExecuted);
-        }
-
-        [Fact]
-        public void Fire_InterceptorInvokesActionThatThrows_ExceptionNotWrapped()
-        {
-            //Arrange
-            Session.ActionInterceptor = new ActionInterceptor(invoke: true);
-
-            var fact1 = new FactType1();
-            var fact2 = new FactType2();
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            GetRuleInstance<TestRule>().Action = () => { throw new InvalidOperationException("Test"); };
-
-            //Act - Assert
-            var ex = Assert.Throws<InvalidOperationException>(() => Session.Fire());
-            Assert.Equal("Test", ex.Message);
-        }
-
-        [Fact]
-        public void Fire_ConditionsMatchInterceptorDoesNotInvoke_DoesNotExecuteAction()
-        {
-            //Arrange
-            Session.ActionInterceptor = new ActionInterceptor(invoke: false);
-
-            var fact1 = new FactType1();
-            var fact2 = new FactType2();
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            bool actionExecuted = false;
-            GetRuleInstance<TestRule>().Action = () => { actionExecuted = true; };
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.False(actionExecuted);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        private class ActionInterceptor : IActionInterceptor
-        {
-            private readonly bool _invoke;
-
-            public ActionInterceptor(bool invoke)
+            if (_invoke)
             {
-                _invoke = invoke;
-            }
-
-            public void Intercept(IContext context, IEnumerable<IActionInvocation> actions)
-            {
-                if (_invoke)
+                foreach (var action in actions)
                 {
-                    foreach (var action in actions)
-                    {
-                        action.Invoke();
-                    }
+                    action.Invoke();
                 }
             }
         }
+    }
 
-        public class FactType1
+    public class FactType1
+    {
+    }
+
+    public class FactType2
+    {
+    }
+
+    public class TestRule : Rule
+    {
+        public Action Action = () => { };
+
+        public override void Define()
         {
+            FactType1 fact = null;
+            IEnumerable<FactType2> collection = null;
+
+            When()
+                .Match<FactType1>(() => fact)
+                .Query(() => collection, x => x
+                    .Match<FactType2>()
+                    .Collect());
+            Then()
+                .Do(ctx => CallAction(ctx, fact, collection));
         }
 
-        public class FactType2
+        private void CallAction(IContext context, FactType1 fact1, IEnumerable<FactType2> collection2)
         {
-        }
-
-        public class TestRule : Rule
-        {
-            public Action Action = () => { };
-
-            public override void Define()
-            {
-                FactType1 fact = null;
-                IEnumerable<FactType2> collection = null;
-
-                When()
-                    .Match<FactType1>(() => fact)
-                    .Query(() => collection, x => x
-                        .Match<FactType2>()
-                        .Collect());
-                Then()
-                    .Do(ctx => CallAction(ctx, fact, collection));
-            }
-
-            private void CallAction(IContext context, FactType1 fact1, IEnumerable<FactType2> collection2)
-            {
-                Action();
-            }
+            Action();
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/ActionTriggerTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/ActionTriggerTest.cs
@@ -4,1581 +4,1580 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class ActionTriggerRepeatableTest : BaseRuleTestFixture
 {
-    public class ActionTriggerRepeatableTest : BaseRuleTestFixture
+    public ActionTriggerRepeatableTest()
     {
-        public ActionTriggerRepeatableTest()
-        {
-            _matchActionCount = 0;
-            _rematchActionCount = 0;
-            _unmatchActionCount = 0;
-        }
-
-        private static int _matchActionCount;
-        private static int _rematchActionCount;
-        private static int _unmatchActionCount;
-
-        private static readonly Action OnMatchAction = () => { _matchActionCount++; };
-        private static readonly Action OnReMatchAction = () => { _rematchActionCount++; };
-        private static readonly Action OnUnMatchAction = () => { _unmatchActionCount++; };
-
-        [Fact]
-        public void Fire_InsertThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_FilterOffInsertThenFire_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            fact.AcceptFilter = false;
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(0, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            Session.Insert(fact);
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFilterOffThenUpdateThenFire_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            Session.Insert(fact);
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(0, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_FilterOffInsertThenFilterOnThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            fact.AcceptFilter = false;
-            Session.Insert(fact);
-            fact.AcceptFilter = true;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFire_FiresOnMatchAndOnRematch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenTwoUpdatesThenFire_FiresOnMatchAndOnRematch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenUpdateThenFilterOnThenUpdateThenFire_FiresOnMatchAndOnRematch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            fact.AcceptFilter = true;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFilterOffThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFireThenUpdateThenFire_FiresOnMatchAndOnRematchTwice()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(2, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenRetractThenFire_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(0, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-        
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnRematchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenRetractThenFireThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(2, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenRetractThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(2, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public bool AcceptFilter { get; set; } = true;
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match(() => fact);
-
-                Filter()
-                    .Where(() => fact.AcceptFilter);
-
-                Then()
-                    .Action(ctx => OnMatchAction(), ActionTrigger.Activated)
-                    .Action(ctx => OnReMatchAction(), ActionTrigger.Reactivated)
-                    .Action(ctx => OnUnMatchAction(), ActionTrigger.Deactivated);
-            }
-        }
+        _matchActionCount = 0;
+        _rematchActionCount = 0;
+        _unmatchActionCount = 0;
     }
 
-    public class ActionTriggerNonRepeatableTest : BaseRuleTestFixture
+    private static int _matchActionCount;
+    private static int _rematchActionCount;
+    private static int _unmatchActionCount;
+
+    private static readonly Action OnMatchAction = () => { _matchActionCount++; };
+    private static readonly Action OnReMatchAction = () => { _rematchActionCount++; };
+    private static readonly Action OnUnMatchAction = () => { _unmatchActionCount++; };
+
+    [Fact]
+    public void Fire_InsertThenFire_FiresOnMatch()
     {
-        public ActionTriggerNonRepeatableTest()
-        {
-            _matchActionCount = 0;
-            _rematchActionCount = 0;
-            _unmatchActionCount = 0;
-        }
-
-        private static int _matchActionCount;
-        private static int _rematchActionCount;
-        private static int _unmatchActionCount;
-
-        private static readonly Action OnMatchAction = () => { _matchActionCount++; };
-        private static readonly Action OnReMatchAction = () => { _rematchActionCount++; };
-        private static readonly Action OnUnMatchAction = () => { _unmatchActionCount++; };
-
-        [Fact]
-        public void Fire_InsertThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_FilterOffInsertThenFire_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            fact.AcceptFilter = false;
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(0, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            Session.Insert(fact);
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFilterOffThenUpdateThenFire_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            Session.Insert(fact);
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(0, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_FilterOffInsertThenFilterOnThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            fact.AcceptFilter = false;
-            Session.Insert(fact);
-            fact.AcceptFilter = true;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenTwoUpdatesThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenUpdateThenFilterOnThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            fact.AcceptFilter = true;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFilterOffThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFireThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenRetractThenFire_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(0, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
+        //Arrange
+        var fact = new FactType();
         
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
 
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenRetractThenFireThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(2, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenRetractThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(2, _matchActionCount);
-            Assert.Equal(0, _rematchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public bool AcceptFilter { get; set; } = true;
-        }
-
-        [Repeatability(RuleRepeatability.NonRepeatable)]
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match(() => fact);
-
-                Filter()
-                    .Where(() => fact.AcceptFilter);
-
-                Then()
-                    .Action(ctx => OnMatchAction(), ActionTrigger.Activated)
-                    .Action(ctx => OnReMatchAction(), ActionTrigger.Reactivated)
-                    .Action(ctx => OnUnMatchAction(), ActionTrigger.Deactivated);
-            }
-        }
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
     }
 
-    public class ActionTriggerNoUpdateRepeatableTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_FilterOffInsertThenFire_DoesNotFire()
     {
-        public ActionTriggerNoUpdateRepeatableTest()
-        {
-            _matchActionCount = 0;
-            _unmatchActionCount = 0;
-        }
-
-        private static int _matchActionCount;
-        private static int _unmatchActionCount;
-
-        private static readonly Action OnMatchAction = () => { _matchActionCount++; };
-        private static readonly Action OnUnMatchAction = () => { _unmatchActionCount++; };
-
-        [Fact]
-        public void Fire_InsertThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_FilterOffInsertThenFire_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            fact.AcceptFilter = false;
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(0, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            Session.Insert(fact);
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFilterOffThenUpdateThenFire_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            Session.Insert(fact);
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(0, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_FilterOffInsertThenFilterOnThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            fact.AcceptFilter = false;
-            Session.Insert(fact);
-            fact.AcceptFilter = true;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFire_FiresOnMatchAndOnRematch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenTwoUpdatesThenFire_FiresOnMatchAndOnRematch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenUpdateThenFilterOnThenUpdateThenFire_FiresOnMatchAndOnRematch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            fact.AcceptFilter = true;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFilterOffThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFireThenUpdateThenFire_FiresOnMatchAndOnRematchTwice()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenRetractThenFire_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(0, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
+        //Arrange
+        var fact = new FactType();
         
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnRematchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
+        //Act
+        fact.AcceptFilter = false;
+        Session.Insert(fact);
+        Session.Fire();
 
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenRetractThenFireThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(2, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenRetractThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(2, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public bool AcceptFilter { get; set; } = true;
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match(() => fact);
-
-                Filter()
-                    .Where(() => fact.AcceptFilter);
-
-                Then()
-                    .Action(ctx => OnMatchAction(), ActionTrigger.Activated)
-                    .Action(ctx => OnUnMatchAction(), ActionTrigger.Deactivated);
-            }
-        }
+        //Assert
+        Assert.Equal(0, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
     }
 
-    public class ActionTriggerNoUpdateNonRepeatableTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_InsertThenUpdateThenFire_FiresOnMatch()
     {
-        public ActionTriggerNoUpdateNonRepeatableTest()
-        {
-            _matchActionCount = 0;
-            _unmatchActionCount = 0;
-        }
-
-        private static int _matchActionCount;
-        private static int _unmatchActionCount;
-
-        private static readonly Action OnMatchAction = () => { _matchActionCount++; };
-        private static readonly Action OnUnMatchAction = () => { _unmatchActionCount++; };
-
-        [Fact]
-        public void Fire_InsertThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_FilterOffInsertThenFire_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            fact.AcceptFilter = false;
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(0, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            Session.Insert(fact);
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFilterOffThenUpdateThenFire_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            Session.Insert(fact);
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(0, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_FilterOffInsertThenFilterOnThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-            
-            //Act
-            fact.AcceptFilter = false;
-            Session.Insert(fact);
-            fact.AcceptFilter = true;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenTwoUpdatesThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenUpdateThenFilterOnThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            fact.AcceptFilter = true;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFilterOffThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFireThenUpdateThenFire_FiresOnMatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenRetractThenFire_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(0, _matchActionCount);
-            Assert.Equal(0, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenRetractThenFire_FiresOnMatchAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Retract(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
+        //Arrange
+        var fact = new FactType();
         
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+        //Act
+        Session.Insert(fact);
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFilterOffThenUpdateThenFire_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        Session.Insert(fact);
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(0, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_FilterOffInsertThenFilterOnThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        fact.AcceptFilter = false;
+        Session.Insert(fact);
+        fact.AcceptFilter = true;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFire_FiresOnMatchAndOnRematch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenTwoUpdatesThenFire_FiresOnMatchAndOnRematch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenUpdateThenFilterOnThenUpdateThenFire_FiresOnMatchAndOnRematch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        fact.AcceptFilter = true;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFilterOffThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFireThenUpdateThenFire_FiresOnMatchAndOnRematchTwice()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(2, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenRetractThenFire_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(0, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+    
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnRematchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenRetractThenFireThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(2, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenRetractThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(2, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public bool AcceptFilter { get; set; } = true;
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact = new FactType();
+            FactType fact = null;
 
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
+            When()
+                .Match(() => fact);
 
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
+            Filter()
+                .Where(() => fact.AcceptFilter);
+
+            Then()
+                .Action(ctx => OnMatchAction(), ActionTrigger.Activated)
+                .Action(ctx => OnReMatchAction(), ActionTrigger.Reactivated)
+                .Action(ctx => OnUnMatchAction(), ActionTrigger.Deactivated);
         }
+    }
+}
 
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+public class ActionTriggerNonRepeatableTest : BaseRuleTestFixture
+{
+    public ActionTriggerNonRepeatableTest()
+    {
+        _matchActionCount = 0;
+        _rematchActionCount = 0;
+        _unmatchActionCount = 0;
+    }
+
+    private static int _matchActionCount;
+    private static int _rematchActionCount;
+    private static int _unmatchActionCount;
+
+    private static readonly Action OnMatchAction = () => { _matchActionCount++; };
+    private static readonly Action OnReMatchAction = () => { _rematchActionCount++; };
+    private static readonly Action OnUnMatchAction = () => { _unmatchActionCount++; };
+
+    [Fact]
+    public void Fire_InsertThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_FilterOffInsertThenFire_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        fact.AcceptFilter = false;
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(0, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        Session.Insert(fact);
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFilterOffThenUpdateThenFire_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        Session.Insert(fact);
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(0, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_FilterOffInsertThenFilterOnThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        fact.AcceptFilter = false;
+        Session.Insert(fact);
+        fact.AcceptFilter = true;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenTwoUpdatesThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenUpdateThenFilterOnThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        fact.AcceptFilter = true;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFilterOffThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFireThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenRetractThenFire_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(0, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+    
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenRetractThenFireThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(2, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenRetractThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(2, _matchActionCount);
+        Assert.Equal(0, _rematchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public bool AcceptFilter { get; set; } = true;
+    }
+
+    [Repeatability(RuleRepeatability.NonRepeatable)]
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact = new FactType();
+            FactType fact = null;
 
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
+            When()
+                .Match(() => fact);
 
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
+            Filter()
+                .Where(() => fact.AcceptFilter);
+
+            Then()
+                .Action(ctx => OnMatchAction(), ActionTrigger.Activated)
+                .Action(ctx => OnReMatchAction(), ActionTrigger.Reactivated)
+                .Action(ctx => OnUnMatchAction(), ActionTrigger.Deactivated);
         }
+    }
+}
 
-        [Fact]
-        public void Fire_InsertThenFireThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+public class ActionTriggerNoUpdateRepeatableTest : BaseRuleTestFixture
+{
+    public ActionTriggerNoUpdateRepeatableTest()
+    {
+        _matchActionCount = 0;
+        _unmatchActionCount = 0;
+    }
+
+    private static int _matchActionCount;
+    private static int _unmatchActionCount;
+
+    private static readonly Action OnMatchAction = () => { _matchActionCount++; };
+    private static readonly Action OnUnMatchAction = () => { _unmatchActionCount++; };
+
+    [Fact]
+    public void Fire_InsertThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_FilterOffInsertThenFire_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        fact.AcceptFilter = false;
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(0, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        Session.Insert(fact);
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFilterOffThenUpdateThenFire_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        Session.Insert(fact);
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(0, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_FilterOffInsertThenFilterOnThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        fact.AcceptFilter = false;
+        Session.Insert(fact);
+        fact.AcceptFilter = true;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFire_FiresOnMatchAndOnRematch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenTwoUpdatesThenFire_FiresOnMatchAndOnRematch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenUpdateThenFilterOnThenUpdateThenFire_FiresOnMatchAndOnRematch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        fact.AcceptFilter = true;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFilterOffThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFireThenUpdateThenFire_FiresOnMatchAndOnRematchTwice()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenRetractThenFire_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(0, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+    
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnRematchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenRetractThenFireThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(2, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenRetractThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(2, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public bool AcceptFilter { get; set; } = true;
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact = new FactType();
+            FactType fact = null;
 
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Update(fact);
-            Session.Retract(fact);
-            Session.Fire();
+            When()
+                .Match(() => fact);
 
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
+            Filter()
+                .Where(() => fact.AcceptFilter);
+
+            Then()
+                .Action(ctx => OnMatchAction(), ActionTrigger.Activated)
+                .Action(ctx => OnUnMatchAction(), ActionTrigger.Deactivated);
         }
+    }
+}
 
-        [Fact]
-        public void Fire_InsertThenFireThenFilterOffThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+public class ActionTriggerNoUpdateNonRepeatableTest : BaseRuleTestFixture
+{
+    public ActionTriggerNoUpdateNonRepeatableTest()
+    {
+        _matchActionCount = 0;
+        _unmatchActionCount = 0;
+    }
+
+    private static int _matchActionCount;
+    private static int _unmatchActionCount;
+
+    private static readonly Action OnMatchAction = () => { _matchActionCount++; };
+    private static readonly Action OnUnMatchAction = () => { _unmatchActionCount++; };
+
+    [Fact]
+    public void Fire_InsertThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_FilterOffInsertThenFire_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        fact.AcceptFilter = false;
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(0, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        Session.Insert(fact);
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFilterOffThenUpdateThenFire_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        Session.Insert(fact);
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(0, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_FilterOffInsertThenFilterOnThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+        
+        //Act
+        fact.AcceptFilter = false;
+        Session.Insert(fact);
+        fact.AcceptFilter = true;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenTwoUpdatesThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenUpdateThenFilterOnThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        fact.AcceptFilter = true;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFilterOffThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFireThenUpdateThenFire_FiresOnMatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenRetractThenFire_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(0, _matchActionCount);
+        Assert.Equal(0, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+    
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenUpdateThenFireThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Update(fact);
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenFilterOffThenUpdateThenRetractThenFire_FiresOnMatchAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        fact.AcceptFilter = false;
+        Session.Update(fact);
+        Session.Retract(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(1, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenRetractThenFireThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Fire();
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(2, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    [Fact]
+    public void Fire_InsertThenFireThenRetractThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
+    {
+        //Arrange
+        var fact = new FactType();
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+        Session.Retract(fact);
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        Assert.Equal(2, _matchActionCount);
+        Assert.Equal(1, _unmatchActionCount);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public bool AcceptFilter { get; set; } = true;
+    }
+
+    [Repeatability(RuleRepeatability.NonRepeatable)]
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact = new FactType();
+            FactType fact = null;
 
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            fact.AcceptFilter = false;
-            Session.Update(fact);
-            Session.Retract(fact);
-            Session.Fire();
+            When()
+                .Match(() => fact);
 
-            //Assert
-            Assert.Equal(1, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
+            Filter()
+                .Where(() => fact.AcceptFilter);
 
-        [Fact]
-        public void Fire_InsertThenFireThenRetractThenFireThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Fire();
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(2, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        [Fact]
-        public void Fire_InsertThenFireThenRetractThenInsertThenFire_FiresOnMatchTwiceAndOnUnmatch()
-        {
-            //Arrange
-            var fact = new FactType();
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-            Session.Retract(fact);
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            Assert.Equal(2, _matchActionCount);
-            Assert.Equal(1, _unmatchActionCount);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public bool AcceptFilter { get; set; } = true;
-        }
-
-        [Repeatability(RuleRepeatability.NonRepeatable)]
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match(() => fact);
-
-                Filter()
-                    .Where(() => fact.AcceptFilter);
-
-                Then()
-                    .Action(ctx => OnMatchAction(), ActionTrigger.Activated)
-                    .Action(ctx => OnUnMatchAction(), ActionTrigger.Deactivated);
-            }
+            Then()
+                .Action(ctx => OnMatchAction(), ActionTrigger.Activated)
+                .Action(ctx => OnUnMatchAction(), ActionTrigger.Deactivated);
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/AggregateEvaluationExceptionTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/AggregateEvaluationExceptionTest.cs
@@ -7,414 +7,413 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class AggregateEvaluationExceptionTest : BaseRuleTestFixture
 {
-    public class AggregateEvaluationExceptionTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_ErrorInAggregateNoErrorHandler_Throws()
     {
-        [Fact]
-        public void Fire_ErrorInAggregateNoErrorHandler_Throws()
+        //Arrange
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+
+        Expression expression = null;
+        IList<IFact> facts = null;
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => expression = args.Expression;
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => facts = args.Facts.ToList();
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+
+        //Act - Assert
+        var ex = Assert.Throws<RuleLhsExpressionEvaluationException>(() => Session.Insert(fact21));
+        Assert.NotNull(expression);
+        Assert.Equal(2, facts.Count);
+        Assert.Same(fact11, facts.First().Value);
+        Assert.Same(fact21, facts.Skip(1).First().Value);
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void Fire_FailedAssert_DoesNotFire()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_AssertThenFailedAssertForSameJoin_DoesNotFire()
+    {
+        //Arrange
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact21);
+
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+
+        var fact22 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact22);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FailedAssertThenAssertForSameJoin_Fires()
+    {
+        //Arrange
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact21);
+
+        GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
+
+        var fact22 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact22);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        var group = GetFiredFact<IEnumerable<FactType2>>();
+        Assert.Equal(2, group.Count());
+    }
+
+    [Fact]
+    public void Fire_FailedAssertThenAssertForSameJoinThenUpdate_Fires()
+    {
+        //Arrange
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact21);
+
+        GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
+
+        var fact22 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact22);
+
+        Session.Update(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        var group = GetFiredFact<IEnumerable<FactType2>>();
+        Assert.Equal(2, group.Count());
+    }
+
+    [Fact]
+    public void Fire_AssertThenFailedAssertForDifferentJoin_FiresForSuccessfulJoin()
+    {
+        //Arrange
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        var fact12 = new FactType1 { TestProperty = "Valid Value 2" };
+        Session.Insert(fact12);
+
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact21);
+
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+
+        var fact22 = new FactType2 { GroupProperty = "Group2", JoinProperty = "Valid Value 2" };
+        Session.Insert(fact22);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Valid Value 1", GetFiredFact<FactType1>().TestProperty);
+    }
+
+    [Fact]
+    public void Fire_FailedAssertThenAssertForDifferentJoin_FiresForSuccessfulJoin()
+    {
+        //Arrange
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        var fact12 = new FactType1 { TestProperty = "Valid Value 2" };
+        Session.Insert(fact12);
+
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact21);
+
+        GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
+
+        var fact22 = new FactType2 { GroupProperty = "Group2", JoinProperty = "Valid Value 2" };
+        Session.Insert(fact22);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Valid Value 2", GetFiredFact<FactType1>().TestProperty);
+    }
+
+    [Fact]
+    public void Fire_AssertThenFailedUpdate_DoesNotFire()
+    {
+        //Arrange
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact21);
+
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+        Session.Update(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_AssertThenFailedUpdateThenUpdate_Fires()
+    {
+        //Arrange
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact21);
+
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+        Session.Update(fact21);
+
+        GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
+        Session.Update(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_FailedAssertThenUpdate_Fires()
+    {
+        //Arrange
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+        
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact21);
+
+        GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
+        
+        Session.Update(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_FailedAssertThenUpdateJoin_Fires()
+    {
+        //Arrange
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact21);
+
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+
+        var fact22 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact22);
+
+        GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
+        
+        Session.Update(fact11);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        var group = GetFiredFact<IEnumerable<FactType2>>();
+        Assert.Equal(2, group.Count());
+    }
+
+    [Fact]
+    public void Fire_FailedAssertThenUpdateThenRetract_DoesNotFire()
+    {
+        //Arrange
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+        
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact21);
+
+        GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
+        
+        Session.Update(fact21);
+        Session.Retract(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FailedAssertThenRetract_DoesNotFire()
+    {
+        //Arrange
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+        
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact21);
+
+        GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
+        
+        Session.Retract(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FailedAssertThenRetractJoined_DoesNotFire()
+    {
+        //Arrange
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        Session.Insert(fact11);
+
+        GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+        
+        var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact21);
+
+        GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
+        
+        Session.Retract(fact11);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    private static readonly Func<FactType2, object> SuccessfulGrouping = x => x.GroupProperty;
+    private static readonly Func<FactType2, object> ThrowGrouping = x => throw new InvalidOperationException("Grouping failed");
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string JoinProperty { get; set; }
+        public string GroupProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public Func<FactType2, object> Grouping = SuccessfulGrouping;
+
+        public override void Define()
         {
-            //Arrange
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
+            FactType1 fact1 = null;
+            IEnumerable<FactType2> fact2Group = null;
 
-            Expression expression = null;
-            IList<IFact> facts = null;
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => expression = args.Expression;
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => facts = args.Facts.ToList();
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-
-            //Act - Assert
-            var ex = Assert.Throws<RuleLhsExpressionEvaluationException>(() => Session.Insert(fact21));
-            Assert.NotNull(expression);
-            Assert.Equal(2, facts.Count);
-            Assert.Same(fact11, facts.First().Value);
-            Assert.Same(fact21, facts.Skip(1).First().Value);
-            Assert.IsType<InvalidOperationException>(ex.InnerException);
+            When()
+                .Match(() => fact1)
+                .Query(() => fact2Group, q => q
+                    .Match<FactType2>(f => f.JoinProperty == fact1.TestProperty)
+                    .GroupBy(f => Grouping(f))
+                    .Select(x => x)
+                );
+            Then()
+                .Do(ctx => NoOp());
         }
 
-        [Fact]
-        public void Fire_FailedAssert_DoesNotFire()
-        {
-            //Arrange
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
-
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_AssertThenFailedAssertForSameJoin_DoesNotFire()
-        {
-            //Arrange
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact21);
-
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
-
-            var fact22 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact22);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FailedAssertThenAssertForSameJoin_Fires()
-        {
-            //Arrange
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
-
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact21);
-
-            GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
-
-            var fact22 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact22);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            var group = GetFiredFact<IEnumerable<FactType2>>();
-            Assert.Equal(2, group.Count());
-        }
-
-        [Fact]
-        public void Fire_FailedAssertThenAssertForSameJoinThenUpdate_Fires()
-        {
-            //Arrange
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
-
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact21);
-
-            GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
-
-            var fact22 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact22);
-
-            Session.Update(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            var group = GetFiredFact<IEnumerable<FactType2>>();
-            Assert.Equal(2, group.Count());
-        }
-
-        [Fact]
-        public void Fire_AssertThenFailedAssertForDifferentJoin_FiresForSuccessfulJoin()
-        {
-            //Arrange
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            var fact12 = new FactType1 { TestProperty = "Valid Value 2" };
-            Session.Insert(fact12);
-
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact21);
-
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
-
-            var fact22 = new FactType2 { GroupProperty = "Group2", JoinProperty = "Valid Value 2" };
-            Session.Insert(fact22);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Valid Value 1", GetFiredFact<FactType1>().TestProperty);
-        }
-
-        [Fact]
-        public void Fire_FailedAssertThenAssertForDifferentJoin_FiresForSuccessfulJoin()
-        {
-            //Arrange
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            var fact12 = new FactType1 { TestProperty = "Valid Value 2" };
-            Session.Insert(fact12);
-
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
-
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact21);
-
-            GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
-
-            var fact22 = new FactType2 { GroupProperty = "Group2", JoinProperty = "Valid Value 2" };
-            Session.Insert(fact22);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Valid Value 2", GetFiredFact<FactType1>().TestProperty);
-        }
-
-        [Fact]
-        public void Fire_AssertThenFailedUpdate_DoesNotFire()
-        {
-            //Arrange
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact21);
-
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
-            Session.Update(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_AssertThenFailedUpdateThenUpdate_Fires()
-        {
-            //Arrange
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact21);
-
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
-            Session.Update(fact21);
-
-            GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
-            Session.Update(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_FailedAssertThenUpdate_Fires()
-        {
-            //Arrange
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
-            
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact21);
-
-            GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
-            
-            Session.Update(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_FailedAssertThenUpdateJoin_Fires()
-        {
-            //Arrange
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact21);
-
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
-
-            var fact22 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact22);
-
-            GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
-            
-            Session.Update(fact11);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            var group = GetFiredFact<IEnumerable<FactType2>>();
-            Assert.Equal(2, group.Count());
-        }
-
-        [Fact]
-        public void Fire_FailedAssertThenUpdateThenRetract_DoesNotFire()
-        {
-            //Arrange
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
-            
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact21);
-
-            GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
-            
-            Session.Update(fact21);
-            Session.Retract(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FailedAssertThenRetract_DoesNotFire()
-        {
-            //Arrange
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
-            
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact21);
-
-            GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
-            
-            Session.Retract(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FailedAssertThenRetractJoined_DoesNotFire()
-        {
-            //Arrange
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            Session.Insert(fact11);
-
-            GetRuleInstance<TestRule>().Grouping = ThrowGrouping;
-            
-            var fact21 = new FactType2 { GroupProperty = "Group1", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact21);
-
-            GetRuleInstance<TestRule>().Grouping = x => x.GroupProperty;
-            
-            Session.Retract(fact11);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        private static readonly Func<FactType2, object> SuccessfulGrouping = x => x.GroupProperty;
-        private static readonly Func<FactType2, object> ThrowGrouping = x => throw new InvalidOperationException("Grouping failed");
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string JoinProperty { get; set; }
-            public string GroupProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public Func<FactType2, object> Grouping = SuccessfulGrouping;
-
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-                IEnumerable<FactType2> fact2Group = null;
-
-                When()
-                    .Match(() => fact1)
-                    .Query(() => fact2Group, q => q
-                        .Match<FactType2>(f => f.JoinProperty == fact1.TestProperty)
-                        .GroupBy(f => Grouping(f))
-                        .Select(x => x)
-                    );
-                Then()
-                    .Do(ctx => NoOp());
-            }
-
-            private static void NoOp() { }
-        }
+        private static void NoOp() { }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/AggregateSubnetTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/AggregateSubnetTest.cs
@@ -3,90 +3,89 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class AggregateSubnetTest : BaseRuleTestFixture
 {
-    public class AggregateSubnetTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFactInsertedThenUpdatedNoFactsOfSecondKind_UpdatePropagatesFiresOnce()
     {
-        [Fact]
-        public void Fire_OneMatchingFactInsertedThenUpdatedNoFactsOfSecondKind_UpdatePropagatesFiresOnce()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        Session.Insert(fact1);
+
+        fact1.TestProperty = "Valid Value 2";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        var calculatedFact = GetFiredFact<CalculatedFact>();
+        Assert.Equal("Valid Value 2", calculatedFact.Value);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactInsertedThenUpdatedHasFactsOfSecondKind_UpdatePropagatesFiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        Session.Insert(fact1);
+
+        var fact2 = new FactType2 {TestProperty = "Valid Value 1"};
+        Session.Insert(fact2);
+
+        fact1.TestProperty = "Valid Value 2";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        var calculatedFact = GetFiredFact<CalculatedFact>();
+        Assert.Equal("Valid Value 2", calculatedFact.Value);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class CalculatedFact
+    {
+        public string Value { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            Session.Insert(fact1);
+            FactType1 fact1 = null;
+            IEnumerable<FactType2> query = null;
+            CalculatedFact calculatedFact = null;
 
-            fact1.TestProperty = "Valid Value 2";
-            Session.Update(fact1);
+            When()
+                .Match(() => fact1)
+                .Query(() => query, q => q
+                    .Match<FactType2>(f => f.TestProperty.StartsWith("Valid"))
+                    .Select(x => x)
+                    .Collect())
+                .Let(() => calculatedFact, () => new CalculatedFact {Value = fact1.TestProperty});
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            var calculatedFact = GetFiredFact<CalculatedFact>();
-            Assert.Equal("Valid Value 2", calculatedFact.Value);
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactInsertedThenUpdatedHasFactsOfSecondKind_UpdatePropagatesFiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            Session.Insert(fact1);
-
-            var fact2 = new FactType2 {TestProperty = "Valid Value 1"};
-            Session.Insert(fact2);
-
-            fact1.TestProperty = "Valid Value 2";
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            var calculatedFact = GetFiredFact<CalculatedFact>();
-            Assert.Equal("Valid Value 2", calculatedFact.Value);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class CalculatedFact
-        {
-            public string Value { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-                IEnumerable<FactType2> query = null;
-                CalculatedFact calculatedFact = null;
-
-                When()
-                    .Match(() => fact1)
-                    .Query(() => query, q => q
-                        .Match<FactType2>(f => f.TestProperty.StartsWith("Valid"))
-                        .Select(x => x)
-                        .Collect())
-                    .Let(() => calculatedFact, () => new CalculatedFact {Value = fact1.TestProperty});
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/BatchedForwardChainingTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/BatchedForwardChainingTest.cs
@@ -5,342 +5,341 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class BatchedForwardChainingTest : BaseRuleTestFixture
 {
-    public class BatchedForwardChainingTest : BaseRuleTestFixture
+    public BatchedForwardChainingTest()
     {
-        public BatchedForwardChainingTest()
+        Session.AutoPropagateLinkedFacts = false;
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFact_FiresFirstRuleAndChainsSecond()
+    {
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+        Session.PropagateLinked();
+
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce<ForwardChainingFirstRule>();
+        AssertFiredOnce<ForwardChainingSecondRule>();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFacts_FiresFirstRuleAndChainsSecond()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.InsertAll(new []{fact11, fact12});
+
+        //Act
+        Session.Fire();
+        var result = Session.PropagateLinked();
+
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice<ForwardChainingFirstRule>();
+        AssertFiredTwice<ForwardChainingSecondRule>();
+        Assert.Single(result);
+        Assert.Equal(LinkedFactAction.Insert, result.ElementAt(0).Action);
+        Assert.Equal(2, result.ElementAt(0).FactCount);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedThenUpdated_FiresFirstRuleAndChainsSecond()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.InsertAll(new []{fact11, fact12});
+        Session.UpdateAll(new []{fact11, fact12});
+
+        //Act
+        Session.Fire();
+        var result = Session.PropagateLinked();
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice<ForwardChainingFirstRule>();
+        AssertFiredTwice<ForwardChainingSecondRule>();
+        Assert.Single(result);
+        Assert.Equal(LinkedFactAction.Insert, result.ElementAt(0).Action);
+        Assert.Equal(2, result.ElementAt(0).FactCount);
+    }
+
+    [Fact]
+    public void Fire_ManyMatchingFactsInsertedPropagatedThenUpdatedTwice_FiresFirstRuleAndChainsSecond()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 2", ChainProperty = "Valid Value 2" };
+        var fact13 = new FactType1 { TestProperty = "Valid Value 3", ChainProperty = "Valid Value 3" };
+        var fact14 = new FactType1 { TestProperty = "Valid Value 4", ChainProperty = "Valid Value 4" };
+        var fact15 = new FactType1 { TestProperty = "Valid Value 5", ChainProperty = "Valid Value 5" };
+        var fact16 = new FactType1 { TestProperty = "Valid Value 6", ChainProperty = "Valid Value 6" };
+        var fact17 = new FactType1 { TestProperty = "Valid Value 7", ChainProperty = "Valid Value 7" };
+        var fact18 = new FactType1 { TestProperty = "Valid Value 8", ChainProperty = "Valid Value 8" };
+        var fact19 = new FactType1 { TestProperty = "Valid Value 9", ChainProperty = "Valid Value 9" };
+        Session.InsertAll(new []{fact11, fact12, fact13, fact14, fact15, fact16, fact17, fact18, fact19});
+
+        Session.Fire();
+        Session.PropagateLinked();
+
+        //Act
+        Session.Update(fact11);
+        Session.Update(fact12);
+        Session.Update(fact13);
+        Session.Update(fact14);
+        Session.Update(fact15);
+        Session.Update(fact16);
+        Session.Update(fact17);
+        Session.Update(fact18);
+        Session.Update(fact19);
+
+        Session.Update(fact11);
+        Session.Update(fact12);
+        Session.Update(fact13);
+        Session.Update(fact14);
+        Session.Update(fact15);
+        Session.Update(fact16);
+        Session.Update(fact17);
+        Session.Update(fact18);
+        Session.Update(fact19);
+
+        Session.Fire();
+        var result = Session.PropagateLinked();
+
+        Session.Fire();
+
+        //Assert
+        AssertFiredTimes<ForwardChainingFirstRule>(18);
+        AssertFiredTimes<ForwardChainingSecondRule>(18);
+        Assert.Single(result);
+        Assert.Equal(LinkedFactAction.Update, result.ElementAt(0).Action);
+        Assert.Equal(9, result.ElementAt(0).FactCount);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedThenUpdatedThenRetracted_FiresFirstRuleAndChainsSecond()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.InsertAll(new []{fact11, fact12});
+        Session.UpdateAll(new []{fact11, fact12});
+        Session.RetractAll(new []{fact11, fact12});
+
+        //Act
+        Session.Fire();
+        var result = Session.PropagateLinked();
+
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire<ForwardChainingFirstRule>();
+        AssertDidNotFire<ForwardChainingSecondRule>();
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedAndFiredThenUpdatedToInvalidateSecond_FiresFirstRuleAndChainsSecond()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.InsertAll(new []{fact11, fact12});
+
+        Session.Fire();
+        Session.PropagateLinked();
+
+        Session.Fire();
+
+        fact11.ChainProperty = "Invalid Value 1";
+        fact12.ChainProperty = "Invalid Value 1";
+        Session.UpdateAll(new []{fact11, fact12});
+
+        //Act
+        Session.Fire();
+        var result = Session.PropagateLinked();
+        Session.Fire();
+
+        //Assert
+        AssertFiredTimes<ForwardChainingFirstRule>(4);
+        AssertFiredTimes<ForwardChainingSecondRule>(2);
+        Assert.Single(result);
+        Assert.Equal(LinkedFactAction.Retract, result.ElementAt(0).Action);
+        Assert.Equal(2, result.ElementAt(0).FactCount);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedAndFiredThenUpdatedToInvalid_FiresFirstRuleAndChainsSecond()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.InsertAll(new []{fact11, fact12});
+
+        Session.Fire();
+        Session.PropagateLinked();
+
+        Session.Fire();
+
+        fact11.TestProperty = "Invalid Value 1";
+        fact12.TestProperty = "Invalid Value 1";
+        Session.UpdateAll(new []{fact11, fact12});
+
+        //Act
+        Session.Fire();
+        var result = Session.PropagateLinked();
+
+        //Assert
+        AssertFiredTimes<ForwardChainingFirstRule>(2);
+        AssertFiredTimes<ForwardChainingSecondRule>(2);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedAndFiredThenLinkedFactsRetractedAndExceptionThrown_RetractsAndThrows()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.InsertAll(new []{fact11, fact12});
+
+        Session.Fire();
+        Session.PropagateLinked();
+
+        Session.Fire();
+
+        fact11.ChainProperty = "Throw";
+        fact12.ChainProperty = "Throw";
+        Session.UpdateAll(new []{fact11, fact12});
+
+        //Act
+        Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
+        Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
+        var result = Session.PropagateLinked();
+
+        //Assert
+        AssertFiredTimes<ForwardChainingFirstRule>(2);
+        AssertFiredTimes<ForwardChainingSecondRule>(2);
+        Assert.Single(result);
+        Assert.Equal(LinkedFactAction.Retract, result.ElementAt(0).Action);
+        Assert.Equal(2, result.ElementAt(0).FactCount);
+    }
+
+    [Fact]
+    public void FireWithAutoPropagation_TwoMatchingFactsInsertedAndFiredThenLinkedFactsRetractedAndExceptionThrown_RetractsAndThrows()
+    {
+        //Arrange
+        Session.AutoPropagateLinkedFacts = true;
+
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.InsertAll(new []{fact11, fact12});
+
+        Session.Fire();
+
+        fact11.ChainProperty = "Throw";
+        fact12.ChainProperty = "Throw";
+        Session.UpdateAll(new []{fact11, fact12});
+
+        int retracted = 0;
+        Session.Events.FactRetractedEvent += (sender, args) => retracted++;
+
+        //Act
+        Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
+        Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
+
+        //Assert
+        AssertFiredTimes<ForwardChainingFirstRule>(2);
+        AssertFiredTimes<ForwardChainingSecondRule>(2);
+        Assert.Equal(2, retracted);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<ForwardChainingFirstRule>();
+        SetUpRule<ForwardChainingSecondRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+        public string ChainProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public int UpdateCount { get; set; } = 1;
+        public string TestProperty { get; set; }
+    }
+
+    public class ForwardChainingFirstRule : Rule
+    {
+        public override void Define()
         {
-            Session.AutoPropagateLinkedFacts = false;
+            FactType1 fact1 = null;
+
+            When()
+                .Match(() => fact1, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                //.Yield(ctx => Create(fact1), (ctx, fact2) => Update(fact1, fact2))
+                .Do(ctx => YieldIfValid(ctx, fact1));
         }
 
-        [Fact]
-        public void Fire_OneMatchingFact_FiresFirstRuleAndChainsSecond()
+        private void YieldIfValid(IContext ctx, FactType1 fact1)
         {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-            Session.PropagateLinked();
-
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce<ForwardChainingFirstRule>();
-            AssertFiredOnce<ForwardChainingSecondRule>();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFacts_FiresFirstRuleAndChainsSecond()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.InsertAll(new []{fact11, fact12});
-
-            //Act
-            Session.Fire();
-            var result = Session.PropagateLinked();
-
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice<ForwardChainingFirstRule>();
-            AssertFiredTwice<ForwardChainingSecondRule>();
-            Assert.Single(result);
-            Assert.Equal(LinkedFactAction.Insert, result.ElementAt(0).Action);
-            Assert.Equal(2, result.ElementAt(0).FactCount);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedThenUpdated_FiresFirstRuleAndChainsSecond()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.InsertAll(new []{fact11, fact12});
-            Session.UpdateAll(new []{fact11, fact12});
-
-            //Act
-            Session.Fire();
-            var result = Session.PropagateLinked();
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice<ForwardChainingFirstRule>();
-            AssertFiredTwice<ForwardChainingSecondRule>();
-            Assert.Single(result);
-            Assert.Equal(LinkedFactAction.Insert, result.ElementAt(0).Action);
-            Assert.Equal(2, result.ElementAt(0).FactCount);
-        }
-
-        [Fact]
-        public void Fire_ManyMatchingFactsInsertedPropagatedThenUpdatedTwice_FiresFirstRuleAndChainsSecond()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 2", ChainProperty = "Valid Value 2" };
-            var fact13 = new FactType1 { TestProperty = "Valid Value 3", ChainProperty = "Valid Value 3" };
-            var fact14 = new FactType1 { TestProperty = "Valid Value 4", ChainProperty = "Valid Value 4" };
-            var fact15 = new FactType1 { TestProperty = "Valid Value 5", ChainProperty = "Valid Value 5" };
-            var fact16 = new FactType1 { TestProperty = "Valid Value 6", ChainProperty = "Valid Value 6" };
-            var fact17 = new FactType1 { TestProperty = "Valid Value 7", ChainProperty = "Valid Value 7" };
-            var fact18 = new FactType1 { TestProperty = "Valid Value 8", ChainProperty = "Valid Value 8" };
-            var fact19 = new FactType1 { TestProperty = "Valid Value 9", ChainProperty = "Valid Value 9" };
-            Session.InsertAll(new []{fact11, fact12, fact13, fact14, fact15, fact16, fact17, fact18, fact19});
-
-            Session.Fire();
-            Session.PropagateLinked();
-
-            //Act
-            Session.Update(fact11);
-            Session.Update(fact12);
-            Session.Update(fact13);
-            Session.Update(fact14);
-            Session.Update(fact15);
-            Session.Update(fact16);
-            Session.Update(fact17);
-            Session.Update(fact18);
-            Session.Update(fact19);
-
-            Session.Update(fact11);
-            Session.Update(fact12);
-            Session.Update(fact13);
-            Session.Update(fact14);
-            Session.Update(fact15);
-            Session.Update(fact16);
-            Session.Update(fact17);
-            Session.Update(fact18);
-            Session.Update(fact19);
-
-            Session.Fire();
-            var result = Session.PropagateLinked();
-
-            Session.Fire();
-
-            //Assert
-            AssertFiredTimes<ForwardChainingFirstRule>(18);
-            AssertFiredTimes<ForwardChainingSecondRule>(18);
-            Assert.Single(result);
-            Assert.Equal(LinkedFactAction.Update, result.ElementAt(0).Action);
-            Assert.Equal(9, result.ElementAt(0).FactCount);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedThenUpdatedThenRetracted_FiresFirstRuleAndChainsSecond()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.InsertAll(new []{fact11, fact12});
-            Session.UpdateAll(new []{fact11, fact12});
-            Session.RetractAll(new []{fact11, fact12});
-
-            //Act
-            Session.Fire();
-            var result = Session.PropagateLinked();
-
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire<ForwardChainingFirstRule>();
-            AssertDidNotFire<ForwardChainingSecondRule>();
-            Assert.Empty(result);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedAndFiredThenUpdatedToInvalidateSecond_FiresFirstRuleAndChainsSecond()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.InsertAll(new []{fact11, fact12});
-
-            Session.Fire();
-            Session.PropagateLinked();
-
-            Session.Fire();
-
-            fact11.ChainProperty = "Invalid Value 1";
-            fact12.ChainProperty = "Invalid Value 1";
-            Session.UpdateAll(new []{fact11, fact12});
-
-            //Act
-            Session.Fire();
-            var result = Session.PropagateLinked();
-            Session.Fire();
-
-            //Assert
-            AssertFiredTimes<ForwardChainingFirstRule>(4);
-            AssertFiredTimes<ForwardChainingSecondRule>(2);
-            Assert.Single(result);
-            Assert.Equal(LinkedFactAction.Retract, result.ElementAt(0).Action);
-            Assert.Equal(2, result.ElementAt(0).FactCount);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedAndFiredThenUpdatedToInvalid_FiresFirstRuleAndChainsSecond()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.InsertAll(new []{fact11, fact12});
-
-            Session.Fire();
-            Session.PropagateLinked();
-
-            Session.Fire();
-
-            fact11.TestProperty = "Invalid Value 1";
-            fact12.TestProperty = "Invalid Value 1";
-            Session.UpdateAll(new []{fact11, fact12});
-
-            //Act
-            Session.Fire();
-            var result = Session.PropagateLinked();
-
-            //Assert
-            AssertFiredTimes<ForwardChainingFirstRule>(2);
-            AssertFiredTimes<ForwardChainingSecondRule>(2);
-            Assert.Empty(result);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedAndFiredThenLinkedFactsRetractedAndExceptionThrown_RetractsAndThrows()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.InsertAll(new []{fact11, fact12});
-
-            Session.Fire();
-            Session.PropagateLinked();
-
-            Session.Fire();
-
-            fact11.ChainProperty = "Throw";
-            fact12.ChainProperty = "Throw";
-            Session.UpdateAll(new []{fact11, fact12});
-
-            //Act
-            Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
-            Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
-            var result = Session.PropagateLinked();
-
-            //Assert
-            AssertFiredTimes<ForwardChainingFirstRule>(2);
-            AssertFiredTimes<ForwardChainingSecondRule>(2);
-            Assert.Single(result);
-            Assert.Equal(LinkedFactAction.Retract, result.ElementAt(0).Action);
-            Assert.Equal(2, result.ElementAt(0).FactCount);
-        }
-
-        [Fact]
-        public void FireWithAutoPropagation_TwoMatchingFactsInsertedAndFiredThenLinkedFactsRetractedAndExceptionThrown_RetractsAndThrows()
-        {
-            //Arrange
-            Session.AutoPropagateLinkedFacts = true;
-
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.InsertAll(new []{fact11, fact12});
-
-            Session.Fire();
-
-            fact11.ChainProperty = "Throw";
-            fact12.ChainProperty = "Throw";
-            Session.UpdateAll(new []{fact11, fact12});
-
-            int retracted = 0;
-            Session.Events.FactRetractedEvent += (sender, args) => retracted++;
-
-            //Act
-            Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
-            Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
-
-            //Assert
-            AssertFiredTimes<ForwardChainingFirstRule>(2);
-            AssertFiredTimes<ForwardChainingSecondRule>(2);
-            Assert.Equal(2, retracted);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<ForwardChainingFirstRule>();
-            SetUpRule<ForwardChainingSecondRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-            public string ChainProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public int UpdateCount { get; set; } = 1;
-            public string TestProperty { get; set; }
-        }
-
-        public class ForwardChainingFirstRule : Rule
-        {
-            public override void Define()
+            var fact2 = (FactType2)ctx.GetLinked("key");
+            if (fact1.ChainProperty.StartsWith("Valid"))
             {
-                FactType1 fact1 = null;
-
-                When()
-                    .Match(() => fact1, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    //.Yield(ctx => Create(fact1), (ctx, fact2) => Update(fact1, fact2))
-                    .Do(ctx => YieldIfValid(ctx, fact1));
+                if (fact2 == null)
+                    ctx.InsertLinked("key", Create(fact1));
+                else
+                    ctx.UpdateLinked("key", Update(fact1, fact2));
+            }
+            else if (fact2 != null)
+            {
+                ctx.RetractLinked("key", fact2);
             }
 
-            private void YieldIfValid(IContext ctx, FactType1 fact1)
-            {
-                var fact2 = (FactType2)ctx.GetLinked("key");
-                if (fact1.ChainProperty.StartsWith("Valid"))
-                {
-                    if (fact2 == null)
-                        ctx.InsertLinked("key", Create(fact1));
-                    else
-                        ctx.UpdateLinked("key", Update(fact1, fact2));
-                }
-                else if (fact2 != null)
-                {
-                    ctx.RetractLinked("key", fact2);
-                }
-
-                if (fact1.ChainProperty == "Throw")
-                    throw new InvalidOperationException("Chaining failed");
-            }
-
-            private static FactType2 Create(FactType1 fact1)
-            {
-                var fact2 = new FactType2 {TestProperty = fact1.ChainProperty};
-                return fact2;
-            }
-
-            private static FactType2 Update(FactType1 fact1, FactType2 fact2)
-            {
-                fact2.TestProperty = fact1.ChainProperty;
-                fact2.UpdateCount++;
-                return fact2;
-            }
+            if (fact1.ChainProperty == "Throw")
+                throw new InvalidOperationException("Chaining failed");
         }
 
-        public class ForwardChainingSecondRule : Rule
+        private static FactType2 Create(FactType1 fact1)
         {
-            public override void Define()
-            {
-                FactType2 fact2 = null;
+            var fact2 = new FactType2 {TestProperty = fact1.ChainProperty};
+            return fact2;
+        }
 
-                When()
-                    .Match(() => fact2, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+        private static FactType2 Update(FactType1 fact1, FactType2 fact2)
+        {
+            fact2.TestProperty = fact1.ChainProperty;
+            fact2.UpdateCount++;
+            return fact2;
+        }
+    }
+
+    public class ForwardChainingSecondRule : Rule
+    {
+        public override void Define()
+        {
+            FactType2 fact2 = null;
+
+            When()
+                .Match(() => fact2, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/BindingEvaluationExceptionTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/BindingEvaluationExceptionTest.cs
@@ -7,170 +7,169 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class BindingEvaluationExceptionTest : BaseRuleTestFixture
 {
-    public class BindingEvaluationExceptionTest : BaseRuleTestFixture
+    [Fact]
+    public void Insert_ErrorInBindingNoErrorHandler_Throws()
     {
-        [Fact]
-        public void Insert_ErrorInBindingNoErrorHandler_Throws()
+        //Arrange
+        GetRuleInstance<TestRule>().Binding = ThrowBinding;
+
+        Expression expression = null;
+        IList<IFact> facts = null;
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => expression = args.Expression;
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => facts = args.Facts.ToList();
+
+        var fact = new FactType { TestProperty = "Valid value" };
+
+        //Act - Assert
+        var ex = Assert.Throws<RuleLhsExpressionEvaluationException>(() => Session.Insert(fact));
+        Assert.NotNull(expression);
+        Assert.Equal(1, facts.Count);
+        Assert.Same(fact, facts.First().Value);
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void Fire_FailedAssert_DoesNotFire()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().Binding = ThrowBinding;
+
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact = new FactType { TestProperty = "Valid value" };
+
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FailedAssertThenAssertAnother_Fires()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().Binding = ThrowBinding;
+
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact1 = new FactType { TestProperty = "Valid value" };
+        Session.Insert(fact1);
+
+        GetRuleInstance<TestRule>().Binding = SuccessfulBinding;
+        
+        var fact2 = new FactType { TestProperty = "Valid value" };
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_FailedAssertThenUpdate_Fires()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().Binding = ThrowBinding;
+
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact = new FactType {TestProperty = "Valid value"};
+
+        Session.Insert(fact);
+        GetRuleInstance<TestRule>().Binding = SuccessfulBinding;
+
+        Session.Update(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_FailedAssertThenUpdateThenRetract_DoesNotFire()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().Binding = ThrowBinding;
+
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact = new FactType {TestProperty = "Valid value"};
+
+        Session.Insert(fact);
+        GetRuleInstance<TestRule>().Binding = SuccessfulBinding;
+
+        Session.Update(fact);
+        Session.Retract(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FailedAssertThenRetract_DoesNotFire()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().Binding = ThrowBinding;
+
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact = new FactType {TestProperty = "Valid value"};
+
+        Session.Insert(fact);
+        GetRuleInstance<TestRule>().Binding = SuccessfulBinding;
+
+        Session.Retract(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    private static readonly Func<FactType, string> SuccessfulBinding = f => "value";
+    private static readonly Func<FactType, string> ThrowBinding = f => throw new InvalidOperationException("Binding failed");
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public Func<FactType, string> Binding = SuccessfulBinding;
+
+        public override void Define()
         {
-            //Arrange
-            GetRuleInstance<TestRule>().Binding = ThrowBinding;
+            FactType fact = null;
+            string binding = null;
 
-            Expression expression = null;
-            IList<IFact> facts = null;
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => expression = args.Expression;
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => facts = args.Facts.ToList();
-
-            var fact = new FactType { TestProperty = "Valid value" };
-
-            //Act - Assert
-            var ex = Assert.Throws<RuleLhsExpressionEvaluationException>(() => Session.Insert(fact));
-            Assert.NotNull(expression);
-            Assert.Equal(1, facts.Count);
-            Assert.Same(fact, facts.First().Value);
-            Assert.IsType<InvalidOperationException>(ex.InnerException);
+            When()
+                .Match(() => fact, f => f.TestProperty.StartsWith("Valid"))
+                .Let(() => binding, () => Binding(fact));
+            Then()
+                .Do(ctx => NoOp());
         }
 
-        [Fact]
-        public void Fire_FailedAssert_DoesNotFire()
-        {
-            //Arrange
-            GetRuleInstance<TestRule>().Binding = ThrowBinding;
-
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact = new FactType { TestProperty = "Valid value" };
-
-            Session.Insert(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FailedAssertThenAssertAnother_Fires()
-        {
-            //Arrange
-            GetRuleInstance<TestRule>().Binding = ThrowBinding;
-
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact1 = new FactType { TestProperty = "Valid value" };
-            Session.Insert(fact1);
-
-            GetRuleInstance<TestRule>().Binding = SuccessfulBinding;
-            
-            var fact2 = new FactType { TestProperty = "Valid value" };
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_FailedAssertThenUpdate_Fires()
-        {
-            //Arrange
-            GetRuleInstance<TestRule>().Binding = ThrowBinding;
-
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact = new FactType {TestProperty = "Valid value"};
-
-            Session.Insert(fact);
-            GetRuleInstance<TestRule>().Binding = SuccessfulBinding;
-
-            Session.Update(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_FailedAssertThenUpdateThenRetract_DoesNotFire()
-        {
-            //Arrange
-            GetRuleInstance<TestRule>().Binding = ThrowBinding;
-
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact = new FactType {TestProperty = "Valid value"};
-
-            Session.Insert(fact);
-            GetRuleInstance<TestRule>().Binding = SuccessfulBinding;
-
-            Session.Update(fact);
-            Session.Retract(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FailedAssertThenRetract_DoesNotFire()
-        {
-            //Arrange
-            GetRuleInstance<TestRule>().Binding = ThrowBinding;
-
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact = new FactType {TestProperty = "Valid value"};
-
-            Session.Insert(fact);
-            GetRuleInstance<TestRule>().Binding = SuccessfulBinding;
-
-            Session.Retract(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        private static readonly Func<FactType, string> SuccessfulBinding = f => "value";
-        private static readonly Func<FactType, string> ThrowBinding = f => throw new InvalidOperationException("Binding failed");
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public Func<FactType, string> Binding = SuccessfulBinding;
-
-            public override void Define()
-            {
-                FactType fact = null;
-                string binding = null;
-
-                When()
-                    .Match(() => fact, f => f.TestProperty.StartsWith("Valid"))
-                    .Let(() => binding, () => Binding(fact));
-                Then()
-                    .Do(ctx => NoOp());
-            }
-
-            private static void NoOp() { }
-        }
+        private static void NoOp() { }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/CoJoinedBindingAndQueryRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/CoJoinedBindingAndQueryRuleTest.cs
@@ -4,177 +4,176 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class CoJoinedBindingAndQueryRuleTest : BaseRuleTestFixture
 {
-    public class CoJoinedBindingAndQueryRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchingFactOfGroupKindOnly_FiresWithDefaultKey()
     {
-        [Fact]
-        public void Fire_MatchingFactOfGroupKindOnly_FiresWithDefaultKey()
-        {
-            //Arrange
-            var fact = new FactType2 {GroupKey = "Group1"};
+        //Arrange
+        var fact = new FactType2 {GroupKey = "Group1"};
 
-            Session.Insert(fact);
+        Session.Insert(fact);
 
-            //Act
-            Session.Fire();
+        //Act
+        Session.Fire();
 
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Group1|0", GetFiredFact<IGrouping<string, FactType2>>().Key);
-        }
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Group1|0", GetFiredFact<IGrouping<string, FactType2>>().Key);
+    }
 
-        [Fact]
-        public void Fire_MatchingFactsOfBothKinds_FiresWithCorrectKey()
-        {
-            //Arrange
-            var fact1 = new FactType1 {Value = "1"};
-            var fact2 = new FactType2 {GroupKey = "Group1"};
+    [Fact]
+    public void Fire_MatchingFactsOfBothKinds_FiresWithCorrectKey()
+    {
+        //Arrange
+        var fact1 = new FactType1 {Value = "1"};
+        var fact2 = new FactType2 {GroupKey = "Group1"};
 
-            Session.Insert(fact1);
-            Session.Insert(fact2);
+        Session.Insert(fact1);
+        Session.Insert(fact2);
 
-            //Act
-            Session.Fire();
+        //Act
+        Session.Fire();
 
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Group1|1", GetFiredFact<IGrouping<string, FactType2>>().Key);
-        }
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Group1|1", GetFiredFact<IGrouping<string, FactType2>>().Key);
+    }
 
-        [Fact]
-        public void Fire_MatchingFactsOfBothKindsReverseInsertOrder_FiresWithCorrectKey()
-        {
-            //Arrange
-            var fact1 = new FactType1 {Value = "1"};
-            var fact2 = new FactType2 {GroupKey = "Group1"};
+    [Fact]
+    public void Fire_MatchingFactsOfBothKindsReverseInsertOrder_FiresWithCorrectKey()
+    {
+        //Arrange
+        var fact1 = new FactType1 {Value = "1"};
+        var fact2 = new FactType2 {GroupKey = "Group1"};
 
-            Session.Insert(fact2);
-            Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact1);
 
-            //Act
-            Session.Fire();
+        //Act
+        Session.Fire();
 
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Group1|1", GetFiredFact<IGrouping<string, FactType2>>().Key);
-        }
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Group1|1", GetFiredFact<IGrouping<string, FactType2>>().Key);
+    }
 
-        [Fact]
-        public void Fire_MatchingFactsOfBothKindsFirstUpdated_FiresWithCorrectKey()
-        {
-            //Arrange
-            var fact1 = new FactType1 {Value = "1"};
-            var fact2 = new FactType2 {GroupKey = "Group1"};
+    [Fact]
+    public void Fire_MatchingFactsOfBothKindsFirstUpdated_FiresWithCorrectKey()
+    {
+        //Arrange
+        var fact1 = new FactType1 {Value = "1"};
+        var fact2 = new FactType2 {GroupKey = "Group1"};
 
-            Session.Insert(fact1);
-            Session.Insert(fact2);
+        Session.Insert(fact1);
+        Session.Insert(fact2);
 
-            fact1.Value = "2";
-            Session.Update(fact1);
-            
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Group1|2", GetFiredFact<IGrouping<string, FactType2>>().Key);
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsOfBothKindsSecondUpdated_FiresWithCorrectKey()
-        {
-            //Arrange
-            var fact1 = new FactType1 {Value = "1"};
-            var fact2 = new FactType2 {GroupKey = "Group1"};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact2.GroupKey = "Group2";
-            Session.Update(fact2);
-            
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Group2|1", GetFiredFact<IGrouping<string, FactType2>>().Key);
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsOfBothKindsFirstRetracted_FiresWithDefaultKey()
-        {
-            //Arrange
-            var fact1 = new FactType1 {Value = "1"};
-            var fact2 = new FactType2 {GroupKey = "Group1"};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            Session.Retract(fact1);
-            
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Group1|0", GetFiredFact<IGrouping<string, FactType2>>().Key);
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsOfBothKindsSecondRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {Value = "1"};
-            var fact2 = new FactType2 {GroupKey = "Group1"};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            Session.Retract(fact2);
-            
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
+        fact1.Value = "2";
+        Session.Update(fact1);
         
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
+        //Act
+        Session.Fire();
 
-        public class FactType1
-        {
-            public string Value { get; set; }
-        }
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Group1|2", GetFiredFact<IGrouping<string, FactType2>>().Key);
+    }
 
-        public class FactType2
-        {
-            public string GroupKey { get; set; }
-        }
+    [Fact]
+    public void Fire_MatchingFactsOfBothKindsSecondUpdated_FiresWithCorrectKey()
+    {
+        //Arrange
+        var fact1 = new FactType1 {Value = "1"};
+        var fact2 = new FactType2 {GroupKey = "Group1"};
 
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact = null;
-                IEnumerable<FactType1> collection = null;
-                IGrouping<string, FactType2> group = null;
+        Session.Insert(fact1);
+        Session.Insert(fact2);
 
-                When()
-                    .Query(() => collection, q => q
-                        .Match<FactType1>()
-                        .Collect())
-                    .Let(() => fact, () => collection.FirstOrDefault() ?? new FactType1{Value = "0"})
-                    .Query(() => group, q => q
-                        .Match<FactType2>()
-                        .GroupBy(x => x.GroupKey + "|" + fact.Value));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+        fact2.GroupKey = "Group2";
+        Session.Update(fact2);
+        
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Group2|1", GetFiredFact<IGrouping<string, FactType2>>().Key);
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsOfBothKindsFirstRetracted_FiresWithDefaultKey()
+    {
+        //Arrange
+        var fact1 = new FactType1 {Value = "1"};
+        var fact2 = new FactType2 {GroupKey = "Group1"};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        Session.Retract(fact1);
+        
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Group1|0", GetFiredFact<IGrouping<string, FactType2>>().Key);
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsOfBothKindsSecondRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {Value = "1"};
+        var fact2 = new FactType2 {GroupKey = "Group1"};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        Session.Retract(fact2);
+        
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+    
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string Value { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string GroupKey { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
+        {
+            FactType1 fact = null;
+            IEnumerable<FactType1> collection = null;
+            IGrouping<string, FactType2> group = null;
+
+            When()
+                .Query(() => collection, q => q
+                    .Match<FactType1>()
+                    .Collect())
+                .Let(() => fact, () => collection.FirstOrDefault() ?? new FactType1{Value = "0"})
+                .Query(() => group, q => q
+                    .Match<FactType2>()
+                    .GroupBy(x => x.GroupKey + "|" + fact.Value));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/CoJoinedCollectAndExistsRulesTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/CoJoinedCollectAndExistsRulesTest.cs
@@ -3,93 +3,92 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class CoJoinedCollectAndExistsRulesTest : BaseRuleTestFixture
 {
-    public class CoJoinedCollectAndExistsRulesTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchingFactOfFirstKindNoFactsOfOtherKind_FiresCollect()
     {
-        [Fact]
-        public void Fire_MatchingFactOfFirstKindNoFactsOfOtherKind_FiresCollect()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce<CollectionRule>();
+        AssertDidNotFire<ExistsRule>();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactOfFirstKindAndMatchingFactOfOtherKind_EachFiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce<CollectionRule>();
+        AssertFiredOnce<ExistsRule>();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<ExistsRule>();
+        SetUpRule<CollectionRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class ExistsRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+            FactType1 fact = null;
 
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce<CollectionRule>();
-            AssertDidNotFire<ExistsRule>();
+            When()
+                .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
+                .Exists<FactType2>(f => f.TestProperty.StartsWith("Valid"),
+                    f => f.JoinProperty == fact.TestProperty);
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
+    }
 
-        [Fact]
-        public void Fire_MatchingFactOfFirstKindAndMatchingFactOfOtherKind_EachFiresOnce()
+    public class CollectionRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+            FactType1 fact = null;
+            IEnumerable<FactType2> collection = null;
 
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce<CollectionRule>();
-            AssertFiredOnce<ExistsRule>();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<ExistsRule>();
-            SetUpRule<CollectionRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class ExistsRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact = null;
-
-                When()
-                    .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
-                    .Exists<FactType2>(f => f.TestProperty.StartsWith("Valid"),
-                        f => f.JoinProperty == fact.TestProperty);
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-        }
-
-        public class CollectionRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact = null;
-                IEnumerable<FactType2> collection = null;
-
-                When()
-                    .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
-                    .Query(() => collection, x => x
-                        .Match<FactType2>(
-                            f => f.TestProperty.StartsWith("Valid"),
-                            f => f.JoinProperty == fact.TestProperty)
-                        .Collect());
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
+                .Query(() => collection, x => x
+                    .Match<FactType2>(
+                        f => f.TestProperty.StartsWith("Valid"),
+                        f => f.JoinProperty == fact.TestProperty)
+                    .Collect());
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/CollectionWithConditionsRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/CollectionWithConditionsRuleTest.cs
@@ -4,90 +4,89 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class CollectionWithConditionsRuleTest : BaseRuleTestFixture
 {
-    public class CollectionWithConditionsRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_TwoMatchingFacts_DoesNotFire()
     {
-        [Fact]
-        public void Fire_TwoMatchingFacts_DoesNotFire()
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+    
+    [Fact]
+    public void Fire_ThreeMatchingFacts_FiresOnceWithThreeFacts()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+        var fact3 = new FactType {TestProperty = "Valid Value 3"};
+
+        var facts = new[] {fact1, fact2, fact3};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(3, GetFiredFact<IEnumerable<FactType>>().Count());
+    }
+    
+    [Fact]
+    public void Fire_ThreeMatchingFactsOneRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+        var fact3 = new FactType {TestProperty = "Valid Value 3"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+        Session.Insert(fact3);
+        Session.Retract(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
+            IEnumerable<FactType> collection = null;
 
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-        
-        [Fact]
-        public void Fire_ThreeMatchingFacts_FiresOnceWithThreeFacts()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
-            var fact3 = new FactType {TestProperty = "Valid Value 3"};
-
-            var facts = new[] {fact1, fact2, fact3};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(3, GetFiredFact<IEnumerable<FactType>>().Count());
-        }
-        
-        [Fact]
-        public void Fire_ThreeMatchingFactsOneRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
-            var fact3 = new FactType {TestProperty = "Valid Value 3"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-            Session.Insert(fact3);
-            Session.Retract(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                IEnumerable<FactType> collection = null;
-
-                When()
-                    .Query(() => collection, x => x
-                        .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
-                        .Collect()
-                        .Where(c => c.Count() > 2));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => collection, x => x
+                    .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
+                    .Collect()
+                    .Where(c => c.Count() > 2));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/CustomFirstAggregatorTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/CustomFirstAggregatorTest.cs
@@ -8,180 +8,179 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class CustomFirstAggregatorTest : BaseRuleTestFixture
 {
-    public class CustomFirstAggregatorTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_NoMatchingFacts_DoesNotFire()
     {
-        [Fact]
-        public void Fire_NoMatchingFacts_DoesNotFire()
-        {
-            //Arrange - Act
-            Session.Fire();
+        //Arrange - Act
+        Session.Fire();
 
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoGroupsOfMatchingFacts_FiresTwiceWithFirstValidFactInEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType { GroupProperty = "1", TestProperty = "Valid Value 1" };
-            var fact2 = new FactType { GroupProperty = "1", TestProperty = "Valid Value 2" };
-            var fact3 = new FactType { GroupProperty = "2", TestProperty = "Invalid Value 3" };
-            var fact4 = new FactType { GroupProperty = "2", TestProperty = "Valid Value 4" };
-
-            var facts = new[] { fact1, fact2, fact3, fact4 };
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal("Valid Value 1", GetFiredFact<FactType>(0).TestProperty);
-            Assert.Equal("Valid Value 4", GetFiredFact<FactType>(1).TestProperty);
-        }
-
-        [Fact]
-        public void Fire_OneGroupsOfMatchingFactsThenFirstFactRetracted_FiresOnceWithSecondFact()
-        {
-            //Arrange
-            var fact1 = new FactType { GroupProperty = "1", TestProperty = "Valid Value 1" };
-            var fact2 = new FactType { GroupProperty = "1", TestProperty = "Valid Value 2" };
-            var fact3 = new FactType { GroupProperty = "1", TestProperty = "Valid Value 3" };
-
-            var facts = new[] { fact1, fact2, fact3 };
-            Session.InsertAll(facts);
-            Session.Retract(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Valid Value 2", GetFiredFact<FactType>().TestProperty);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string GroupProperty { get; set; }
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType first = null;
-
-                When()
-                    .Query(() => first, q => q
-                        .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
-                        .GroupBy(x => x.GroupProperty)
-                        .First());
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-        }
+        //Assert
+        AssertDidNotFire();
     }
 
-    public static class FirstQueryExtensions
+    [Fact]
+    public void Fire_TwoGroupsOfMatchingFacts_FiresTwiceWithFirstValidFactInEachGroup()
     {
-        public static IQuery<TSource> First<TSource>(this IQuery<IEnumerable<TSource>> source)
-        {
-            var expressions = new List<KeyValuePair<string, LambdaExpression>>();
-            source.Builder.Aggregate<IEnumerable<TSource>, TSource>("First", expressions, typeof(CustomFirstAggregatorFactory));
-            return new QueryExpression<TSource>(source.Builder);
-        }
+        //Arrange
+        var fact1 = new FactType { GroupProperty = "1", TestProperty = "Valid Value 1" };
+        var fact2 = new FactType { GroupProperty = "1", TestProperty = "Valid Value 2" };
+        var fact3 = new FactType { GroupProperty = "2", TestProperty = "Invalid Value 3" };
+        var fact4 = new FactType { GroupProperty = "2", TestProperty = "Valid Value 4" };
+
+        var facts = new[] { fact1, fact2, fact3, fact4 };
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal("Valid Value 1", GetFiredFact<FactType>(0).TestProperty);
+        Assert.Equal("Valid Value 4", GetFiredFact<FactType>(1).TestProperty);
     }
 
-    internal class CustomFirstAggregatorFactory : IAggregatorFactory
+    [Fact]
+    public void Fire_OneGroupsOfMatchingFactsThenFirstFactRetracted_FiresOnceWithSecondFact()
     {
-        private Func<IAggregator> _factory;
+        //Arrange
+        var fact1 = new FactType { GroupProperty = "1", TestProperty = "Valid Value 1" };
+        var fact2 = new FactType { GroupProperty = "1", TestProperty = "Valid Value 2" };
+        var fact3 = new FactType { GroupProperty = "1", TestProperty = "Valid Value 3" };
 
-        public void Compile(AggregateElement element, IEnumerable<IAggregateExpression> compiledExpressions)
-        {
-            var elementType = element.ResultType;
-            var aggregatorType = typeof(CustomFirstAggregator<>).MakeGenericType(elementType);
-            var factoryExpression = Expression.Lambda<Func<IAggregator>>(Expression.New(aggregatorType));
-            _factory = factoryExpression.Compile();
-        }
+        var facts = new[] { fact1, fact2, fact3 };
+        Session.InsertAll(facts);
+        Session.Retract(fact1);
 
-        public IAggregator Create()
-        {
-            return _factory();
-        }
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Valid Value 2", GetFiredFact<FactType>().TestProperty);
     }
 
-    public class CustomFirstAggregator<TElement> : IAggregator
+    protected override void SetUpRules()
     {
-        private readonly Dictionary<object, TElement> _firstElements = new Dictionary<object, TElement>();
+        SetUpRule<TestRule>();
+    }
 
-        public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    public class FactType
+    {
+        public string GroupProperty { get; set; }
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            var results = new List<AggregationResult>();
-            foreach (var fact in facts)
-            {
-                var collection = (IEnumerable<TElement>)fact.Value;
-                foreach (var value in collection)
-                {
-                    _firstElements[fact] = value;
-                    results.Add(AggregationResult.Added(value, Enumerable.Repeat(fact, 1)));
-                    break;
-                }
-            }
-            return results;
+            FactType first = null;
+
+            When()
+                .Query(() => first, q => q
+                    .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
+                    .GroupBy(x => x.GroupProperty)
+                    .First());
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
+    }
+}
 
-        public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+public static class FirstQueryExtensions
+{
+    public static IQuery<TSource> First<TSource>(this IQuery<IEnumerable<TSource>> source)
+    {
+        var expressions = new List<KeyValuePair<string, LambdaExpression>>();
+        source.Builder.Aggregate<IEnumerable<TSource>, TSource>("First", expressions, typeof(CustomFirstAggregatorFactory));
+        return new QueryExpression<TSource>(source.Builder);
+    }
+}
+
+internal class CustomFirstAggregatorFactory : IAggregatorFactory
+{
+    private Func<IAggregator> _factory;
+
+    public void Compile(AggregateElement element, IEnumerable<IAggregateExpression> compiledExpressions)
+    {
+        var elementType = element.ResultType;
+        var aggregatorType = typeof(CustomFirstAggregator<>).MakeGenericType(elementType);
+        var factoryExpression = Expression.Lambda<Func<IAggregator>>(Expression.New(aggregatorType));
+        _factory = factoryExpression.Compile();
+    }
+
+    public IAggregator Create()
+    {
+        return _factory();
+    }
+}
+
+public class CustomFirstAggregator<TElement> : IAggregator
+{
+    private readonly Dictionary<object, TElement> _firstElements = new Dictionary<object, TElement>();
+
+    public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var results = new List<AggregationResult>();
+        foreach (var fact in facts)
         {
-            var results = new List<AggregationResult>();
-            foreach (var fact in facts)
+            var collection = (IEnumerable<TElement>)fact.Value;
+            foreach (var value in collection)
             {
-                var collection = (IEnumerable<TElement>)fact.Value;
-                foreach (var value in collection)
-                {
-                    if (_firstElements.TryGetValue(fact, out var oldFirst))
-                    {
-                        if (Equals(oldFirst, value))
-                        {
-                            results.Add(AggregationResult.Modified(value, value, Enumerable.Repeat(fact, 1)));
-                        }
-                        else
-                        {
-                            results.Add(AggregationResult.Removed(oldFirst));
-                            results.Add(AggregationResult.Added(value, Enumerable.Repeat(fact, 1)));
-                        }
-                    }
-                    else
-                    {
-                        results.Add(AggregationResult.Added(value, Enumerable.Repeat(fact, 1)));
-                    }
-                    _firstElements[fact] = value;
-                    break;
-                }
+                _firstElements[fact] = value;
+                results.Add(AggregationResult.Added(value, Enumerable.Repeat(fact, 1)));
+                break;
             }
-            return results;
         }
+        return results;
+    }
 
-        public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var results = new List<AggregationResult>();
+        foreach (var fact in facts)
         {
-            var results = new List<AggregationResult>();
-            foreach (var fact in facts)
+            var collection = (IEnumerable<TElement>)fact.Value;
+            foreach (var value in collection)
             {
                 if (_firstElements.TryGetValue(fact, out var oldFirst))
                 {
-                    results.Add(AggregationResult.Removed(oldFirst));
-                    _firstElements.Remove(fact);
+                    if (Equals(oldFirst, value))
+                    {
+                        results.Add(AggregationResult.Modified(value, value, Enumerable.Repeat(fact, 1)));
+                    }
+                    else
+                    {
+                        results.Add(AggregationResult.Removed(oldFirst));
+                        results.Add(AggregationResult.Added(value, Enumerable.Repeat(fact, 1)));
+                    }
                 }
+                else
+                {
+                    results.Add(AggregationResult.Added(value, Enumerable.Repeat(fact, 1)));
+                }
+                _firstElements[fact] = value;
+                break;
             }
-            return results;
         }
+        return results;
+    }
+
+    public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var results = new List<AggregationResult>();
+        foreach (var fact in facts)
+        {
+            if (_firstElements.TryGetValue(fact, out var oldFirst))
+            {
+                results.Add(AggregationResult.Removed(oldFirst));
+                _firstElements.Remove(fact);
+            }
+        }
+        return results;
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/CustomSelectAggregatorTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/CustomSelectAggregatorTest.cs
@@ -8,204 +8,203 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class CustomSelectAggregatorTest : BaseRuleTestFixture
 {
-    public class CustomSelectAggregatorTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFact_FiresOnce()
     {
-        [Fact]
-        public void Fire_OneMatchingFact_FiresOnce()
+        //Arrange
+        var fact = new FactType { TestProperty = "Valid Value 1" };
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(fact.TestProperty, GetFiredFact<FactProjection>().Value);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactInsertedThenUpdated_FiresOnce()
+    {
+        //Arrange
+        var fact = new FactType { TestProperty = "Valid Value 1" };
+        Session.Insert(fact);
+        Session.Update(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(fact.TestProperty, GetFiredFact<FactProjection>().Value);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType { TestProperty = "Valid Value 1" };
+        Session.Insert(fact);
+        Session.Retract(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    protected override ISessionFactory Compile()
+    {
+        var compiler = new RuleCompiler();
+        compiler.AggregatorRegistry.RegisterFactory("CustomSelect", typeof(CustomSelectAggregateFactory));
+
+        var factory = compiler.Compile(Repository.GetRules());
+        return factory;
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactProjection : IEquatable<FactProjection>
+    {
+        public FactProjection(FactType fact)
         {
-            //Arrange
-            var fact = new FactType { TestProperty = "Valid Value 1" };
-            Session.Insert(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(fact.TestProperty, GetFiredFact<FactProjection>().Value);
+            Value = fact.TestProperty;
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactInsertedThenUpdated_FiresOnce()
+        public string Value { get; }
+
+        public bool Equals(FactProjection other)
         {
-            //Arrange
-            var fact = new FactType { TestProperty = "Valid Value 1" };
-            Session.Insert(fact);
-            Session.Update(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(fact.TestProperty, GetFiredFact<FactProjection>().Value);
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(Value, other.Value);
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactAssertedAndRetracted_DoesNotFire()
+        public override bool Equals(object obj)
         {
-            //Arrange
-            var fact = new FactType { TestProperty = "Valid Value 1" };
-            Session.Insert(fact);
-            Session.Retract(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((FactProjection)obj);
         }
 
-        protected override void SetUpRules()
+        public override int GetHashCode()
         {
-            SetUpRule<TestRule>();
-        }
-
-        protected override ISessionFactory Compile()
-        {
-            var compiler = new RuleCompiler();
-            compiler.AggregatorRegistry.RegisterFactory("CustomSelect", typeof(CustomSelectAggregateFactory));
-
-            var factory = compiler.Compile(Repository.GetRules());
-            return factory;
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactProjection : IEquatable<FactProjection>
-        {
-            public FactProjection(FactType fact)
-            {
-                Value = fact.TestProperty;
-            }
-
-            public string Value { get; }
-
-            public bool Equals(FactProjection other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return string.Equals(Value, other.Value);
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((FactProjection)obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return (Value != null ? Value.GetHashCode() : 0);
-            }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactProjection projection = null;
-
-                When()
-                    .Query(() => projection, q => q
-                        .Match<FactType>()
-                        .CustomSelect(f => new FactProjection(f))
-                        .Where(p => p.Value.StartsWith("Valid")));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            return (Value != null ? Value.GetHashCode() : 0);
         }
     }
 
-    public static class CustomSelectQuery
+    public class TestRule : Rule
     {
-        public static IQuery<TResult> CustomSelect<TSource, TResult>(this IQuery<TSource> source, Expression<Func<TSource, TResult>> selector)
+        public override void Define()
         {
-            var expressions = new List<KeyValuePair<string, LambdaExpression>>
-            {
-                new KeyValuePair<string, LambdaExpression>("Selector", selector)
-            };
-            source.Builder.Aggregate<TSource, TResult>("CustomSelect", expressions);
-            return new QueryExpression<TResult>(source.Builder);
+            FactProjection projection = null;
+
+            When()
+                .Query(() => projection, q => q
+                    .Match<FactType>()
+                    .CustomSelect(f => new FactProjection(f))
+                    .Where(p => p.Value.StartsWith("Valid")));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
+}
 
-    internal class CustomSelectAggregateFactory : IAggregatorFactory
+public static class CustomSelectQuery
+{
+    public static IQuery<TResult> CustomSelect<TSource, TResult>(this IQuery<TSource> source, Expression<Func<TSource, TResult>> selector)
     {
-        private Func<IAggregator> _factory;
-
-        public void Compile(AggregateElement element, IEnumerable<IAggregateExpression> compiledExpressions)
+        var expressions = new List<KeyValuePair<string, LambdaExpression>>
         {
-            var selector = element.Expressions["Selector"];
-            var sourceType = element.Source.ValueType;
-            var resultType = selector.Expression.ReturnType;
-            var aggregatorType = typeof(CustomSelectAggregator<,>).MakeGenericType(sourceType, resultType);
+            new KeyValuePair<string, LambdaExpression>("Selector", selector)
+        };
+        source.Builder.Aggregate<TSource, TResult>("CustomSelect", expressions);
+        return new QueryExpression<TResult>(source.Builder);
+    }
+}
 
-            var compiledSelector = compiledExpressions.FindSingle("Selector");
-            var ctor = aggregatorType.GetConstructors().Single();
-            var factoryExpression = Expression.Lambda<Func<IAggregator>>(
-                Expression.New(ctor, Expression.Constant(compiledSelector)));
-            _factory = factoryExpression.Compile();
-        }
+internal class CustomSelectAggregateFactory : IAggregatorFactory
+{
+    private Func<IAggregator> _factory;
 
-        public IAggregator Create()
-        {
-            return _factory();
-        }
+    public void Compile(AggregateElement element, IEnumerable<IAggregateExpression> compiledExpressions)
+    {
+        var selector = element.Expressions["Selector"];
+        var sourceType = element.Source.ValueType;
+        var resultType = selector.Expression.ReturnType;
+        var aggregatorType = typeof(CustomSelectAggregator<,>).MakeGenericType(sourceType, resultType);
+
+        var compiledSelector = compiledExpressions.FindSingle("Selector");
+        var ctor = aggregatorType.GetConstructors().Single();
+        var factoryExpression = Expression.Lambda<Func<IAggregator>>(
+            Expression.New(ctor, Expression.Constant(compiledSelector)));
+        _factory = factoryExpression.Compile();
     }
 
-    public class CustomSelectAggregator<TSource, TResult> : IAggregator
+    public IAggregator Create()
     {
-        private readonly IAggregateExpression _selector;
-        private readonly Dictionary<IFact, object> _sourceToValue = new Dictionary<IFact, object>();
+        return _factory();
+    }
+}
 
-        public CustomSelectAggregator(IAggregateExpression selector)
-        {
-            _selector = selector;
-        }
+public class CustomSelectAggregator<TSource, TResult> : IAggregator
+{
+    private readonly IAggregateExpression _selector;
+    private readonly Dictionary<IFact, object> _sourceToValue = new Dictionary<IFact, object>();
 
-        public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
-        {
-            var results = new List<AggregationResult>();
-            foreach (var fact in facts)
-            {
-                var value = _selector.Invoke(context, tuple, fact);
-                _sourceToValue[fact] = value;
-                results.Add(AggregationResult.Added(value, Enumerable.Repeat(fact, 1)));
-            }
-            return results;
-        }
+    public CustomSelectAggregator(IAggregateExpression selector)
+    {
+        _selector = selector;
+    }
 
-        public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    public IEnumerable<AggregationResult> Add(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var results = new List<AggregationResult>();
+        foreach (var fact in facts)
         {
-            var results = new List<AggregationResult>();
-            foreach (var fact in facts)
-            {
-                var value = _selector.Invoke(context, tuple, fact);
-                var oldValue = (TResult)_sourceToValue[fact];
-                _sourceToValue[fact] = value;
-                results.Add(AggregationResult.Modified(value, oldValue, Enumerable.Repeat(fact, 1)));
-            }
-            return results;
+            var value = _selector.Invoke(context, tuple, fact);
+            _sourceToValue[fact] = value;
+            results.Add(AggregationResult.Added(value, Enumerable.Repeat(fact, 1)));
         }
+        return results;
+    }
 
-        public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    public IEnumerable<AggregationResult> Modify(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var results = new List<AggregationResult>();
+        foreach (var fact in facts)
         {
-            var results = new List<AggregationResult>();
-            foreach (var fact in facts)
-            {
-                var oldValue = _sourceToValue[fact];
-                _sourceToValue.Remove(fact);
-                results.Add(AggregationResult.Removed(oldValue));
-            }
-            return results;
+            var value = _selector.Invoke(context, tuple, fact);
+            var oldValue = (TResult)_sourceToValue[fact];
+            _sourceToValue[fact] = value;
+            results.Add(AggregationResult.Modified(value, oldValue, Enumerable.Repeat(fact, 1)));
         }
+        return results;
+    }
+
+    public IEnumerable<AggregationResult> Remove(AggregationContext context, ITuple tuple, IEnumerable<IFact> facts)
+    {
+        var results = new List<AggregationResult>();
+        foreach (var fact in facts)
+        {
+            var oldValue = _sourceToValue[fact];
+            _sourceToValue.Remove(fact);
+            results.Add(AggregationResult.Removed(oldValue));
+        }
+        return results;
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/EvaluationEventTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/EvaluationEventTest.cs
@@ -6,259 +6,258 @@ using NRules.Fluent.Dsl;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class EvaluationEventTest
 {
-    public class EvaluationEventTest
+    [Fact]
+    public void Insert_Fact_RaisesAlphaConditionExpressionEvalEvent()
     {
-        [Fact]
-        public void Insert_Fact_RaisesAlphaConditionExpressionEvalEvent()
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
+
+        var handledEvents = new List<LhsExpressionEventArgs>();
+        factory.Events.LhsExpressionEvaluatedEvent += (sender, args) =>
         {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
+            handledEvents.Add(args);
+        };
 
-            var handledEvents = new List<LhsExpressionEventArgs>();
-            factory.Events.LhsExpressionEvaluatedEvent += (sender, args) =>
-            {
-                handledEvents.Add(args);
-            };
+        var fact1 = new FactType1 { TestProperty = "Valid Value" };
 
-            var fact1 = new FactType1 { TestProperty = "Valid Value" };
+        //Act
+        session.Insert(fact1);
 
-            //Act
-            session.Insert(fact1);
+        //Assert
+        Assert.Single(handledEvents);
+        var eventArgs = handledEvents[0];
+        Assert.Collection(eventArgs.Arguments, x => Assert.Same(fact1, x));
+        Assert.Collection(eventArgs.Facts.Select(x => x.Value), x => Assert.Same(fact1, x));
+        Assert.Equal(true, eventArgs.Result);
+        Assert.Null(eventArgs.Exception);
+    }
+    
+    [Fact]
+    public void Insert_Fact_RaisesAlphaConditionExpressionEvalEventWithException()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
 
-            //Assert
-            Assert.Single(handledEvents);
-            var eventArgs = handledEvents[0];
-            Assert.Collection(eventArgs.Arguments, x => Assert.Same(fact1, x));
-            Assert.Collection(eventArgs.Facts.Select(x => x.Value), x => Assert.Same(fact1, x));
-            Assert.Equal(true, eventArgs.Result);
-            Assert.Null(eventArgs.Exception);
+        var handledEvents = new List<LhsExpressionEventArgs>();
+        factory.Events.LhsExpressionEvaluatedEvent += (sender, args) =>
+        {
+            handledEvents.Add(args);
+        };
+
+        var fact1 = new FactType1 { TestProperty = null };
+
+        //Act - Assert
+        var ex = Assert.Throws<RuleLhsExpressionEvaluationException>(() => session.Insert(fact1));
+        Assert.Single(handledEvents);
+        var eventArgs = handledEvents[0];
+        Assert.Collection(eventArgs.Arguments, x => Assert.Same(fact1, x));
+        Assert.Collection(eventArgs.Facts.Select(x => x.Value), x => Assert.Same(fact1, x));
+        Assert.Equal(false, eventArgs.Result);
+        Assert.Same(ex.InnerException, eventArgs.Exception);
+    }
+    
+    [Fact]
+    public void Insert_Fact_RaisesBetaConditionExpressionEvalEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
+
+        var handledEvents = new List<LhsExpressionEventArgs>();
+        factory.Events.LhsExpressionEvaluatedEvent += (sender, args) =>
+        {
+            handledEvents.Add(args);
+        };
+
+        var fact1 = new FactType1 { TestProperty = "Valid Value" };
+        var fact2 = new FactType2 { JoinProperty = "Invalid Value", SelectProperty = "12345"};
+
+        //Act
+        session.Insert(fact1);
+        session.Insert(fact2);
+
+        //Assert
+        Assert.Equal(2, handledEvents.Count);
+        var eventArgs = handledEvents[1];
+        Assert.Collection(eventArgs.Arguments, x => Assert.Same(fact2, x), x => Assert.Same(fact1, x));
+        Assert.Collection(eventArgs.Facts.Select(x => x.Value), x => Assert.Same(fact1, x), x => Assert.Same(fact2, x));
+        Assert.Equal(false, eventArgs.Result);
+        Assert.Null(eventArgs.Exception);
+    }
+    
+    [Fact]
+    public void Insert_Fact_RaisesAggregateExpressionEvalEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
+
+        var handledEvents = new List<LhsExpressionEventArgs>();
+        factory.Events.LhsExpressionEvaluatedEvent += (sender, args) =>
+        {
+            handledEvents.Add(args);
+        };
+
+        var fact1 = new FactType1 { TestProperty = "Valid Value" };
+        var fact2 = new FactType2 { JoinProperty = "Valid Value", SelectProperty = "12345"};
+
+        //Act
+        session.Insert(fact1);
+        session.Insert(fact2);
+
+        //Assert
+        Assert.Equal(5, handledEvents.Count);
+        var eventArgs = handledEvents[2];
+        Assert.Collection(eventArgs.Arguments, x => Assert.Same(fact2, x));
+        Assert.Collection(eventArgs.Facts.Select(x => x.Value), x => Assert.Same(fact1, x), x => Assert.Same(fact2, x));
+        Assert.Equal("12345", eventArgs.Result);
+        Assert.Null(eventArgs.Exception);
+    }
+    
+    [Fact]
+    public void Insert_Fact_RaisesBindingExpressionEvalEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
+
+        var handledEvents = new List<LhsExpressionEventArgs>();
+        factory.Events.LhsExpressionEvaluatedEvent += (sender, args) =>
+        {
+            handledEvents.Add(args);
+        };
+
+        var fact1 = new FactType1 { TestProperty = "Valid Value" };
+        var fact2 = new FactType2 { JoinProperty = "Valid Value", SelectProperty = "12345"};
+
+        //Act
+        session.Insert(fact1);
+        session.Insert(fact2);
+
+        //Assert
+        Assert.Equal(5, handledEvents.Count);
+        var eventArgs = handledEvents[3];
+        Assert.Collection(eventArgs.Arguments, x => Assert.Equal("12345", x));
+        Assert.Collection(eventArgs.Facts.Select(x => x.Value), x => Assert.Equal(fact1, x), x => Assert.Equal("12345", x));
+        Assert.Equal(5, eventArgs.Result);
+        Assert.Null(eventArgs.Exception);
+    }
+    
+    [Fact]
+    public void Insert_Fact_RaisesFilterExpressionEvalEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
+
+        var handledEvents = new List<AgendaExpressionEventArgs>();
+        factory.Events.AgendaExpressionEvaluatedEvent += (sender, args) =>
+        {
+            handledEvents.Add(args);
+        };
+
+        var fact1 = new FactType1 { TestProperty = "Valid Value" };
+        var fact2 = new FactType2 { JoinProperty = "Valid Value", SelectProperty = "123456"};
+
+        //Act
+        session.Insert(fact1);
+        session.Insert(fact2);
+        session.Fire();
+
+        //Assert
+        Assert.Single(handledEvents);
+        var eventArgs = handledEvents[0];
+        Assert.Collection(eventArgs.Arguments, x => Assert.Equal(6, x));
+        Assert.Collection(eventArgs.Facts.Select(x => x.Value), x => Assert.Equal(fact1, x), x => Assert.Equal("123456", x), x => Assert.Equal(6, x));
+        Assert.Equal(false, eventArgs.Result);
+        Assert.Null(eventArgs.Exception);
+        Assert.Equal("Test Rule", eventArgs.Rule.Name);
+    }
+
+    [Fact]
+    public void Fire_Rule_RaisesActionExpressionEvalEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
+
+        var handledEvents = new List<RhsExpressionEventArgs>();
+        factory.Events.RhsExpressionEvaluatedEvent += (sender, args) =>
+        {
+            handledEvents.Add(args);
+        };
+
+        var fact1 = new FactType1 { TestProperty = "Valid Value" };
+        var fact2 = new FactType2 { JoinProperty = "Valid Value", SelectProperty = "1234567890A"};
+
+        //Act
+        session.Insert(fact1);
+        session.Insert(fact2);
+        session.Fire();
+
+        //Assert
+        Assert.Single(handledEvents);
+        var eventArgs = handledEvents[0];
+        Assert.Collection(eventArgs.Arguments, x => Assert.Equal(fact1, x), x => Assert.Equal("1234567890A", x));
+        Assert.Collection(eventArgs.Match.Facts.Select(x => x.Value), x => Assert.Equal(fact1, x), x => Assert.Equal("1234567890A", x), x => Assert.Equal(11, x));
+        Assert.Null(eventArgs.Result);
+        Assert.Null(eventArgs.Exception);
+        Assert.Equal("Test Rule", eventArgs.Match.Rule.Name);
+        Assert.Equal(MatchTrigger.Created, eventArgs.Match.Trigger);
+    }
+
+    private ISessionFactory CreateTarget()
+    {
+        var repository = new RuleRepository();
+        repository.Load(x => x.NestedTypes().From(typeof(TestRule)));
+        return repository.Compile();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string JoinProperty { get; set; }
+        public string SelectProperty { get; set; }
+    }
+
+    [Name("Test Rule")]
+    public class TestRule : Rule
+    {
+        public override void Define()
+        {
+            FactType1 fact = null;
+            string value = null;
+            int length = 0;
+
+            When()
+                .Match<FactType1>(() => fact,
+                    f => f.TestProperty.StartsWith("Valid"))
+                .Query(() => value, q => q
+                    .Match<FactType2>(
+                        f => f.JoinProperty == fact.TestProperty)
+                    .Select(x => x.SelectProperty))
+                .Let(() => length, () => value.Length)
+                .Having(() => length > 5);
+
+            Filter()
+                .Where(() => length > 10);
+
+            Then()
+                .Do(ctx => NoOp(fact, value));
         }
-        
-        [Fact]
-        public void Insert_Fact_RaisesAlphaConditionExpressionEvalEventWithException()
+
+        private void NoOp(FactType1 fact, string value)
         {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
-
-            var handledEvents = new List<LhsExpressionEventArgs>();
-            factory.Events.LhsExpressionEvaluatedEvent += (sender, args) =>
-            {
-                handledEvents.Add(args);
-            };
-
-            var fact1 = new FactType1 { TestProperty = null };
-
-            //Act - Assert
-            var ex = Assert.Throws<RuleLhsExpressionEvaluationException>(() => session.Insert(fact1));
-            Assert.Single(handledEvents);
-            var eventArgs = handledEvents[0];
-            Assert.Collection(eventArgs.Arguments, x => Assert.Same(fact1, x));
-            Assert.Collection(eventArgs.Facts.Select(x => x.Value), x => Assert.Same(fact1, x));
-            Assert.Equal(false, eventArgs.Result);
-            Assert.Same(ex.InnerException, eventArgs.Exception);
-        }
-        
-        [Fact]
-        public void Insert_Fact_RaisesBetaConditionExpressionEvalEvent()
-        {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
-
-            var handledEvents = new List<LhsExpressionEventArgs>();
-            factory.Events.LhsExpressionEvaluatedEvent += (sender, args) =>
-            {
-                handledEvents.Add(args);
-            };
-
-            var fact1 = new FactType1 { TestProperty = "Valid Value" };
-            var fact2 = new FactType2 { JoinProperty = "Invalid Value", SelectProperty = "12345"};
-
-            //Act
-            session.Insert(fact1);
-            session.Insert(fact2);
-
-            //Assert
-            Assert.Equal(2, handledEvents.Count);
-            var eventArgs = handledEvents[1];
-            Assert.Collection(eventArgs.Arguments, x => Assert.Same(fact2, x), x => Assert.Same(fact1, x));
-            Assert.Collection(eventArgs.Facts.Select(x => x.Value), x => Assert.Same(fact1, x), x => Assert.Same(fact2, x));
-            Assert.Equal(false, eventArgs.Result);
-            Assert.Null(eventArgs.Exception);
-        }
-        
-        [Fact]
-        public void Insert_Fact_RaisesAggregateExpressionEvalEvent()
-        {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
-
-            var handledEvents = new List<LhsExpressionEventArgs>();
-            factory.Events.LhsExpressionEvaluatedEvent += (sender, args) =>
-            {
-                handledEvents.Add(args);
-            };
-
-            var fact1 = new FactType1 { TestProperty = "Valid Value" };
-            var fact2 = new FactType2 { JoinProperty = "Valid Value", SelectProperty = "12345"};
-
-            //Act
-            session.Insert(fact1);
-            session.Insert(fact2);
-
-            //Assert
-            Assert.Equal(5, handledEvents.Count);
-            var eventArgs = handledEvents[2];
-            Assert.Collection(eventArgs.Arguments, x => Assert.Same(fact2, x));
-            Assert.Collection(eventArgs.Facts.Select(x => x.Value), x => Assert.Same(fact1, x), x => Assert.Same(fact2, x));
-            Assert.Equal("12345", eventArgs.Result);
-            Assert.Null(eventArgs.Exception);
-        }
-        
-        [Fact]
-        public void Insert_Fact_RaisesBindingExpressionEvalEvent()
-        {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
-
-            var handledEvents = new List<LhsExpressionEventArgs>();
-            factory.Events.LhsExpressionEvaluatedEvent += (sender, args) =>
-            {
-                handledEvents.Add(args);
-            };
-
-            var fact1 = new FactType1 { TestProperty = "Valid Value" };
-            var fact2 = new FactType2 { JoinProperty = "Valid Value", SelectProperty = "12345"};
-
-            //Act
-            session.Insert(fact1);
-            session.Insert(fact2);
-
-            //Assert
-            Assert.Equal(5, handledEvents.Count);
-            var eventArgs = handledEvents[3];
-            Assert.Collection(eventArgs.Arguments, x => Assert.Equal("12345", x));
-            Assert.Collection(eventArgs.Facts.Select(x => x.Value), x => Assert.Equal(fact1, x), x => Assert.Equal("12345", x));
-            Assert.Equal(5, eventArgs.Result);
-            Assert.Null(eventArgs.Exception);
-        }
-        
-        [Fact]
-        public void Insert_Fact_RaisesFilterExpressionEvalEvent()
-        {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
-
-            var handledEvents = new List<AgendaExpressionEventArgs>();
-            factory.Events.AgendaExpressionEvaluatedEvent += (sender, args) =>
-            {
-                handledEvents.Add(args);
-            };
-
-            var fact1 = new FactType1 { TestProperty = "Valid Value" };
-            var fact2 = new FactType2 { JoinProperty = "Valid Value", SelectProperty = "123456"};
-
-            //Act
-            session.Insert(fact1);
-            session.Insert(fact2);
-            session.Fire();
-
-            //Assert
-            Assert.Single(handledEvents);
-            var eventArgs = handledEvents[0];
-            Assert.Collection(eventArgs.Arguments, x => Assert.Equal(6, x));
-            Assert.Collection(eventArgs.Facts.Select(x => x.Value), x => Assert.Equal(fact1, x), x => Assert.Equal("123456", x), x => Assert.Equal(6, x));
-            Assert.Equal(false, eventArgs.Result);
-            Assert.Null(eventArgs.Exception);
-            Assert.Equal("Test Rule", eventArgs.Rule.Name);
-        }
-
-        [Fact]
-        public void Fire_Rule_RaisesActionExpressionEvalEvent()
-        {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
-
-            var handledEvents = new List<RhsExpressionEventArgs>();
-            factory.Events.RhsExpressionEvaluatedEvent += (sender, args) =>
-            {
-                handledEvents.Add(args);
-            };
-
-            var fact1 = new FactType1 { TestProperty = "Valid Value" };
-            var fact2 = new FactType2 { JoinProperty = "Valid Value", SelectProperty = "1234567890A"};
-
-            //Act
-            session.Insert(fact1);
-            session.Insert(fact2);
-            session.Fire();
-
-            //Assert
-            Assert.Single(handledEvents);
-            var eventArgs = handledEvents[0];
-            Assert.Collection(eventArgs.Arguments, x => Assert.Equal(fact1, x), x => Assert.Equal("1234567890A", x));
-            Assert.Collection(eventArgs.Match.Facts.Select(x => x.Value), x => Assert.Equal(fact1, x), x => Assert.Equal("1234567890A", x), x => Assert.Equal(11, x));
-            Assert.Null(eventArgs.Result);
-            Assert.Null(eventArgs.Exception);
-            Assert.Equal("Test Rule", eventArgs.Match.Rule.Name);
-            Assert.Equal(MatchTrigger.Created, eventArgs.Match.Trigger);
-        }
-
-        private ISessionFactory CreateTarget()
-        {
-            var repository = new RuleRepository();
-            repository.Load(x => x.NestedTypes().From(typeof(TestRule)));
-            return repository.Compile();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string JoinProperty { get; set; }
-            public string SelectProperty { get; set; }
-        }
-
-        [Name("Test Rule")]
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact = null;
-                string value = null;
-                int length = 0;
-
-                When()
-                    .Match<FactType1>(() => fact,
-                        f => f.TestProperty.StartsWith("Valid"))
-                    .Query(() => value, q => q
-                        .Match<FactType2>(
-                            f => f.JoinProperty == fact.TestProperty)
-                        .Select(x => x.SelectProperty))
-                    .Let(() => length, () => value.Length)
-                    .Having(() => length > 5);
-
-                Filter()
-                    .Where(() => length > 10);
-
-                Then()
-                    .Do(ctx => NoOp(fact, value));
-            }
-
-            private void NoOp(FactType1 fact, string value)
-            {
-            }
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/EvaluationExceptionTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/EvaluationExceptionTest.cs
@@ -8,276 +8,275 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class EvaluationExceptionTest : BaseRuleTestFixture
 {
-    public class EvaluationExceptionTest : BaseRuleTestFixture
+    [Fact]
+    public void Insert_ConditionErrorNoErrorHandler_Throws()
     {
-        [Fact]
-        public void Insert_ConditionErrorNoErrorHandler_Throws()
+        //Arrange
+        GetRuleInstance<TestRule>().Condition = ThrowCondition;
+
+        Expression expression = null;
+        IList<IFact> facts = null; 
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => expression = args.Expression;
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => facts = args.Facts.ToList();
+
+        var fact = new FactType {TestProperty = "Valid Value" };
+
+        //Act - Assert
+        var ex = Assert.Throws<RuleLhsExpressionEvaluationException>(() => Session.Insert(fact));
+        Assert.NotNull(expression);
+        Assert.Single(facts);
+        Assert.Same(fact, facts.First().Value);
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void Fire_ConditionFailedInsert_DoesNotFire()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().Condition = ThrowCondition;
+
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_ConditionFailedInsertThenUpdate_Fires()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().Condition = ThrowCondition;
+
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+        Session.Insert(fact);
+
+        GetRuleInstance<TestRule>().Condition = SuccessfulCondition;
+
+        Session.Update(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_ConditionInsertThenFailedUpdate_DoesNotFire()
+    {
+        //Arrange
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+        Session.Insert(fact);
+
+        GetRuleInstance<TestRule>().Condition = ThrowCondition;
+
+        Session.Update(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_ConditionFailedInsertThenRetract_DoesNotFire()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().Condition = ThrowCondition;
+
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+        Session.Insert(fact);
+
+        GetRuleInstance<TestRule>().Condition = SuccessfulCondition;
+
+        Session.Retract(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_ConditionFailedInsertThenUpdateThenRetract_DoesNotFire()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().Condition = ThrowCondition;
+
+        Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+        Session.Insert(fact);
+
+        GetRuleInstance<TestRule>().Condition = SuccessfulCondition;
+
+        Session.Update(fact);
+        Session.Retract(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Insert_FilterErrorNoErrorHandler_Throws()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().FilterCondition = ThrowFilter;
+
+        Expression expression = null;
+        IList<IFactMatch> facts = null;
+        Session.Events.AgendaExpressionFailedEvent += (sender, args) => expression = args.Expression;
+        Session.Events.AgendaExpressionFailedEvent += (sender, args) => facts = args.Facts.ToList();
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+
+        //Act - Assert
+        var ex = Assert.Throws<AgendaExpressionEvaluationException>(() => Session.Insert(fact));
+        Assert.NotNull(expression);
+        Assert.Single(facts);
+        Assert.Same(fact, facts.First().Value);
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void Insert_FilterErrorHasErrorHandler_DoesNotFire()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().FilterCondition = ThrowFilter;
+
+        Session.Events.AgendaExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+        var fact = new FactType { TestProperty = "Valid Value" };
+
+        //Act
+        Session.Insert(fact);
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_ActionErrorNoErrorHandler_Throws()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().Action = ThrowAction;
+
+        Expression expression = null;
+        IList<IFactMatch> facts = null;
+        Session.Events.RhsExpressionFailedEvent += (sender, args) => expression = args.Expression;
+        Session.Events.RhsExpressionFailedEvent += (sender, args) => facts = args.Match.Facts.ToList();
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+        Session.Insert(fact);
+
+        //Act - Assert
+        var ex = Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
+        Assert.NotNull(expression);
+        Assert.Single(facts);
+        Assert.Same(fact, facts.First().Value);
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void Fire_ActionErrorHasErrorHandler_DoesNotThrow()
+    {
+        //Arrange
+        GetRuleInstance<TestRule>().Action = ThrowAction;
+
+        Session.Events.RhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+        Session.Insert(fact);
+
+        //Act - Assert
+        Session.Fire();
+    }
+
+    [Fact]
+    public void Fire_ActionErrorNoErrorHandlerWithInterceptor_ThrowsBareException()
+    {
+        //Arrange
+        Session.ActionInterceptor = new PassThroughActionInterceptor();
+        GetRuleInstance<TestRule>().Action = ThrowAction;
+
+        Expression expression = null;
+        IList<IFactMatch> facts = null;
+        Session.Events.RhsExpressionFailedEvent += (sender, args) => expression = args.Expression;
+        Session.Events.RhsExpressionFailedEvent += (sender, args) => facts = args.Match.Facts.ToList();
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+        Session.Insert(fact);
+
+        //Act - Assert
+        Assert.Throws<InvalidOperationException>(() => Session.Fire());
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    private static readonly Action SuccessfulAction = () => { };
+    private static readonly Action ThrowAction = () => throw new InvalidOperationException("Action failed");
+    private static readonly Func<FactType, bool> SuccessfulCondition = f => true;
+    private static readonly Func<FactType, bool> ThrowCondition = f => throw new InvalidOperationException("Condition failed");
+    private static readonly Func<FactType, bool> SuccessfulFilter = f => true;
+    private static readonly Func<FactType, bool> ThrowFilter = f => throw new InvalidOperationException("Filter failed");
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public Action Action = SuccessfulAction;
+        public Func<FactType, bool> Condition = SuccessfulCondition;
+        public Func<FactType, bool> FilterCondition = SuccessfulFilter;
+
+        public override void Define()
         {
-            //Arrange
-            GetRuleInstance<TestRule>().Condition = ThrowCondition;
+            FactType fact = null;
 
-            Expression expression = null;
-            IList<IFact> facts = null; 
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => expression = args.Expression;
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => facts = args.Facts.ToList();
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid") && Condition(f));
 
-            var fact = new FactType {TestProperty = "Valid Value" };
+            Filter()
+                .Where(() => FilterCondition(fact));
 
-            //Act - Assert
-            var ex = Assert.Throws<RuleLhsExpressionEvaluationException>(() => Session.Insert(fact));
-            Assert.NotNull(expression);
-            Assert.Single(facts);
-            Assert.Same(fact, facts.First().Value);
-            Assert.IsType<InvalidOperationException>(ex.InnerException);
+            Then()
+                .Do(ctx => Action());
         }
+    }
 
-        [Fact]
-        public void Fire_ConditionFailedInsert_DoesNotFire()
+    public class PassThroughActionInterceptor : IActionInterceptor
+    {
+        public void Intercept(IContext context, IEnumerable<IActionInvocation> actions)
         {
-            //Arrange
-            GetRuleInstance<TestRule>().Condition = ThrowCondition;
-
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-            Session.Insert(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_ConditionFailedInsertThenUpdate_Fires()
-        {
-            //Arrange
-            GetRuleInstance<TestRule>().Condition = ThrowCondition;
-
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-            Session.Insert(fact);
-
-            GetRuleInstance<TestRule>().Condition = SuccessfulCondition;
-
-            Session.Update(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_ConditionInsertThenFailedUpdate_DoesNotFire()
-        {
-            //Arrange
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-            Session.Insert(fact);
-
-            GetRuleInstance<TestRule>().Condition = ThrowCondition;
-
-            Session.Update(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_ConditionFailedInsertThenRetract_DoesNotFire()
-        {
-            //Arrange
-            GetRuleInstance<TestRule>().Condition = ThrowCondition;
-
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-            Session.Insert(fact);
-
-            GetRuleInstance<TestRule>().Condition = SuccessfulCondition;
-
-            Session.Retract(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_ConditionFailedInsertThenUpdateThenRetract_DoesNotFire()
-        {
-            //Arrange
-            GetRuleInstance<TestRule>().Condition = ThrowCondition;
-
-            Session.Events.LhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-            Session.Insert(fact);
-
-            GetRuleInstance<TestRule>().Condition = SuccessfulCondition;
-
-            Session.Update(fact);
-            Session.Retract(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Insert_FilterErrorNoErrorHandler_Throws()
-        {
-            //Arrange
-            GetRuleInstance<TestRule>().FilterCondition = ThrowFilter;
-
-            Expression expression = null;
-            IList<IFactMatch> facts = null;
-            Session.Events.AgendaExpressionFailedEvent += (sender, args) => expression = args.Expression;
-            Session.Events.AgendaExpressionFailedEvent += (sender, args) => facts = args.Facts.ToList();
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-
-            //Act - Assert
-            var ex = Assert.Throws<AgendaExpressionEvaluationException>(() => Session.Insert(fact));
-            Assert.NotNull(expression);
-            Assert.Single(facts);
-            Assert.Same(fact, facts.First().Value);
-            Assert.IsType<InvalidOperationException>(ex.InnerException);
-        }
-
-        [Fact]
-        public void Insert_FilterErrorHasErrorHandler_DoesNotFire()
-        {
-            //Arrange
-            GetRuleInstance<TestRule>().FilterCondition = ThrowFilter;
-
-            Session.Events.AgendaExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-            var fact = new FactType { TestProperty = "Valid Value" };
-
-            //Act
-            Session.Insert(fact);
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_ActionErrorNoErrorHandler_Throws()
-        {
-            //Arrange
-            GetRuleInstance<TestRule>().Action = ThrowAction;
-
-            Expression expression = null;
-            IList<IFactMatch> facts = null;
-            Session.Events.RhsExpressionFailedEvent += (sender, args) => expression = args.Expression;
-            Session.Events.RhsExpressionFailedEvent += (sender, args) => facts = args.Match.Facts.ToList();
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-            Session.Insert(fact);
-
-            //Act - Assert
-            var ex = Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
-            Assert.NotNull(expression);
-            Assert.Single(facts);
-            Assert.Same(fact, facts.First().Value);
-            Assert.IsType<InvalidOperationException>(ex.InnerException);
-        }
-
-        [Fact]
-        public void Fire_ActionErrorHasErrorHandler_DoesNotThrow()
-        {
-            //Arrange
-            GetRuleInstance<TestRule>().Action = ThrowAction;
-
-            Session.Events.RhsExpressionFailedEvent += (sender, args) => args.IsHandled = true;
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-            Session.Insert(fact);
-
-            //Act - Assert
-            Session.Fire();
-        }
-
-        [Fact]
-        public void Fire_ActionErrorNoErrorHandlerWithInterceptor_ThrowsBareException()
-        {
-            //Arrange
-            Session.ActionInterceptor = new PassThroughActionInterceptor();
-            GetRuleInstance<TestRule>().Action = ThrowAction;
-
-            Expression expression = null;
-            IList<IFactMatch> facts = null;
-            Session.Events.RhsExpressionFailedEvent += (sender, args) => expression = args.Expression;
-            Session.Events.RhsExpressionFailedEvent += (sender, args) => facts = args.Match.Facts.ToList();
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-            Session.Insert(fact);
-
-            //Act - Assert
-            Assert.Throws<InvalidOperationException>(() => Session.Fire());
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        private static readonly Action SuccessfulAction = () => { };
-        private static readonly Action ThrowAction = () => throw new InvalidOperationException("Action failed");
-        private static readonly Func<FactType, bool> SuccessfulCondition = f => true;
-        private static readonly Func<FactType, bool> ThrowCondition = f => throw new InvalidOperationException("Condition failed");
-        private static readonly Func<FactType, bool> SuccessfulFilter = f => true;
-        private static readonly Func<FactType, bool> ThrowFilter = f => throw new InvalidOperationException("Filter failed");
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public Action Action = SuccessfulAction;
-            public Func<FactType, bool> Condition = SuccessfulCondition;
-            public Func<FactType, bool> FilterCondition = SuccessfulFilter;
-
-            public override void Define()
+            foreach (var action in actions)
             {
-                FactType fact = null;
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid") && Condition(f));
-
-                Filter()
-                    .Where(() => FilterCondition(fact));
-
-                Then()
-                    .Do(ctx => Action());
-            }
-        }
-
-        public class PassThroughActionInterceptor : IActionInterceptor
-        {
-            public void Intercept(IContext context, IEnumerable<IActionInvocation> actions)
-            {
-                foreach (var action in actions)
-                {
-                    action.Invoke();
-                }
+                action.Invoke();
             }
         }
     }

--- a/src/NRules/Tests/NRules.IntegrationTests/ExpressionParameterOrderTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/ExpressionParameterOrderTest.cs
@@ -2,113 +2,112 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class ExpressionParameterOrderTest : BaseRuleTestFixture
 {
-    public class ExpressionParameterOrderTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchGroup1_FiresOnce()
     {
-        [Fact]
-        public void Fire_MatchGroup1_FiresOnce()
+        //Arrange
+        var f0 = new FactType0();
+        var f1 = new FactType1();
+        var f2 = new FactType2();
+        Session.InsertAll(new object[]{f0, f1, f2});
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchGroup2_FiresOnce()
+    {
+        //Arrange
+        var f0 = new FactType0();
+        var f3 = new FactType3();
+        Session.InsertAll(new object[]{f0, f3});
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType0
+    {
+    }
+
+    public class FactType1
+    {
+    }
+
+    public class FactType2
+    {
+    }
+
+    public class FactType3
+    {
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var f0 = new FactType0();
-            var f1 = new FactType1();
-            var f2 = new FactType2();
-            Session.InsertAll(new object[]{f0, f1, f2});
+            FactType0 f0 = null;
+            FactType1 f1 = null;
+            FactType2 f2 = null;
+            FactType3 f3 = null;
 
-            //Act
-            Session.Fire();
+            When()
+                .Or(x => x
+                    .And(xx => xx
+                        .Match(() => f0)
+                        .Match(() => f1)
+                        .Match(() => f2)
+                        .Having(() => Condition(f0, f1, f2))
+                        .Having(() => Condition(f2, f3, f0)))
+                    .And(xx => xx
+                        .Match(() => f3)
+                        .Match(() => f0)
+                        .Having(() => Condition(f0, f3))
+                        .Having(() => Condition(f3, f0)))
+                );
 
-            //Assert
-            AssertFiredOnce();
+            Then()
+                .Do(ctx => Action(f2, f0, f3));
         }
 
-        [Fact]
-        public void Fire_MatchGroup2_FiresOnce()
+        private bool Condition(FactType0 f0, FactType1 f1, FactType2 f2)
         {
-            //Arrange
-            var f0 = new FactType0();
-            var f3 = new FactType3();
-            Session.InsertAll(new object[]{f0, f3});
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
+            return true;
         }
 
-        protected override void SetUpRules()
+        private bool Condition(FactType2 f2, FactType3 f3, FactType0 f0)
         {
-            SetUpRule<TestRule>();
+            return true;
         }
 
-        public class FactType0
+        private bool Condition(FactType0 f0, FactType3 f3)
         {
+            return true;
         }
 
-        public class FactType1
+        private bool Condition(FactType3 f3, FactType0 f0)
         {
+            return true;
         }
 
-        public class FactType2
+        private void Action(FactType2 f2, FactType0 f0, FactType3 f3)
         {
-        }
-
-        public class FactType3
-        {
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType0 f0 = null;
-                FactType1 f1 = null;
-                FactType2 f2 = null;
-                FactType3 f3 = null;
-
-                When()
-                    .Or(x => x
-                        .And(xx => xx
-                            .Match(() => f0)
-                            .Match(() => f1)
-                            .Match(() => f2)
-                            .Having(() => Condition(f0, f1, f2))
-                            .Having(() => Condition(f2, f3, f0)))
-                        .And(xx => xx
-                            .Match(() => f3)
-                            .Match(() => f0)
-                            .Having(() => Condition(f0, f3))
-                            .Having(() => Condition(f3, f0)))
-                    );
-
-                Then()
-                    .Do(ctx => Action(f2, f0, f3));
-            }
-
-            private bool Condition(FactType0 f0, FactType1 f1, FactType2 f2)
-            {
-                return true;
-            }
-
-            private bool Condition(FactType2 f2, FactType3 f3, FactType0 f0)
-            {
-                return true;
-            }
-
-            private bool Condition(FactType0 f0, FactType3 f3)
-            {
-                return true;
-            }
-
-            private bool Condition(FactType3 f3, FactType0 f0)
-            {
-                return true;
-            }
-
-            private void Action(FactType2 f2, FactType0 f0, FactType3 f3)
-            {
-            }
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/ForwardChainingLinkedTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/ForwardChainingLinkedTest.cs
@@ -5,214 +5,213 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class ForwardChainingLinkedTest : BaseRuleTestFixture
 {
-    public class ForwardChainingLinkedTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFact_FiresFirstRuleAndChainsSecond()
     {
-        [Fact]
-        public void Fire_OneMatchingFact_FiresFirstRuleAndChainsSecond()
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce<ForwardChainingFirstRule>();
+        AssertFiredOnce<ForwardChainingSecondRule>();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactInsertedThenUpdated_FiresFirstRuleAndChainsSecondLinkedFactsUpdated()
+    {
+        //Arrange
+        FactType2 matchedFact2 = null;
+        FactType3 matchedFact3 = null;
+        Session.Events.FactInsertedEvent += (sender, args) =>
         {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.Insert(fact1);
+            if (args.Fact.Type == typeof(FactType2)) matchedFact2 = (FactType2) args.Fact.Value;
+            if (args.Fact.Type == typeof(FactType3)) matchedFact3 = (FactType3) args.Fact.Value;
+        };
+        Session.Events.FactUpdatedEvent += (sender, args) =>
+        {
+            if (args.Fact.Type == typeof(FactType2)) matchedFact2 = (FactType2) args.Fact.Value;
+            if (args.Fact.Type == typeof(FactType3)) matchedFact3 = (FactType3) args.Fact.Value;
+        };
 
-            //Act
-            Session.Fire();
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.Insert(fact1);
 
-            //Assert
-            AssertFiredOnce<ForwardChainingFirstRule>();
-            AssertFiredOnce<ForwardChainingSecondRule>();
+        //Act - I
+        Session.Fire();
+
+        //Assert - I
+        AssertFiredOnce<ForwardChainingFirstRule>();
+        AssertFiredOnce<ForwardChainingSecondRule>();
+        Assert.Equal(1, matchedFact2.UpdateCount);
+        Assert.Equal("Valid Value 1", matchedFact2.TestProperty);
+        Assert.Equal("Valid Value 1", matchedFact3.TestProperty);
+
+        //Act - II
+        fact1.ChainProperty = "Valid Value 2";
+        Session.Update(fact1);
+        Session.Fire();
+
+        //Assert - II
+        AssertFiredTwice<ForwardChainingFirstRule>();
+        AssertFiredTwice<ForwardChainingSecondRule>();
+        Assert.Equal(2, matchedFact2.UpdateCount);
+        Assert.Equal("Valid Value 2", matchedFact2.TestProperty);
+        Assert.Equal("Valid Value 2", matchedFact3.TestProperty);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactInsertedThenRetracted_FiresFirstRuleAndChainsSecondLinkedFactsRetracted()
+    {
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+
+        //Act - I
+        Session.Fire();
+
+        //Assert - I
+        AssertFiredOnce<ForwardChainingFirstRule>();
+        AssertFiredOnce<ForwardChainingSecondRule>();
+        Assert.Equal(1, Session.Query<FactType2>().Count());
+        Assert.Equal(1, Session.Query<FactType3>().Count());
+
+        //Act - II
+        Session.Retract(fact1);
+        Session.Fire();
+
+        //Assert - II
+        Assert.Equal(0, Session.Query<FactType2>().Count());
+        Assert.Equal(0, Session.Query<FactType3>().Count());
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFact_LinkedFactHasSource()
+    {
+        //Arrange
+        IFact matchedFact2 = null;
+        IFact matchedFact3 = null;
+        Session.Events.FactInsertedEvent += (sender, args) =>
+        {
+            if (args.Fact.Type == typeof(FactType2)) matchedFact2 = args.Fact;
+            if (args.Fact.Type == typeof(FactType3)) matchedFact3 = args.Fact;
+        };
+
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Assert.NotNull(matchedFact2);
+        Assert.NotNull(matchedFact3);
+        Assert.NotNull(matchedFact2.Source);
+        Assert.Equal(FactSourceType.Linked, matchedFact2.Source.SourceType);
+        Assert.Single(matchedFact2.Source.Facts, x => x.Value == fact1);
+
+        var linkedSource = (ILinkedFactSource)matchedFact2.Source;
+        Assert.NotNull(linkedSource.Rule);
+        Assert.Contains(nameof(ForwardChainingFirstRule), linkedSource.Rule.Name);
+    }
+
+    [Fact]
+    public void Fire_DirectUpdateOfLinkedFact_Fails()
+    {
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Fire();
+
+        var linkedFacts = Session.Query<FactType2>();
+
+        //Act - Assert
+        Assert.Throws<ArgumentException>(() => Session.UpdateAll(linkedFacts));
+    }
+
+    [Fact]
+    public void Fire_DirectRetractOfLinkedFact_Fails()
+    {
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Fire();
+
+        var linkedFacts = Session.Query<FactType2>();
+
+        //Act - Assert
+        Assert.Throws<ArgumentException>(() => Session.RetractAll(linkedFacts));
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<ForwardChainingFirstRule>();
+        SetUpRule<ForwardChainingSecondRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+        public string ChainProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public int UpdateCount { get; set; } = 1;
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType3
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class ForwardChainingFirstRule : Rule
+    {
+        public override void Define()
+        {
+            FactType1 fact1 = null;
+
+            When()
+                .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Yield(ctx => Create(fact1), (ctx, fact2) => Update(fact1, fact2))
+                .Yield(ctx => new FactType3 {TestProperty = fact1.ChainProperty});
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactInsertedThenUpdated_FiresFirstRuleAndChainsSecondLinkedFactsUpdated()
+        private static FactType2 Create(FactType1 fact1)
         {
-            //Arrange
-            FactType2 matchedFact2 = null;
-            FactType3 matchedFact3 = null;
-            Session.Events.FactInsertedEvent += (sender, args) =>
-            {
-                if (args.Fact.Type == typeof(FactType2)) matchedFact2 = (FactType2) args.Fact.Value;
-                if (args.Fact.Type == typeof(FactType3)) matchedFact3 = (FactType3) args.Fact.Value;
-            };
-            Session.Events.FactUpdatedEvent += (sender, args) =>
-            {
-                if (args.Fact.Type == typeof(FactType2)) matchedFact2 = (FactType2) args.Fact.Value;
-                if (args.Fact.Type == typeof(FactType3)) matchedFact3 = (FactType3) args.Fact.Value;
-            };
-
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.Insert(fact1);
-
-            //Act - I
-            Session.Fire();
-
-            //Assert - I
-            AssertFiredOnce<ForwardChainingFirstRule>();
-            AssertFiredOnce<ForwardChainingSecondRule>();
-            Assert.Equal(1, matchedFact2.UpdateCount);
-            Assert.Equal("Valid Value 1", matchedFact2.TestProperty);
-            Assert.Equal("Valid Value 1", matchedFact3.TestProperty);
-
-            //Act - II
-            fact1.ChainProperty = "Valid Value 2";
-            Session.Update(fact1);
-            Session.Fire();
-
-            //Assert - II
-            AssertFiredTwice<ForwardChainingFirstRule>();
-            AssertFiredTwice<ForwardChainingSecondRule>();
-            Assert.Equal(2, matchedFact2.UpdateCount);
-            Assert.Equal("Valid Value 2", matchedFact2.TestProperty);
-            Assert.Equal("Valid Value 2", matchedFact3.TestProperty);
+            var fact2 = new FactType2 {TestProperty = fact1.ChainProperty};
+            return fact2;
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactInsertedThenRetracted_FiresFirstRuleAndChainsSecondLinkedFactsRetracted()
+        private static FactType2 Update(FactType1 fact1, FactType2 fact2)
         {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.Insert(fact1);
-
-            //Act - I
-            Session.Fire();
-
-            //Assert - I
-            AssertFiredOnce<ForwardChainingFirstRule>();
-            AssertFiredOnce<ForwardChainingSecondRule>();
-            Assert.Equal(1, Session.Query<FactType2>().Count());
-            Assert.Equal(1, Session.Query<FactType3>().Count());
-
-            //Act - II
-            Session.Retract(fact1);
-            Session.Fire();
-
-            //Assert - II
-            Assert.Equal(0, Session.Query<FactType2>().Count());
-            Assert.Equal(0, Session.Query<FactType3>().Count());
+            fact2.TestProperty = fact1.ChainProperty;
+            fact2.UpdateCount++;
+            return fact2;
         }
+    }
 
-        [Fact]
-        public void Fire_OneMatchingFact_LinkedFactHasSource()
+    public class ForwardChainingSecondRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            IFact matchedFact2 = null;
-            IFact matchedFact3 = null;
-            Session.Events.FactInsertedEvent += (sender, args) =>
-            {
-                if (args.Fact.Type == typeof(FactType2)) matchedFact2 = args.Fact;
-                if (args.Fact.Type == typeof(FactType3)) matchedFact3 = args.Fact;
-            };
+            FactType2 fact2 = null;
+            FactType3 fact3 = null;
 
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            Assert.NotNull(matchedFact2);
-            Assert.NotNull(matchedFact3);
-            Assert.NotNull(matchedFact2.Source);
-            Assert.Equal(FactSourceType.Linked, matchedFact2.Source.SourceType);
-            Assert.Single(matchedFact2.Source.Facts, x => x.Value == fact1);
-
-            var linkedSource = (ILinkedFactSource)matchedFact2.Source;
-            Assert.NotNull(linkedSource.Rule);
-            Assert.Contains(nameof(ForwardChainingFirstRule), linkedSource.Rule.Name);
-        }
-
-        [Fact]
-        public void Fire_DirectUpdateOfLinkedFact_Fails()
-        {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.Insert(fact1);
-            Session.Fire();
-
-            var linkedFacts = Session.Query<FactType2>();
-
-            //Act - Assert
-            Assert.Throws<ArgumentException>(() => Session.UpdateAll(linkedFacts));
-        }
-
-        [Fact]
-        public void Fire_DirectRetractOfLinkedFact_Fails()
-        {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1", ChainProperty = "Valid Value 1" };
-            Session.Insert(fact1);
-            Session.Fire();
-
-            var linkedFacts = Session.Query<FactType2>();
-
-            //Act - Assert
-            Assert.Throws<ArgumentException>(() => Session.RetractAll(linkedFacts));
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<ForwardChainingFirstRule>();
-            SetUpRule<ForwardChainingSecondRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-            public string ChainProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public int UpdateCount { get; set; } = 1;
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType3
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class ForwardChainingFirstRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-
-                When()
-                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Yield(ctx => Create(fact1), (ctx, fact2) => Update(fact1, fact2))
-                    .Yield(ctx => new FactType3 {TestProperty = fact1.ChainProperty});
-            }
-
-            private static FactType2 Create(FactType1 fact1)
-            {
-                var fact2 = new FactType2 {TestProperty = fact1.ChainProperty};
-                return fact2;
-            }
-
-            private static FactType2 Update(FactType1 fact1, FactType2 fact2)
-            {
-                fact2.TestProperty = fact1.ChainProperty;
-                fact2.UpdateCount++;
-                return fact2;
-            }
-        }
-
-        public class ForwardChainingSecondRule : Rule
-        {
-            public override void Define()
-            {
-                FactType2 fact2 = null;
-                FactType3 fact3 = null;
-
-                When()
-                    .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"))
-                    .Match<FactType3>(() => fact3, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"))
+                .Match<FactType3>(() => fact3, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/ForwardChainingLinkedToSelfTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/ForwardChainingLinkedToSelfTest.cs
@@ -4,89 +4,88 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class ForwardChainingLinkedToSelfTest : BaseRuleTestFixture
 {
-    public class ForwardChainingLinkedToSelfTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_TwoMatchingSetsOfFactsYieldsThenRetracted_FiresAndYieldedFactsAreRemoved()
     {
-        [Fact]
-        public void Fire_TwoMatchingSetsOfFactsYieldsThenRetracted_FiresAndYieldedFactsAreRemoved()
-        {
-            //Arrange
-            var order1 = new FactType1 { GroupKey = "Group 1" };
-            var order2 = new FactType1 { GroupKey = "Group 2" };
-            Session.InsertAll(new[] {order1, order2});
-            
-            //Act
-            Session.Fire();
-            Session.Retract(order1);
-            Session.Retract(order2);
+        //Arrange
+        var order1 = new FactType1 { GroupKey = "Group 1" };
+        var order2 = new FactType1 { GroupKey = "Group 2" };
+        Session.InsertAll(new[] {order1, order2});
+        
+        //Act
+        Session.Fire();
+        Session.Retract(order1);
+        Session.Retract(order2);
 
-            //Assert
-            AssertFiredTimes(3);
-            Assert.Equal(0, Session.Query<FactType4>().Count());
+        //Assert
+        AssertFiredTimes(3);
+        Assert.Equal(0, Session.Query<FactType4>().Count());
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<ForwardChainingRule>();
+    }
+
+    public class FactType1
+    {
+        public string GroupKey { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string Key { get; set; }
+    }
+
+    public class FactType3
+    {
+        public int Value { get; set; }
+    }
+
+    public class FactType4
+    {
+        public int Value { get; set; }
+    }
+
+    public class ForwardChainingRule : Rule
+    {
+        public override void Define()
+        {
+            IGrouping<string, FactType1> facts = null;
+            IEnumerable<FactType2> otherFacts = null;
+            FactType4 projection = null;
+
+            When()
+                .Query(() => facts, q => q
+                    .Match<FactType1>()
+                    .GroupBy(x => x.GroupKey))
+                .Query(() => otherFacts, q => q
+                    .Match<FactType2>(x => x.Key != facts.Key)
+                    .Collect())
+                .Query(() => projection, q => q
+                    .Match<FactType3>()
+                    .Collect()
+                    .Select(x => ProjectValue(x)));
+
+            Filter()
+                .OnChange(() => otherFacts.Count());
+
+            Then()
+                .Yield(ctx => Create(facts));
         }
 
-        protected override void SetUpRules()
+        private static FactType4 ProjectValue(IEnumerable<FactType3> x)
         {
-            SetUpRule<ForwardChainingRule>();
+            return new FactType4 {Value = x.Select(p => p.Value).FirstOrDefault()};
         }
 
-        public class FactType1
+        private static FactType2 Create(IGrouping<string, FactType1> orders)
         {
-            public string GroupKey { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string Key { get; set; }
-        }
-
-        public class FactType3
-        {
-            public int Value { get; set; }
-        }
-
-        public class FactType4
-        {
-            public int Value { get; set; }
-        }
-
-        public class ForwardChainingRule : Rule
-        {
-            public override void Define()
-            {
-                IGrouping<string, FactType1> facts = null;
-                IEnumerable<FactType2> otherFacts = null;
-                FactType4 projection = null;
-
-                When()
-                    .Query(() => facts, q => q
-                        .Match<FactType1>()
-                        .GroupBy(x => x.GroupKey))
-                    .Query(() => otherFacts, q => q
-                        .Match<FactType2>(x => x.Key != facts.Key)
-                        .Collect())
-                    .Query(() => projection, q => q
-                        .Match<FactType3>()
-                        .Collect()
-                        .Select(x => ProjectValue(x)));
-
-                Filter()
-                    .OnChange(() => otherFacts.Count());
-
-                Then()
-                    .Yield(ctx => Create(facts));
-            }
-
-            private static FactType4 ProjectValue(IEnumerable<FactType3> x)
-            {
-                return new FactType4 {Value = x.Select(p => p.Value).FirstOrDefault()};
-            }
-
-            private static FactType2 Create(IGrouping<string, FactType1> orders)
-            {
-                return new FactType2 {Key = orders.Key};
-            }
+            return new FactType2 {Key = orders.Key};
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/ForwardChainingTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/ForwardChainingTest.cs
@@ -2,102 +2,101 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class ForwardChainingTest : BaseRuleTestFixture
 {
-    public class ForwardChainingTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFact_FiresFirstRuleAndChainsSecond()
     {
-        [Fact]
-        public void Fire_OneMatchingFact_FiresFirstRuleAndChainsSecond()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Valid Value 1"};
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce<ForwardChainingFirstRule>();
+        AssertFiredOnce<ForwardChainingSecondRule>();
+    }
+    
+    [Fact]
+    public void Fire_OneMatchingFactErrorInSecondCondition_FiresFirstRuleAndChainsSecond()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = null};
+        Session.Insert(fact1);
+
+        //Act - Assert
+        var ex = Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
+        Assert.NotNull(ex.InnerException);
+        Assert.IsType<RuleLhsExpressionEvaluationException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfOneKindAndOneOfAnotherKind_FiresSecondRuleDirectlyAndChained()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2"};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce<ForwardChainingFirstRule>();
+        AssertFiredTwice<ForwardChainingSecondRule>();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<ForwardChainingFirstRule>();
+        SetUpRule<ForwardChainingSecondRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class ForwardChainingFirstRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Valid Value 1"};
-            Session.Insert(fact1);
+            FactType1 fact1 = null;
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce<ForwardChainingFirstRule>();
-            AssertFiredOnce<ForwardChainingSecondRule>();
+            When()
+                .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.Insert(new FactType2
+                {
+                    TestProperty = fact1.JoinProperty,
+                    JoinProperty = fact1.TestProperty
+                }));
         }
-        
-        [Fact]
-        public void Fire_OneMatchingFactErrorInSecondCondition_FiresFirstRuleAndChainsSecond()
+    }
+
+    public class ForwardChainingSecondRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = null};
-            Session.Insert(fact1);
+            FactType2 fact2 = null;
 
-            //Act - Assert
-            var ex = Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
-            Assert.NotNull(ex.InnerException);
-            Assert.IsType<RuleLhsExpressionEvaluationException>(ex.InnerException);
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactOfOneKindAndOneOfAnotherKind_FiresSecondRuleDirectlyAndChained()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2"};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce<ForwardChainingFirstRule>();
-            AssertFiredTwice<ForwardChainingSecondRule>();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<ForwardChainingFirstRule>();
-            SetUpRule<ForwardChainingSecondRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class ForwardChainingFirstRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-
-                When()
-                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.Insert(new FactType2
-                    {
-                        TestProperty = fact1.JoinProperty,
-                        JoinProperty = fact1.TestProperty
-                    }));
-            }
-        }
-
-        public class ForwardChainingSecondRule : Rule
-        {
-            public override void Define()
-            {
-                FactType2 fact2 = null;
-
-                When()
-                    .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/ForwardChainingTransitiveTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/ForwardChainingTransitiveTest.cs
@@ -3,141 +3,140 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class ForwardChainingTransitiveTest : BaseRuleTestFixture
 {
-    public class ForwardChainingTransitiveTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_FactInserted_EachRuleFires()
     {
-        [Fact]
-        public void Fire_FactInserted_EachRuleFires()
+        //Arrange
+        var order = new FactType {Value = "Value1"};
+
+        Session.Insert(order);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce<FactToCalc1Rule>();
+        AssertFiredOnce<Calc1ToCalc2Rule>();
+        AssertFiredOnce<Calc1Calc2ToCalc3Rule>();
+    }
+
+    [Fact]
+    public void Fire_FactInsertedThenUpdated_EachRuleFiresTwice()
+    {
+        //Arrange
+        var order = new FactType {Value = "Value1"};
+
+        Session.Insert(order);
+        Session.Fire();
+
+        order.Value = "Value2";
+        Session.Update(order);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice<FactToCalc1Rule>();
+        AssertFiredTwice<Calc1ToCalc2Rule>();
+        AssertFiredTwice<Calc1Calc2ToCalc3Rule>();
+    }
+    
+    protected override void SetUpRules()
+    {
+        SetUpRule<FactToCalc1Rule>();
+        SetUpRule<Calc1ToCalc2Rule>();
+        SetUpRule<Calc1Calc2ToCalc3Rule>();
+    }
+
+    public class FactType
+    {
+        public string Value { get; set; }
+    }
+
+    public class Calc1
+    {
+        public string Key { get; set; }
+        public string Value { get; set; }
+    }
+
+    public class Calc2
+    {
+        public string Key { get; set; }
+        public string Value { get; set; }
+    }
+
+    public class Calc3 : IEquatable<Calc3>
+    {
+        public bool Equals(Calc3 other)
         {
-            //Arrange
-            var order = new FactType {Value = "Value1"};
-
-            Session.Insert(order);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce<FactToCalc1Rule>();
-            AssertFiredOnce<Calc1ToCalc2Rule>();
-            AssertFiredOnce<Calc1Calc2ToCalc3Rule>();
+            return true;
         }
 
-        [Fact]
-        public void Fire_FactInsertedThenUpdated_EachRuleFiresTwice()
+        public override bool Equals(object obj)
         {
-            //Arrange
-            var order = new FactType {Value = "Value1"};
-
-            Session.Insert(order);
-            Session.Fire();
-
-            order.Value = "Value2";
-            Session.Update(order);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice<FactToCalc1Rule>();
-            AssertFiredTwice<Calc1ToCalc2Rule>();
-            AssertFiredTwice<Calc1Calc2ToCalc3Rule>();
-        }
-        
-        protected override void SetUpRules()
-        {
-            SetUpRule<FactToCalc1Rule>();
-            SetUpRule<Calc1ToCalc2Rule>();
-            SetUpRule<Calc1Calc2ToCalc3Rule>();
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Calc3) obj);
         }
 
-        public class FactType
+        public override int GetHashCode()
         {
-            public string Value { get; set; }
+            return 1;
         }
+    }
 
-        public class Calc1
+    public class FactToCalc1Rule : Rule
+    {
+        public override void Define()
         {
-            public string Key { get; set; }
-            public string Value { get; set; }
+            FactType o = null;
+
+            When()
+                .Match(() => o);
+
+            Filter()
+                .OnChange(() => o.Value);
+
+            Then()
+                .Yield(_ => new Calc1 {Key = o.Value});
         }
+    }
 
-        public class Calc2
+    public class Calc1ToCalc2Rule : Rule
+    {
+        public override void Define()
         {
-            public string Key { get; set; }
-            public string Value { get; set; }
+            Calc1 calc = null;
+
+            When()
+                .Match(() => calc);
+
+            Filter()
+                .OnChange(() => calc);
+
+            Then()
+                .Yield(_ => new Calc2{Key = calc.Key});
         }
+    }
 
-        public class Calc3 : IEquatable<Calc3>
+    public class Calc1Calc2ToCalc3Rule : Rule
+    {
+        public override void Define()
         {
-            public bool Equals(Calc3 other)
-            {
-                return true;
-            }
+            Calc1 calc1 = null;
+            Calc2 calc2 = null;
 
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((Calc3) obj);
-            }
+            When()
+                .Match(() => calc1)
+                .Match(() => calc2, c => c.Key.Equals(calc1.Key));
 
-            public override int GetHashCode()
-            {
-                return 1;
-            }
-        }
-
-        public class FactToCalc1Rule : Rule
-        {
-            public override void Define()
-            {
-                FactType o = null;
-
-                When()
-                    .Match(() => o);
-
-                Filter()
-                    .OnChange(() => o.Value);
-
-                Then()
-                    .Yield(_ => new Calc1 {Key = o.Value});
-            }
-        }
-
-        public class Calc1ToCalc2Rule : Rule
-        {
-            public override void Define()
-            {
-                Calc1 calc = null;
-
-                When()
-                    .Match(() => calc);
-
-                Filter()
-                    .OnChange(() => calc);
-
-                Then()
-                    .Yield(_ => new Calc2{Key = calc.Key});
-            }
-        }
-
-        public class Calc1Calc2ToCalc3Rule : Rule
-        {
-            public override void Define()
-            {
-                Calc1 calc1 = null;
-                Calc2 calc2 = null;
-
-                When()
-                    .Match(() => calc1)
-                    .Match(() => calc2, c => c.Key.Equals(calc1.Key));
-
-                Then()
-                    .Yield(_ => new Calc3());
-            }
+            Then()
+                .Yield(_ => new Calc3());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/FromQueryComplexReferenceTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/FromQueryComplexReferenceTest.cs
@@ -4,88 +4,87 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class FromQueryComplexReferenceTest : BaseRuleTestFixture
 {
-    public class FromQueryComplexReferenceTest : BaseRuleTestFixture
+    [Fact]
+    public void FromComplex_JoinedWithKeyAndFactsFiltered_FiresForEachGroup()
     {
-        [Fact]
-        public void FromComplex_JoinedWithKeyAndFactsFiltered_FiresForEachGroup()
+        // Arrange
+        var values = new[] {"a", "b", "b", "a"};
+        var keys = new[] {1, 1, 2, 2};
+        var facts = values.Zip(keys, (v, k) => new Fact {Key = k, Value = v});
+
+        var key = new Key {Value = 1};
+
+        Session.Insert(key);
+        Session.InsertAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void FromComplex_JoinedWithKeyAndFactsFiltered_NoMatches_DoesNotFire()
+    {
+        // Arrange
+        var values = new[] {"a", "b", "b", "a"};
+        var keys = new[] {1, 1, 2, 2};
+        var facts = values.Zip(keys, (v, k) => new Fact {Key = k, Value = v});
+
+        var key = new Key {Value = 3};
+
+        Session.Insert(key);
+        Session.InsertAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<FromQueryComplexReferenceRule>();
+    }
+
+    public class Fact
+    {
+        public int Key { get; set; }
+        public string Value { get; set; }
+    }
+
+    public class Key
+    {
+        public int Value { get; set; }
+    }
+
+    public class FromQueryComplexReferenceRule : Rule
+    {
+        public override void Define()
         {
-            // Arrange
-            var values = new[] {"a", "b", "b", "a"};
-            var keys = new[] {1, 1, 2, 2};
-            var facts = values.Zip(keys, (v, k) => new Fact {Key = k, Value = v});
+            IEnumerable<Fact> factsAll = null;
+            Key key = null;
+            IGrouping<string, Fact> factsFilteredGrouped = null;
 
-            var key = new Key {Value = 1};
+            When()
+                .Query(() => factsAll, q => q
+                    .Match<Fact>()
+                    .Collect()
+                    .Where(c => c.Any()))
+                .Match(() => key)
+                .Query(() => factsFilteredGrouped, q => q
+                    .From(() => factsAll.Where(f => f.Key == key.Value))
+                    .SelectMany(c => c)
+                    .GroupBy(f => f.Value));
 
-            Session.Insert(key);
-            Session.InsertAll(facts);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredTwice();
-        }
-
-        [Fact]
-        public void FromComplex_JoinedWithKeyAndFactsFiltered_NoMatches_DoesNotFire()
-        {
-            // Arrange
-            var values = new[] {"a", "b", "b", "a"};
-            var keys = new[] {1, 1, 2, 2};
-            var facts = values.Zip(keys, (v, k) => new Fact {Key = k, Value = v});
-
-            var key = new Key {Value = 3};
-
-            Session.Insert(key);
-            Session.InsertAll(facts);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertDidNotFire();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<FromQueryComplexReferenceRule>();
-        }
-
-        public class Fact
-        {
-            public int Key { get; set; }
-            public string Value { get; set; }
-        }
-
-        public class Key
-        {
-            public int Value { get; set; }
-        }
-
-        public class FromQueryComplexReferenceRule : Rule
-        {
-            public override void Define()
-            {
-                IEnumerable<Fact> factsAll = null;
-                Key key = null;
-                IGrouping<string, Fact> factsFilteredGrouped = null;
-
-                When()
-                    .Query(() => factsAll, q => q
-                        .Match<Fact>()
-                        .Collect()
-                        .Where(c => c.Any()))
-                    .Match(() => key)
-                    .Query(() => factsFilteredGrouped, q => q
-                        .From(() => factsAll.Where(f => f.Key == key.Value))
-                        .SelectMany(c => c)
-                        .GroupBy(f => f.Value));
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/FromQueryDoubleReferenceTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/FromQueryDoubleReferenceTest.cs
@@ -4,90 +4,89 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class FromQueryDoubleReferenceTest : BaseRuleTestFixture
 {
-    public class FromQueryDoubleReferenceTest : BaseRuleTestFixture
+    [Fact]
+    public void FromDoubleReference_SplitByKey_FiresCorrectNumberOfTimesWithCorrectFactCounts()
     {
-        [Fact]
-        public void FromDoubleReference_SplitByKey_FiresCorrectNumberOfTimesWithCorrectFactCounts()
+        // Arrange
+        var values = new[] {"a", "a", "b", "b", "c", "c"};
+        var keys = new[] {1, 2, 2, 1, 2, 3};
+        var facts = values.Zip(keys, (v, k) => new Fact {Key = k, Value = v})
+            .ToArray();
+
+        Session.InsertAll(facts);
+
+        // factsAll = 1a 2a 2b 1b 2c 3c
+        // factsOne = 1a 1b
+        // factsTwo = 2a 2b 2c
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFacts<IEnumerable<Fact>>().ToArray();
+        var factsAllExpected = facts;
+        var factsOneExpected = facts.Where(f => f.Key == 1).ToArray();
+        var factsTwoExpected = facts.Where(f => f.Key == 2).ToArray();
+        var factsOneTwoExpected = factsOneExpected.Concat(factsTwoExpected).ToArray();
+        var factsAllActual = firedFacts.Single(f => f.Count() == 6).ToArray();
+        var factsOneActual = firedFacts.Single(f => f.Count() == 2).ToArray();
+        var factsTwoActual = firedFacts.Single(f => f.Count() == 3).ToArray();
+        var factsOneTwoActual = firedFacts.Single(f => f.Count() == 5).ToArray();
+
+        Assert.Equal(factsAllExpected, factsAllActual);
+        Assert.Equal(factsOneExpected, factsOneActual);
+        Assert.Equal(factsTwoExpected, factsTwoActual);
+        Assert.Equal(factsOneTwoExpected, factsOneTwoActual);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<FromQueryDoubleReferenceRule>();
+    }
+
+    public class Fact
+    {
+        public int Key { get; set; }
+        public string Value { get; set; }
+    }
+
+    public class FromQueryDoubleReferenceRule : Rule
+    {
+        public override void Define()
         {
-            // Arrange
-            var values = new[] {"a", "a", "b", "b", "c", "c"};
-            var keys = new[] {1, 2, 2, 1, 2, 3};
-            var facts = values.Zip(keys, (v, k) => new Fact {Key = k, Value = v})
-                .ToArray();
+            IEnumerable<Fact> factsAll = null;
+            IEnumerable<Fact> factsOne = null;
+            IEnumerable<Fact> factsTwo = null;
+            IEnumerable<Fact> factsOneTwo = null;
 
-            Session.InsertAll(facts);
+            When()
+                .Query(() => factsAll, q => q
+                    .Match<Fact>()
+                    .Collect()
+                    .Where(c => c.Any()))
+                .Query(() => factsOne, q => q
+                    .From(() => factsAll)
+                    .SelectMany(f => f)
+                    .Where(f => f.Key == 1)
+                    .Collect()
+                    .Where(c => c.Any()))
+                .Query(() => factsTwo, q => q
+                    .From(() => factsAll)
+                    .SelectMany(c => c)
+                    .Where(f => f.Key == 2)
+                    .Collect()
+                    .Where(c => c.Any()))
+                .Query(() => factsOneTwo, q => q
+                    .From(() => factsOne.Concat(factsTwo)));
 
-            // factsAll = 1a 2a 2b 1b 2c 3c
-            // factsOne = 1a 1b
-            // factsTwo = 2a 2b 2c
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFacts<IEnumerable<Fact>>().ToArray();
-            var factsAllExpected = facts;
-            var factsOneExpected = facts.Where(f => f.Key == 1).ToArray();
-            var factsTwoExpected = facts.Where(f => f.Key == 2).ToArray();
-            var factsOneTwoExpected = factsOneExpected.Concat(factsTwoExpected).ToArray();
-            var factsAllActual = firedFacts.Single(f => f.Count() == 6).ToArray();
-            var factsOneActual = firedFacts.Single(f => f.Count() == 2).ToArray();
-            var factsTwoActual = firedFacts.Single(f => f.Count() == 3).ToArray();
-            var factsOneTwoActual = firedFacts.Single(f => f.Count() == 5).ToArray();
-
-            Assert.Equal(factsAllExpected, factsAllActual);
-            Assert.Equal(factsOneExpected, factsOneActual);
-            Assert.Equal(factsTwoExpected, factsTwoActual);
-            Assert.Equal(factsOneTwoExpected, factsOneTwoActual);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<FromQueryDoubleReferenceRule>();
-        }
-
-        public class Fact
-        {
-            public int Key { get; set; }
-            public string Value { get; set; }
-        }
-
-        public class FromQueryDoubleReferenceRule : Rule
-        {
-            public override void Define()
-            {
-                IEnumerable<Fact> factsAll = null;
-                IEnumerable<Fact> factsOne = null;
-                IEnumerable<Fact> factsTwo = null;
-                IEnumerable<Fact> factsOneTwo = null;
-
-                When()
-                    .Query(() => factsAll, q => q
-                        .Match<Fact>()
-                        .Collect()
-                        .Where(c => c.Any()))
-                    .Query(() => factsOne, q => q
-                        .From(() => factsAll)
-                        .SelectMany(f => f)
-                        .Where(f => f.Key == 1)
-                        .Collect()
-                        .Where(c => c.Any()))
-                    .Query(() => factsTwo, q => q
-                        .From(() => factsAll)
-                        .SelectMany(c => c)
-                        .Where(f => f.Key == 2)
-                        .Collect()
-                        .Where(c => c.Any()))
-                    .Query(() => factsOneTwo, q => q
-                        .From(() => factsOne.Concat(factsTwo)));
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/FromQuerySingleReferenceTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/FromQuerySingleReferenceTest.cs
@@ -4,100 +4,99 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class FromQuerySingleReferenceTest : BaseRuleTestFixture
 {
-    public class FromQuerySingleReferenceTest : BaseRuleTestFixture
+    [Fact]
+    public void From_MultipleKeys_ShouldFireOnceForEachGroup()
     {
-        [Fact]
-        public void From_MultipleKeys_ShouldFireOnceForEachGroup()
+        // Arrange
+        var keys = new[] {"K1", "K2", "K2", "K1"};
+        var facts = keys.Select(k => new Fact {Value = k})
+            .ToArray();
+
+        Session.InsertAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void From_SingleKey_FiresOnce()
+    {
+        // Arrange
+        var keys = new[] {"K1", "K1", "K1", "K1"};
+        var facts = keys.Select(k => new Fact {Value = k})
+            .ToArray();
+
+        Session.InsertAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void From_HandlesRetracts_FiresThenDoesNotFire()
+    {
+        // Arrange
+        var keys = new[] {"K1", "K2", "K2", "K1"};
+        var facts = keys.Select(k => new Fact {Value = k})
+            .ToArray();
+
+        Session.InsertAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredTwice();
+
+        // Arrange
+        Session.RetractAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredTwice();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<FromQuerySingleReferenceRule>();
+    }
+
+    public class Fact
+    {
+        public string Value { get; set; }
+    }
+
+    public class FromQuerySingleReferenceRule : Rule
+    {
+        public override void Define()
         {
-            // Arrange
-            var keys = new[] {"K1", "K2", "K2", "K1"};
-            var facts = keys.Select(k => new Fact {Value = k})
-                .ToArray();
+            IEnumerable<Fact> factsAll = null;
+            IGrouping<string, Fact> factsGrouped = null;
 
-            Session.InsertAll(facts);
+            When()
+                .Query(() => factsAll, q => q
+                    .Match<Fact>()
+                    .Collect()
+                    .Where(c => c.Any()))
+                .Query(() => factsGrouped, q => q
+                    .From(() => factsAll)
+                    .SelectMany(c => c)
+                    .GroupBy(f => f.Value));
 
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredTwice();
-        }
-
-        [Fact]
-        public void From_SingleKey_FiresOnce()
-        {
-            // Arrange
-            var keys = new[] {"K1", "K1", "K1", "K1"};
-            var facts = keys.Select(k => new Fact {Value = k})
-                .ToArray();
-
-            Session.InsertAll(facts);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void From_HandlesRetracts_FiresThenDoesNotFire()
-        {
-            // Arrange
-            var keys = new[] {"K1", "K2", "K2", "K1"};
-            var facts = keys.Select(k => new Fact {Value = k})
-                .ToArray();
-
-            Session.InsertAll(facts);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredTwice();
-
-            // Arrange
-            Session.RetractAll(facts);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredTwice();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<FromQuerySingleReferenceRule>();
-        }
-
-        public class Fact
-        {
-            public string Value { get; set; }
-        }
-
-        public class FromQuerySingleReferenceRule : Rule
-        {
-            public override void Define()
-            {
-                IEnumerable<Fact> factsAll = null;
-                IGrouping<string, Fact> factsGrouped = null;
-
-                When()
-                    .Query(() => factsAll, q => q
-                        .Match<Fact>()
-                        .Collect()
-                        .Where(c => c.Any()))
-                    .Query(() => factsGrouped, q => q
-                        .From(() => factsAll)
-                        .SelectMany(c => c)
-                        .GroupBy(f => f.Value));
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/GroupJoinSeveralQueriesTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/GroupJoinSeveralQueriesTest.cs
@@ -4,179 +4,178 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class GroupJoinSeveralQueriesTest : BaseRuleTestFixture
 {
-    public class GroupJoinSeveralQueriesTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_TwoMatchingFactsOfOneKindAndJoinedGroups_FiresTwice()
     {
-        [Fact]
-        public void Fire_TwoMatchingFactsOfOneKindAndJoinedGroups_FiresTwice()
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 11", JoinProperty = "Group 1"};
+        var fact12 = new FactType1 { TestProperty = "Valid Value 12", JoinProperty = "Group 2"};
+        var fact21 = new FactType2(1) { TestProperty = "Value 1" };
+        var fact31 = new FactType3() { TestProperty = "Valid Value 31", GroupProperty = "Group 1"};
+        var fact32 = new FactType3() { TestProperty = "Valid Value 32", GroupProperty = "Group 2"};
+
+        Session.Insert(fact11);
+        Session.Insert(fact12);
+        Session.Insert(fact21);
+        Session.Insert(fact31);
+        Session.Insert(fact32);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(2, fact11.EvalCount);
+    }
+
+    [Fact]
+    public void Fire_MatchingSetFactOfFirstKindUpdated_FiresOnceThenFiresOnceAgain()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 11", JoinProperty = "Group 1"};
+        var fact21 = new FactType2(1) { TestProperty = "Value 1" };
+        var fact31 = new FactType3() { TestProperty = "Valid Value 31", GroupProperty = "Group 1"};
+
+        Session.Insert(fact11);
+        Session.Insert(fact21);
+        Session.Insert(fact31);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredOnce();
+        Assert.Equal(1, fact11.EvalCount);
+
+        //Act - 2
+        Session.Update(fact11);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTwice();
+        Assert.Equal(2, fact11.EvalCount);
+    }
+
+    [Fact]
+    public void Fire_MatchingSetFactOfSecondKindUpdated_FiresOnceThenFiresOnceAgain()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 11", JoinProperty = "Group 1"};
+        var fact21 = new FactType2(1) { TestProperty = "Value 1" };
+        var fact31 = new FactType3() { TestProperty = "Valid Value 31", GroupProperty = "Group 1"};
+
+        Session.Insert(fact11);
+        Session.Insert(fact21);
+        Session.Insert(fact31);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredOnce();
+        Assert.Equal(1, fact11.EvalCount);
+
+        //Act - 2
+        Session.Update(fact21);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTwice();
+        Assert.Equal(2, fact11.EvalCount);
+    }
+
+    [Fact]
+    public void Fire_MatchingSetFactOfThirdKindUpdated_FiresOnceThenFiresOnceAgain()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 11", JoinProperty = "Group 1"};
+        var fact21 = new FactType2(1) { TestProperty = "Value 1" };
+        var fact31 = new FactType3() { TestProperty = "Valid Value 31", GroupProperty = "Group 1"};
+
+        Session.Insert(fact11);
+        Session.Insert(fact21);
+        Session.Insert(fact31);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredOnce();
+        Assert.Equal(1, fact11.EvalCount);
+
+        //Act - 2
+        Session.Update(fact31);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTwice();
+        Assert.Equal(2, fact11.EvalCount);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+        public int EvalCount { get; set; }
+    }
+
+    public class FactType2
+    {
+        public FactType2(int id)
         {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 11", JoinProperty = "Group 1"};
-            var fact12 = new FactType1 { TestProperty = "Valid Value 12", JoinProperty = "Group 2"};
-            var fact21 = new FactType2(1) { TestProperty = "Value 1" };
-            var fact31 = new FactType3() { TestProperty = "Valid Value 31", GroupProperty = "Group 1"};
-            var fact32 = new FactType3() { TestProperty = "Valid Value 32", GroupProperty = "Group 2"};
-
-            Session.Insert(fact11);
-            Session.Insert(fact12);
-            Session.Insert(fact21);
-            Session.Insert(fact31);
-            Session.Insert(fact32);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(2, fact11.EvalCount);
+            Id = id;
         }
 
-        [Fact]
-        public void Fire_MatchingSetFactOfFirstKindUpdated_FiresOnceThenFiresOnceAgain()
+        public int Id { get; }
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType3
+    {
+        public string TestProperty { get; set; }
+        public string GroupProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 11", JoinProperty = "Group 1"};
-            var fact21 = new FactType2(1) { TestProperty = "Value 1" };
-            var fact31 = new FactType3() { TestProperty = "Valid Value 31", GroupProperty = "Group 1"};
+            FactType1 fact1 = null;
+            FactType2 fact21 = null;
+            FactType2 fact22 = null;
+            IEnumerable<FactType3> group = null;
 
-            Session.Insert(fact11);
-            Session.Insert(fact21);
-            Session.Insert(fact31);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredOnce();
-            Assert.Equal(1, fact11.EvalCount);
-
-            //Act - 2
-            Session.Update(fact11);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTwice();
-            Assert.Equal(2, fact11.EvalCount);
+            When()
+                .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                .Query(() => fact21, q => q
+                    .Match<FactType2>(f => f.TestProperty == "Value 1")
+                    .Collect()
+                    .Select(x => x.FirstOrDefault() ?? new FactType2(0) {TestProperty = "Value 1"}))
+                .Query(() => fact22, q => q
+                    .Match<FactType2>(f => f.TestProperty == "Value 2")
+                    .Collect()
+                    .Select(x => x.FirstOrDefault() ?? new FactType2(0) {TestProperty = "Value 2"}))
+                .Query(() => group, q => q
+                    .Match<FactType3>(f => f.TestProperty.StartsWith("Valid"))
+                    .GroupBy(x => x.GroupProperty)
+                    .Where(g => ValidGroup(fact1, fact21, fact22, g)));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
 
-        [Fact]
-        public void Fire_MatchingSetFactOfSecondKindUpdated_FiresOnceThenFiresOnceAgain()
+        private bool ValidGroup(FactType1 fact1, FactType2 fact21, FactType2 fact22, IGrouping<string, FactType3> group)
         {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 11", JoinProperty = "Group 1"};
-            var fact21 = new FactType2(1) { TestProperty = "Value 1" };
-            var fact31 = new FactType3() { TestProperty = "Valid Value 31", GroupProperty = "Group 1"};
-
-            Session.Insert(fact11);
-            Session.Insert(fact21);
-            Session.Insert(fact31);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredOnce();
-            Assert.Equal(1, fact11.EvalCount);
-
-            //Act - 2
-            Session.Update(fact21);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTwice();
-            Assert.Equal(2, fact11.EvalCount);
-        }
-
-        [Fact]
-        public void Fire_MatchingSetFactOfThirdKindUpdated_FiresOnceThenFiresOnceAgain()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 11", JoinProperty = "Group 1"};
-            var fact21 = new FactType2(1) { TestProperty = "Value 1" };
-            var fact31 = new FactType3() { TestProperty = "Valid Value 31", GroupProperty = "Group 1"};
-
-            Session.Insert(fact11);
-            Session.Insert(fact21);
-            Session.Insert(fact31);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredOnce();
-            Assert.Equal(1, fact11.EvalCount);
-
-            //Act - 2
-            Session.Update(fact31);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTwice();
-            Assert.Equal(2, fact11.EvalCount);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-            public int EvalCount { get; set; }
-        }
-
-        public class FactType2
-        {
-            public FactType2(int id)
-            {
-                Id = id;
-            }
-
-            public int Id { get; }
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType3
-        {
-            public string TestProperty { get; set; }
-            public string GroupProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-                FactType2 fact21 = null;
-                FactType2 fact22 = null;
-                IEnumerable<FactType3> group = null;
-
-                When()
-                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                    .Query(() => fact21, q => q
-                        .Match<FactType2>(f => f.TestProperty == "Value 1")
-                        .Collect()
-                        .Select(x => x.FirstOrDefault() ?? new FactType2(0) {TestProperty = "Value 1"}))
-                    .Query(() => fact22, q => q
-                        .Match<FactType2>(f => f.TestProperty == "Value 2")
-                        .Collect()
-                        .Select(x => x.FirstOrDefault() ?? new FactType2(0) {TestProperty = "Value 2"}))
-                    .Query(() => group, q => q
-                        .Match<FactType3>(f => f.TestProperty.StartsWith("Valid"))
-                        .GroupBy(x => x.GroupProperty)
-                        .Where(g => ValidGroup(fact1, fact21, fact22, g)));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-
-            private bool ValidGroup(FactType1 fact1, FactType2 fact21, FactType2 fact22, IGrouping<string, FactType3> group)
-            {
-                fact1.EvalCount++;
-                return group.Key == fact1.JoinProperty;
-            }
+            fact1.EvalCount++;
+            return group.Key == fact1.JoinProperty;
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/GroupWithGroupFilterRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/GroupWithGroupFilterRuleTest.cs
@@ -3,86 +3,85 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class GroupWithGroupFilterRuleTest : BaseRuleTestFixture
 {
-    public class GroupWithGroupFilterRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_TwoMatchingGroups_FiresTwice()
     {
-        [Fact]
-        public void Fire_TwoMatchingGroups_FiresTwice()
+        //Arrange
+        var fact11 = new FactType {TestProperty = "Valid Test Property 1", GroupProperty = "GP1", GroupTestProperty = "Good"};
+        var fact12 = new FactType {TestProperty = "Valid Test Property 1", GroupProperty = "GP1", GroupTestProperty = "Good" };
+        var fact13 = new FactType {TestProperty = "Valid Test Property 1", GroupProperty = "GP2", GroupTestProperty = "Bad" };
+        var fact14 = new FactType {TestProperty = "Valid Test Property 2", GroupProperty = "GP2", GroupTestProperty = "Good" };
+
+        var facts = new object[] {fact11, fact12, fact13, fact14};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void Fire_MakeAllFactsInelligible_DoesNotFire()
+    {
+        //Arrange
+        var fact11 = new FactType {TestProperty = "Valid Test Property 1", GroupProperty = "GP1", GroupTestProperty = "Good"};
+        var fact12 = new FactType {TestProperty = "Valid Test Property 1", GroupProperty = "GP1", GroupTestProperty = "Good" };
+        var fact13 = new FactType {TestProperty = "Valid Test Property 1", GroupProperty = "GP2", GroupTestProperty = "Bad" };
+        var fact14 = new FactType {TestProperty = "Valid Test Property 2", GroupProperty = "GP2", GroupTestProperty = "Good" };
+
+        var facts = new object[] {fact11, fact12, fact13, fact14};
+        Session.InsertAll(facts);
+
+        fact11.TestProperty = "Bad Test Poroperty";
+        fact12.TestProperty = "Bad Test Poroperty";
+        fact13.TestProperty = "Bad Test Poroperty";
+        fact14.TestProperty = "Bad Test Poroperty";
+        var factsToUpdate = new object[] { fact11, fact12, fact13, fact14 };
+        Session.UpdateAll(factsToUpdate);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+        public string GroupTestProperty { get; set; }
+        public string GroupProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact11 = new FactType {TestProperty = "Valid Test Property 1", GroupProperty = "GP1", GroupTestProperty = "Good"};
-            var fact12 = new FactType {TestProperty = "Valid Test Property 1", GroupProperty = "GP1", GroupTestProperty = "Good" };
-            var fact13 = new FactType {TestProperty = "Valid Test Property 1", GroupProperty = "GP2", GroupTestProperty = "Bad" };
-            var fact14 = new FactType {TestProperty = "Valid Test Property 2", GroupProperty = "GP2", GroupTestProperty = "Good" };
+            IGrouping<string, FactType> group = null;
 
-            var facts = new object[] {fact11, fact12, fact13, fact14};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
+            When()
+                .Query(() => group, x => x
+                    .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
+                    .GroupBy(f => f.GroupProperty)
+                    .Where(z => HasCorrectValue(z)));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
 
-        [Fact]
-        public void Fire_MakeAllFactsInelligible_DoesNotFire()
+        private static bool HasCorrectValue(IGrouping<string, FactType> group)
         {
-            //Arrange
-            var fact11 = new FactType {TestProperty = "Valid Test Property 1", GroupProperty = "GP1", GroupTestProperty = "Good"};
-            var fact12 = new FactType {TestProperty = "Valid Test Property 1", GroupProperty = "GP1", GroupTestProperty = "Good" };
-            var fact13 = new FactType {TestProperty = "Valid Test Property 1", GroupProperty = "GP2", GroupTestProperty = "Bad" };
-            var fact14 = new FactType {TestProperty = "Valid Test Property 2", GroupProperty = "GP2", GroupTestProperty = "Good" };
-
-            var facts = new object[] {fact11, fact12, fact13, fact14};
-            Session.InsertAll(facts);
-
-            fact11.TestProperty = "Bad Test Poroperty";
-            fact12.TestProperty = "Bad Test Poroperty";
-            fact13.TestProperty = "Bad Test Poroperty";
-            fact14.TestProperty = "Bad Test Poroperty";
-            var factsToUpdate = new object[] { fact11, fact12, fact13, fact14 };
-            Session.UpdateAll(factsToUpdate);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-            public string GroupTestProperty { get; set; }
-            public string GroupProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                IGrouping<string, FactType> group = null;
-
-                When()
-                    .Query(() => group, x => x
-                        .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
-                        .GroupBy(f => f.GroupProperty)
-                        .Where(z => HasCorrectValue(z)));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-
-            private static bool HasCorrectValue(IGrouping<string, FactType> group)
-            {
-                return group.Any(x => x.GroupTestProperty.Contains("Good"));
-            }
+            return group.Any(x => x.GroupTestProperty.Contains("Good"));
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/HaltRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/HaltRuleTest.cs
@@ -2,64 +2,63 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class HaltRuleTest : BaseRuleTestFixture
 {
-    public class HaltRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_TwoMatchingFacts_FiresOnceAndHalts()
     {
-        [Fact]
-        public void Fire_TwoMatchingFacts_FiresOnceAndHalts()
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+    
+    [Fact]
+    public void Fire_TwoMatchingFactsFireCalledTwice_FiresOnceThenHaltsThenResumesAndFiresAgain()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
+            FactType fact = null;
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-        
-        [Fact]
-        public void Fire_TwoMatchingFactsFireCalledTwice_FiresOnceThenHaltsThenResumesAndFiresAgain()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.Halt());
-            }
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.Halt());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/IdentityMatchRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/IdentityMatchRuleTest.cs
@@ -2,106 +2,105 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class IdentityMatchRuleTest : BaseRuleTestFixture
 {
-    public class IdentityMatchRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchingFact_FiresOnce()
     {
-        [Fact]
-        public void Fire_MatchingFact_FiresOnce()
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid value"};
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFacts_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid value"};
+        var fact2 = new FactType {TestProperty = "Valid value"};
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactInsertedAndRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid value"};
+        Session.Insert(fact);
+        Session.Retract(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactInsertedAndUpdatedToInvalid_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid value"};
+        Session.Insert(fact);
+        fact.TestProperty = "Invalid value";
+        Session.Update(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_NoMatchingFact_DoesNotFire()
+    {
+        //Arrange
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid value"};
-            Session.Insert(fact);
+            FactType fact1 = null;
+            FactType fact2 = null;
 
-            //Act
-            Session.Fire();
+            When()
+                .Match<FactType>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                .Match<FactType>(() => fact2, f => ReferenceEquals(f, fact1));
 
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFacts_FiresTwice()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid value"};
-            var fact2 = new FactType {TestProperty = "Valid value"};
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactInsertedAndRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid value"};
-            Session.Insert(fact);
-            Session.Retract(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactInsertedAndUpdatedToInvalid_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid value"};
-            Session.Insert(fact);
-            fact.TestProperty = "Invalid value";
-            Session.Update(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_NoMatchingFact_DoesNotFire()
-        {
-            //Arrange
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact1 = null;
-                FactType fact2 = null;
-
-                When()
-                    .Match<FactType>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                    .Match<FactType>(() => fact2, f => ReferenceEquals(f, fact1));
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/JoinFollowedByGroupByOnDifferentKeyTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/JoinFollowedByGroupByOnDifferentKeyTest.cs
@@ -3,215 +3,214 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class JoinFollowedByGroupByOnDifferentKeyTest : BaseRuleTestFixture
 {
-    public class JoinFollowedByGroupByOnDifferentKeyTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_BulkInsertForMultipleTypes_InsertsOnly_FiresThreeTimesWithCorrectCounts()
     {
-        [Fact]
-        public void Fire_BulkInsertForMultipleTypes_InsertsOnly_FiresThreeTimesWithCorrectCounts()
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Join 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 2", JoinProperty = "Join 2" };
+
+        var fact21 = new FactType2 { TestProperty = "Valid Group1", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
+        var fact22 = new FactType2 { TestProperty = "Valid Group2", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
+        var fact23 = new FactType2 { TestProperty = "Valid Group3", JoinProperty = fact11.JoinProperty, GroupProperty = "Group2" };
+
+        var fact24 = new FactType2 { TestProperty = "Valid Group4", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
+        var fact25 = new FactType2 { TestProperty = "Valid Group5", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
+        var fact26 = new FactType2 { TestProperty = "Valid Group6", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
+
+        var facts = new object[] { fact11, fact12, fact21, fact22, fact23, fact24, fact25, fact26 };
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTimes(3);
+        var firedFacts = new[]
         {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Join 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 2", JoinProperty = "Join 2" };
+            GetFiredFact<IGrouping<string, FactType2>>(0),
+            GetFiredFact<IGrouping<string, FactType2>>(1),
+            GetFiredFact<IGrouping<string, FactType2>>(2)
+        };
 
-            var fact21 = new FactType2 { TestProperty = "Valid Group1", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
-            var fact22 = new FactType2 { TestProperty = "Valid Group2", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
-            var fact23 = new FactType2 { TestProperty = "Valid Group3", JoinProperty = fact11.JoinProperty, GroupProperty = "Group2" };
+        var correctNumberofFactsPerGroup = firedFacts.Count(x => x.Count() == 1) == 1 &&
+                                           firedFacts.Count(x => x.Count() == 2) == 1 &&
+                                           firedFacts.Count(x => x.Count() == 3) == 1;
+        Assert.True(correctNumberofFactsPerGroup);
+    }
 
-            var fact24 = new FactType2 { TestProperty = "Valid Group4", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
-            var fact25 = new FactType2 { TestProperty = "Valid Group5", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
-            var fact26 = new FactType2 { TestProperty = "Valid Group6", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
+    [Fact]
+    public void Fire_BulkInsertForMultipleTypes_WithUpdates_FiresThreeTimesWithCorrectCounts()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Join 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 2", JoinProperty = "Join 2" };
 
-            var facts = new object[] { fact11, fact12, fact21, fact22, fact23, fact24, fact25, fact26 };
-            Session.InsertAll(facts);
+        var fact21 = new FactType2 { TestProperty = "Valid Group1", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
+        var fact22 = new FactType2 { TestProperty = "Valid Group2", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
+        var fact23 = new FactType2 { TestProperty = "Valid Group3", JoinProperty = fact11.JoinProperty, GroupProperty = "Group2" };
 
-            //Act
-            Session.Fire();
+        var fact24 = new FactType2 { TestProperty = "Valid Group4", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
+        var fact25 = new FactType2 { TestProperty = "Valid Group5", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
+        var fact26 = new FactType2 { TestProperty = "Valid Group6", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
 
-            //Assert
-            AssertFiredTimes(3);
-            var firedFacts = new[]
-            {
-                GetFiredFact<IGrouping<string, FactType2>>(0),
-                GetFiredFact<IGrouping<string, FactType2>>(1),
-                GetFiredFact<IGrouping<string, FactType2>>(2)
-            };
+        var facts = new object[] { fact11, fact12, fact21, fact22, fact23, fact24, fact25, fact26 };
+        Session.InsertAll(facts);
 
-            var correctNumberofFactsPerGroup = firedFacts.Count(x => x.Count() == 1) == 1 &&
-                                               firedFacts.Count(x => x.Count() == 2) == 1 &&
-                                               firedFacts.Count(x => x.Count() == 3) == 1;
-            Assert.True(correctNumberofFactsPerGroup);
-        }
+        fact21.GroupProperty = "Group3";
+        fact22.GroupProperty = "Group3";
+        fact23.GroupProperty = "Group3";
+        var factsForUpdate = new[] { fact21, fact22, fact23 };
+        Session.UpdateAll(factsForUpdate);
 
-        [Fact]
-        public void Fire_BulkInsertForMultipleTypes_WithUpdates_FiresThreeTimesWithCorrectCounts()
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTimes(2);
+        var firedFacts = new[]
         {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Join 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 2", JoinProperty = "Join 2" };
+            GetFiredFact<IGrouping<string, FactType2>>(0),
+            GetFiredFact<IGrouping<string, FactType2>>(1)
+        };
 
-            var fact21 = new FactType2 { TestProperty = "Valid Group1", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
-            var fact22 = new FactType2 { TestProperty = "Valid Group2", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
-            var fact23 = new FactType2 { TestProperty = "Valid Group3", JoinProperty = fact11.JoinProperty, GroupProperty = "Group2" };
+        var correctNumberofFactsPerGroup = firedFacts.Count(x => x.Count() == 3) == 2;
+        Assert.True(correctNumberofFactsPerGroup);
+    }
 
-            var fact24 = new FactType2 { TestProperty = "Valid Group4", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
-            var fact25 = new FactType2 { TestProperty = "Valid Group5", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
-            var fact26 = new FactType2 { TestProperty = "Valid Group6", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
+    [Fact]
+    public void Fire_BulkInsertForMultipleTypes_WithRetracts_FiresThreeTimesWithCorrectCounts()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Join 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 2", JoinProperty = "Join 2" };
 
-            var facts = new object[] { fact11, fact12, fact21, fact22, fact23, fact24, fact25, fact26 };
-            Session.InsertAll(facts);
+        var fact21 = new FactType2 { TestProperty = "Valid Group1", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
+        var fact22 = new FactType2 { TestProperty = "Valid Group2", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
+        var fact23 = new FactType2 { TestProperty = "Valid Group3", JoinProperty = fact11.JoinProperty, GroupProperty = "Group2" };
 
-            fact21.GroupProperty = "Group3";
-            fact22.GroupProperty = "Group3";
-            fact23.GroupProperty = "Group3";
-            var factsForUpdate = new[] { fact21, fact22, fact23 };
-            Session.UpdateAll(factsForUpdate);
+        var fact24 = new FactType2 { TestProperty = "Valid Group4", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
+        var fact25 = new FactType2 { TestProperty = "Valid Group5", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
+        var fact26 = new FactType2 { TestProperty = "Valid Group6", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
 
-            //Act
-            Session.Fire();
+        var facts = new object[] { fact11, fact12, fact21, fact22, fact23, fact24, fact25, fact26 };
+        Session.InsertAll(facts);
+        
+        var factsForRetract = new[] { fact21, fact22, fact23 };
+        Session.RetractAll(factsForRetract);
 
-            //Assert
-            AssertFiredTimes(2);
-            var firedFacts = new[]
-            {
-                GetFiredFact<IGrouping<string, FactType2>>(0),
-                GetFiredFact<IGrouping<string, FactType2>>(1)
-            };
+        //Act
+        Session.Fire();
 
-            var correctNumberofFactsPerGroup = firedFacts.Count(x => x.Count() == 3) == 2;
-            Assert.True(correctNumberofFactsPerGroup);
-        }
-
-        [Fact]
-        public void Fire_BulkInsertForMultipleTypes_WithRetracts_FiresThreeTimesWithCorrectCounts()
+        //Assert
+        AssertFiredTimes(1);
+        var firedFacts = new[]
         {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Join 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 2", JoinProperty = "Join 2" };
+            GetFiredFact<IGrouping<string, FactType2>>(0)
+        };
 
-            var fact21 = new FactType2 { TestProperty = "Valid Group1", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
-            var fact22 = new FactType2 { TestProperty = "Valid Group2", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
-            var fact23 = new FactType2 { TestProperty = "Valid Group3", JoinProperty = fact11.JoinProperty, GroupProperty = "Group2" };
+        var correctNumberofFactsPerGroup = firedFacts.Count(x => x.Count() == 3) == 1;
+        Assert.True(correctNumberofFactsPerGroup);
+    }
 
-            var fact24 = new FactType2 { TestProperty = "Valid Group4", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
-            var fact25 = new FactType2 { TestProperty = "Valid Group5", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
-            var fact26 = new FactType2 { TestProperty = "Valid Group6", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
+    [Fact]
+    public void Fire_TwoMatchingSetsFactOfFirstKindUpdated_FiresTwiceThenFiresOnce()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Join 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 2", JoinProperty = "Join 2" };
 
-            var facts = new object[] { fact11, fact12, fact21, fact22, fact23, fact24, fact25, fact26 };
-            Session.InsertAll(facts);
-            
-            var factsForRetract = new[] { fact21, fact22, fact23 };
-            Session.RetractAll(factsForRetract);
+        var fact61 = new FactType2 { TestProperty = "Valid Group1", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
+        var fact62 = new FactType2 { TestProperty = "Valid Group2", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
 
-            //Act
-            Session.Fire();
+        var fact63 = new FactType2 { TestProperty = "Valid Group3", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
+        var fact64 = new FactType2 { TestProperty = "Valid Group4", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
 
-            //Assert
-            AssertFiredTimes(1);
-            var firedFacts = new[]
-            {
-                GetFiredFact<IGrouping<string, FactType2>>(0)
-            };
+        var facts = new object[] { fact11, fact12, fact61, fact62, fact63, fact64 };
+        Session.InsertAll(facts);
+        
+        //Act - 1
+        Session.Fire();
 
-            var correctNumberofFactsPerGroup = firedFacts.Count(x => x.Count() == 3) == 1;
-            Assert.True(correctNumberofFactsPerGroup);
-        }
+        //Assert - 1
+        AssertFiredTimes(2);
 
-        [Fact]
-        public void Fire_TwoMatchingSetsFactOfFirstKindUpdated_FiresTwiceThenFiresOnce()
+        //Act - 2
+        Session.Update(fact11);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTimes(3);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingSetsFactOfSecondKindUpdated_FiresTwiceThenFiresOnce()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Join 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 2", JoinProperty = "Join 2" };
+
+        var fact61 = new FactType2 { TestProperty = "Valid Group1", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
+        var fact62 = new FactType2 { TestProperty = "Valid Group2", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
+
+        var fact63 = new FactType2 { TestProperty = "Valid Group3", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
+        var fact64 = new FactType2 { TestProperty = "Valid Group4", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
+
+        var facts = new object[] { fact11, fact12, fact61, fact62, fact63, fact64 };
+        Session.InsertAll(facts);
+        
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredTimes(2);
+
+        //Act - 2
+        Session.Update(fact61);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTimes(3);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+        public string GroupProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Join 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 2", JoinProperty = "Join 2" };
+            FactType1 fact = null;
+            IGrouping<string, FactType2> group = null;
 
-            var fact61 = new FactType2 { TestProperty = "Valid Group1", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
-            var fact62 = new FactType2 { TestProperty = "Valid Group2", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
-
-            var fact63 = new FactType2 { TestProperty = "Valid Group3", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
-            var fact64 = new FactType2 { TestProperty = "Valid Group4", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
-
-            var facts = new object[] { fact11, fact12, fact61, fact62, fact63, fact64 };
-            Session.InsertAll(facts);
-            
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredTimes(2);
-
-            //Act - 2
-            Session.Update(fact11);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTimes(3);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingSetsFactOfSecondKindUpdated_FiresTwiceThenFiresOnce()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Join 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 2", JoinProperty = "Join 2" };
-
-            var fact61 = new FactType2 { TestProperty = "Valid Group1", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
-            var fact62 = new FactType2 { TestProperty = "Valid Group2", JoinProperty = fact11.JoinProperty, GroupProperty = "Group1" };
-
-            var fact63 = new FactType2 { TestProperty = "Valid Group3", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
-            var fact64 = new FactType2 { TestProperty = "Valid Group4", JoinProperty = fact12.JoinProperty, GroupProperty = "Group2" };
-
-            var facts = new object[] { fact11, fact12, fact61, fact62, fact63, fact64 };
-            Session.InsertAll(facts);
-            
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredTimes(2);
-
-            //Act - 2
-            Session.Update(fact61);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTimes(3);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-            public string GroupProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact = null;
-                IGrouping<string, FactType2> group = null;
-
-                When()
-                    .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
-                    .Query(() => group, x => x
-                        .Match<FactType2>(
-                            f => f.TestProperty.StartsWith("Valid"),
-                            f => f.JoinProperty == fact.JoinProperty)
-                        .GroupBy(f => f.GroupProperty));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
+                .Query(() => group, x => x
+                    .Match<FactType2>(
+                        f => f.TestProperty.StartsWith("Valid"),
+                        f => f.JoinProperty == fact.JoinProperty)
+                    .GroupBy(f => f.GroupProperty));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/LifecycleEventTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/LifecycleEventTest.cs
@@ -5,425 +5,424 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class LifecycleEventTest
 {
-    public class LifecycleEventTest
+    [Fact]
+    public void Insert_Fact_RaisesFactInsertingEvent()
     {
-        [Fact]
-        public void Insert_Fact_RaisesFactInsertingEvent()
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+
+        object factorySender = null;
+        WorkingMemoryEventArgs factoryArgs = null;
+        object sessionSender = null;
+        WorkingMemoryEventArgs sessionArgs = null;
+        factory.Events.FactInsertingEvent += (sender, args) =>
         {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-
-            object factorySender = null;
-            WorkingMemoryEventArgs factoryArgs = null;
-            object sessionSender = null;
-            WorkingMemoryEventArgs sessionArgs = null;
-            factory.Events.FactInsertingEvent += (sender, args) =>
-            {
-                factorySender = sender;
-                factoryArgs = args;
-            };
-            session.Events.FactInsertingEvent += (sender, args) =>
-            {
-                sessionSender = sender;
-                sessionArgs = args;
-            };
-
-            //Act
-            session.Insert(fact);
-
-            //Assert
-            Assert.Same(session, factorySender);
-            Assert.Same(session, sessionSender);
-            Assert.Same(fact, factoryArgs.Fact.Value);
-            Assert.Same(fact, sessionArgs.Fact.Value);
-        }
-
-        [Fact]
-        public void Insert_Fact_RaisesFactInsertedEvent()
+            factorySender = sender;
+            factoryArgs = args;
+        };
+        session.Events.FactInsertingEvent += (sender, args) =>
         {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
+            sessionSender = sender;
+            sessionArgs = args;
+        };
 
-            var fact = new FactType { TestProperty = "Valid Value" };
+        //Act
+        session.Insert(fact);
 
-            object factorySender = null;
-            WorkingMemoryEventArgs factoryArgs = null;
-            object sessionSender = null;
-            WorkingMemoryEventArgs sessionArgs = null;
-            factory.Events.FactInsertedEvent += (sender, args) =>
-            {
-                factorySender = sender;
-                factoryArgs = args;
-            };
-            session.Events.FactInsertedEvent += (sender, args) =>
-            {
-                sessionSender = sender;
-                sessionArgs = args;
-            };
+        //Assert
+        Assert.Same(session, factorySender);
+        Assert.Same(session, sessionSender);
+        Assert.Same(fact, factoryArgs.Fact.Value);
+        Assert.Same(fact, sessionArgs.Fact.Value);
+    }
 
-            //Act
-            session.Insert(fact);
+    [Fact]
+    public void Insert_Fact_RaisesFactInsertedEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
 
-            //Assert
-            Assert.Same(session, factorySender);
-            Assert.Same(session, sessionSender);
-            Assert.Same(fact, factoryArgs.Fact.Value);
-            Assert.Same(fact, sessionArgs.Fact.Value);
-        }
+        var fact = new FactType { TestProperty = "Valid Value" };
 
-        [Fact]
-        public void Update_Fact_RaisesFactUpdatingEvent()
+        object factorySender = null;
+        WorkingMemoryEventArgs factoryArgs = null;
+        object sessionSender = null;
+        WorkingMemoryEventArgs sessionArgs = null;
+        factory.Events.FactInsertedEvent += (sender, args) =>
         {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-            session.Insert(fact);
-
-            object factorySender = null;
-            WorkingMemoryEventArgs factoryArgs = null;
-            object sessionSender = null;
-            WorkingMemoryEventArgs sessionArgs = null;
-            factory.Events.FactUpdatingEvent += (sender, args) =>
-            {
-                factorySender = sender;
-                factoryArgs = args;
-            };
-            session.Events.FactUpdatingEvent += (sender, args) =>
-            {
-                sessionSender = sender;
-                sessionArgs = args;
-            };
-
-            //Act
-            session.Update(fact);
-
-            //Assert
-            Assert.Same(session, factorySender);
-            Assert.Same(session, sessionSender);
-            Assert.Same(fact, factoryArgs.Fact.Value);
-            Assert.Same(fact, sessionArgs.Fact.Value);
-        }
-
-        [Fact]
-        public void Update_Fact_RaisesFactUpdatedEvent()
+            factorySender = sender;
+            factoryArgs = args;
+        };
+        session.Events.FactInsertedEvent += (sender, args) =>
         {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
+            sessionSender = sender;
+            sessionArgs = args;
+        };
 
-            var fact = new FactType { TestProperty = "Valid Value" };
-            session.Insert(fact);
+        //Act
+        session.Insert(fact);
 
-            object factorySender = null;
-            WorkingMemoryEventArgs factoryArgs = null;
-            object sessionSender = null;
-            WorkingMemoryEventArgs sessionArgs = null;
-            factory.Events.FactUpdatedEvent += (sender, args) =>
-            {
-                factorySender = sender;
-                factoryArgs = args;
-            };
-            session.Events.FactUpdatedEvent += (sender, args) =>
-            {
-                sessionSender = sender;
-                sessionArgs = args;
-            };
+        //Assert
+        Assert.Same(session, factorySender);
+        Assert.Same(session, sessionSender);
+        Assert.Same(fact, factoryArgs.Fact.Value);
+        Assert.Same(fact, sessionArgs.Fact.Value);
+    }
 
-            //Act
-            session.Update(fact);
+    [Fact]
+    public void Update_Fact_RaisesFactUpdatingEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
 
-            //Assert
-            Assert.Same(session, factorySender);
-            Assert.Same(session, sessionSender);
-            Assert.Same(fact, factoryArgs.Fact.Value);
-            Assert.Same(fact, sessionArgs.Fact.Value);
-        }
+        var fact = new FactType { TestProperty = "Valid Value" };
+        session.Insert(fact);
 
-        [Fact]
-        public void Retract_Fact_RaisesFactRetractingEvent()
+        object factorySender = null;
+        WorkingMemoryEventArgs factoryArgs = null;
+        object sessionSender = null;
+        WorkingMemoryEventArgs sessionArgs = null;
+        factory.Events.FactUpdatingEvent += (sender, args) =>
         {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-            session.Insert(fact);
-
-            object factorySender = null;
-            WorkingMemoryEventArgs factoryArgs = null;
-            object sessionSender = null;
-            WorkingMemoryEventArgs sessionArgs = null;
-            factory.Events.FactRetractingEvent += (sender, args) =>
-            {
-                factorySender = sender;
-                factoryArgs = args;
-            };
-            session.Events.FactRetractingEvent += (sender, args) =>
-            {
-                sessionSender = sender;
-                sessionArgs = args;
-            };
-
-            //Act
-            session.Retract(fact);
-
-            //Assert
-            Assert.Same(session, factorySender);
-            Assert.Same(session, sessionSender);
-            Assert.Same(fact, factoryArgs.Fact.Value);
-            Assert.Same(fact, sessionArgs.Fact.Value);
-        }
-
-        [Fact]
-        public void Retract_Fact_RaisesFactRetractedEvent()
+            factorySender = sender;
+            factoryArgs = args;
+        };
+        session.Events.FactUpdatingEvent += (sender, args) =>
         {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
+            sessionSender = sender;
+            sessionArgs = args;
+        };
 
-            var fact = new FactType { TestProperty = "Valid Value" };
-            session.Insert(fact);
+        //Act
+        session.Update(fact);
 
-            object factorySender = null;
-            WorkingMemoryEventArgs factoryArgs = null;
-            object sessionSender = null;
-            WorkingMemoryEventArgs sessionArgs = null;
-            factory.Events.FactRetractedEvent += (sender, args) =>
-            {
-                factorySender = sender;
-                factoryArgs = args;
-            };
-            session.Events.FactRetractedEvent += (sender, args) =>
-            {
-                sessionSender = sender;
-                sessionArgs = args;
-            };
+        //Assert
+        Assert.Same(session, factorySender);
+        Assert.Same(session, sessionSender);
+        Assert.Same(fact, factoryArgs.Fact.Value);
+        Assert.Same(fact, sessionArgs.Fact.Value);
+    }
 
-            //Act
-            session.Retract(fact);
+    [Fact]
+    public void Update_Fact_RaisesFactUpdatedEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
 
-            //Assert
-            Assert.Same(session, factorySender);
-            Assert.Same(session, sessionSender);
-            Assert.Same(fact, factoryArgs.Fact.Value);
-            Assert.Same(fact, sessionArgs.Fact.Value);
-        }
+        var fact = new FactType { TestProperty = "Valid Value" };
+        session.Insert(fact);
 
-        [Fact]
-        public void Insert_RuleActivated_RaisesActivationCreatedEvent()
+        object factorySender = null;
+        WorkingMemoryEventArgs factoryArgs = null;
+        object sessionSender = null;
+        WorkingMemoryEventArgs sessionArgs = null;
+        factory.Events.FactUpdatedEvent += (sender, args) =>
         {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-
-            object factorySender = null;
-            AgendaEventArgs factoryArgs = null;
-            object sessionSender = null;
-            AgendaEventArgs sessionArgs = null;
-            factory.Events.ActivationCreatedEvent += (sender, args) =>
-            {
-                factorySender = sender;
-                factoryArgs = args;
-            };
-            session.Events.ActivationCreatedEvent += (sender, args) =>
-            {
-                sessionSender = sender;
-                sessionArgs = args;
-            };
-
-            //Act
-            session.Insert(fact);
-
-            //Assert
-            Assert.Same(session, factorySender);
-            Assert.Same(session, sessionSender);
-            Assert.Same(fact, factoryArgs.Facts.Single().Value);
-            Assert.Same(fact, sessionArgs.Facts.Single().Value);
-            Assert.Contains("TestRule", factoryArgs.Rule.Name);
-            Assert.Contains("TestRule", sessionArgs.Rule.Name);
-        }
-
-        [Fact]
-        public void Update_RuleReactivated_RaisesActivationUpatedEvent()
+            factorySender = sender;
+            factoryArgs = args;
+        };
+        session.Events.FactUpdatedEvent += (sender, args) =>
         {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
+            sessionSender = sender;
+            sessionArgs = args;
+        };
 
-            var fact = new FactType { TestProperty = "Valid Value" };
-            session.Insert(fact);
+        //Act
+        session.Update(fact);
 
-            object factorySender = null;
-            AgendaEventArgs factoryArgs = null;
-            object sessionSender = null;
-            AgendaEventArgs sessionArgs = null;
-            factory.Events.ActivationUpdatedEvent += (sender, args) =>
-            {
-                factorySender = sender;
-                factoryArgs = args;
-            };
-            session.Events.ActivationUpdatedEvent += (sender, args) =>
-            {
-                sessionSender = sender;
-                sessionArgs = args;
-            };
+        //Assert
+        Assert.Same(session, factorySender);
+        Assert.Same(session, sessionSender);
+        Assert.Same(fact, factoryArgs.Fact.Value);
+        Assert.Same(fact, sessionArgs.Fact.Value);
+    }
 
-            //Act
-            session.Update(fact);
+    [Fact]
+    public void Retract_Fact_RaisesFactRetractingEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
 
-            //Assert
-            Assert.Same(session, factorySender);
-            Assert.Same(session, sessionSender);
-            Assert.Same(fact, factoryArgs.Facts.Single().Value);
-            Assert.Same(fact, sessionArgs.Facts.Single().Value);
-            Assert.Contains("TestRule", factoryArgs.Rule.Name);
-            Assert.Contains("TestRule", sessionArgs.Rule.Name);
-        }
+        var fact = new FactType { TestProperty = "Valid Value" };
+        session.Insert(fact);
 
-        [Fact]
-        public void Retract_RuleDeactivated_RaisesActivationDeletedEvent()
+        object factorySender = null;
+        WorkingMemoryEventArgs factoryArgs = null;
+        object sessionSender = null;
+        WorkingMemoryEventArgs sessionArgs = null;
+        factory.Events.FactRetractingEvent += (sender, args) =>
         {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-            session.Insert(fact);
-
-            object factorySender = null;
-            AgendaEventArgs factoryArgs = null;
-            object sessionSender = null;
-            AgendaEventArgs sessionArgs = null;
-            factory.Events.ActivationDeletedEvent += (sender, args) =>
-            {
-                factorySender = sender;
-                factoryArgs = args;
-            };
-            session.Events.ActivationDeletedEvent += (sender, args) =>
-            {
-                sessionSender = sender;
-                sessionArgs = args;
-            };
-
-            //Act
-            session.Retract(fact);
-
-            //Assert
-            Assert.Same(session, factorySender);
-            Assert.Same(session, sessionSender);
-            Assert.Same(fact, factoryArgs.Facts.Single().Value);
-            Assert.Same(fact, sessionArgs.Facts.Single().Value);
-            Assert.Contains("TestRule", factoryArgs.Rule.Name);
-            Assert.Contains("TestRule", sessionArgs.Rule.Name);
-        }
-
-        [Fact]
-        public void Fire_RuleFires_RaisesRuleFiringEvent()
+            factorySender = sender;
+            factoryArgs = args;
+        };
+        session.Events.FactRetractingEvent += (sender, args) =>
         {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
+            sessionSender = sender;
+            sessionArgs = args;
+        };
 
-            var fact = new FactType { TestProperty = "Valid Value" };
-            session.Insert(fact);
+        //Act
+        session.Retract(fact);
 
-            object factorySender = null;
-            AgendaEventArgs factoryArgs = null;
-            object sessionSender = null;
-            AgendaEventArgs sessionArgs = null;
-            factory.Events.RuleFiringEvent += (sender, args) =>
-            {
-                factorySender = sender;
-                factoryArgs = args;
-            };
-            session.Events.RuleFiringEvent += (sender, args) =>
-            {
-                sessionSender = sender;
-                sessionArgs = args;
-            };
+        //Assert
+        Assert.Same(session, factorySender);
+        Assert.Same(session, sessionSender);
+        Assert.Same(fact, factoryArgs.Fact.Value);
+        Assert.Same(fact, sessionArgs.Fact.Value);
+    }
 
-            //Act
-            session.Fire();
+    [Fact]
+    public void Retract_Fact_RaisesFactRetractedEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
 
-            //Assert
-            Assert.Same(session, factorySender);
-            Assert.Same(session, sessionSender);
-            Assert.Same(fact, factoryArgs.Facts.Single().Value);
-            Assert.Same(fact, sessionArgs.Facts.Single().Value);
-            Assert.Contains("TestRule", factoryArgs.Rule.Name);
-            Assert.Contains("TestRule", sessionArgs.Rule.Name);
-        }
+        var fact = new FactType { TestProperty = "Valid Value" };
+        session.Insert(fact);
 
-        [Fact]
-        public void Fire_RuleFires_RaisesRuleFiredEvent()
+        object factorySender = null;
+        WorkingMemoryEventArgs factoryArgs = null;
+        object sessionSender = null;
+        WorkingMemoryEventArgs sessionArgs = null;
+        factory.Events.FactRetractedEvent += (sender, args) =>
         {
-            //Arrange
-            var factory = CreateTarget();
-            var session = factory.CreateSession();
-
-            var fact = new FactType { TestProperty = "Valid Value" };
-            session.Insert(fact);
-
-            object factorySender = null;
-            AgendaEventArgs factoryArgs = null;
-            object sessionSender = null;
-            AgendaEventArgs sessionArgs = null;
-            factory.Events.RuleFiredEvent += (sender, args) =>
-            {
-                factorySender = sender;
-                factoryArgs = args;
-            };
-            session.Events.RuleFiredEvent += (sender, args) =>
-            {
-                sessionSender = sender;
-                sessionArgs = args;
-            };
-
-            //Act
-            session.Fire();
-
-            //Assert
-            Assert.Same(session, factorySender);
-            Assert.Same(session, sessionSender);
-            Assert.Same(fact, factoryArgs.Facts.Single().Value);
-            Assert.Same(fact, sessionArgs.Facts.Single().Value);
-            Assert.Contains("TestRule", factoryArgs.Rule.Name);
-            Assert.Contains("TestRule", sessionArgs.Rule.Name);
-        }
-
-        private ISessionFactory CreateTarget()
+            factorySender = sender;
+            factoryArgs = args;
+        };
+        session.Events.FactRetractedEvent += (sender, args) =>
         {
-            var repository = new RuleRepository();
-            repository.Load(x => x.NestedTypes().From(typeof(TestRule)));
-            return repository.Compile();
-        }
+            sessionSender = sender;
+            sessionArgs = args;
+        };
 
-        public class FactType
+        //Act
+        session.Retract(fact);
+
+        //Assert
+        Assert.Same(session, factorySender);
+        Assert.Same(session, sessionSender);
+        Assert.Same(fact, factoryArgs.Fact.Value);
+        Assert.Same(fact, sessionArgs.Fact.Value);
+    }
+
+    [Fact]
+    public void Insert_RuleActivated_RaisesActivationCreatedEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+
+        object factorySender = null;
+        AgendaEventArgs factoryArgs = null;
+        object sessionSender = null;
+        AgendaEventArgs sessionArgs = null;
+        factory.Events.ActivationCreatedEvent += (sender, args) =>
         {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
+            factorySender = sender;
+            factoryArgs = args;
+        };
+        session.Events.ActivationCreatedEvent += (sender, args) =>
         {
-            public override void Define()
-            {
-                FactType fact = null;
+            sessionSender = sender;
+            sessionArgs = args;
+        };
 
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+        //Act
+        session.Insert(fact);
+
+        //Assert
+        Assert.Same(session, factorySender);
+        Assert.Same(session, sessionSender);
+        Assert.Same(fact, factoryArgs.Facts.Single().Value);
+        Assert.Same(fact, sessionArgs.Facts.Single().Value);
+        Assert.Contains("TestRule", factoryArgs.Rule.Name);
+        Assert.Contains("TestRule", sessionArgs.Rule.Name);
+    }
+
+    [Fact]
+    public void Update_RuleReactivated_RaisesActivationUpatedEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+        session.Insert(fact);
+
+        object factorySender = null;
+        AgendaEventArgs factoryArgs = null;
+        object sessionSender = null;
+        AgendaEventArgs sessionArgs = null;
+        factory.Events.ActivationUpdatedEvent += (sender, args) =>
+        {
+            factorySender = sender;
+            factoryArgs = args;
+        };
+        session.Events.ActivationUpdatedEvent += (sender, args) =>
+        {
+            sessionSender = sender;
+            sessionArgs = args;
+        };
+
+        //Act
+        session.Update(fact);
+
+        //Assert
+        Assert.Same(session, factorySender);
+        Assert.Same(session, sessionSender);
+        Assert.Same(fact, factoryArgs.Facts.Single().Value);
+        Assert.Same(fact, sessionArgs.Facts.Single().Value);
+        Assert.Contains("TestRule", factoryArgs.Rule.Name);
+        Assert.Contains("TestRule", sessionArgs.Rule.Name);
+    }
+
+    [Fact]
+    public void Retract_RuleDeactivated_RaisesActivationDeletedEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+        session.Insert(fact);
+
+        object factorySender = null;
+        AgendaEventArgs factoryArgs = null;
+        object sessionSender = null;
+        AgendaEventArgs sessionArgs = null;
+        factory.Events.ActivationDeletedEvent += (sender, args) =>
+        {
+            factorySender = sender;
+            factoryArgs = args;
+        };
+        session.Events.ActivationDeletedEvent += (sender, args) =>
+        {
+            sessionSender = sender;
+            sessionArgs = args;
+        };
+
+        //Act
+        session.Retract(fact);
+
+        //Assert
+        Assert.Same(session, factorySender);
+        Assert.Same(session, sessionSender);
+        Assert.Same(fact, factoryArgs.Facts.Single().Value);
+        Assert.Same(fact, sessionArgs.Facts.Single().Value);
+        Assert.Contains("TestRule", factoryArgs.Rule.Name);
+        Assert.Contains("TestRule", sessionArgs.Rule.Name);
+    }
+
+    [Fact]
+    public void Fire_RuleFires_RaisesRuleFiringEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+        session.Insert(fact);
+
+        object factorySender = null;
+        AgendaEventArgs factoryArgs = null;
+        object sessionSender = null;
+        AgendaEventArgs sessionArgs = null;
+        factory.Events.RuleFiringEvent += (sender, args) =>
+        {
+            factorySender = sender;
+            factoryArgs = args;
+        };
+        session.Events.RuleFiringEvent += (sender, args) =>
+        {
+            sessionSender = sender;
+            sessionArgs = args;
+        };
+
+        //Act
+        session.Fire();
+
+        //Assert
+        Assert.Same(session, factorySender);
+        Assert.Same(session, sessionSender);
+        Assert.Same(fact, factoryArgs.Facts.Single().Value);
+        Assert.Same(fact, sessionArgs.Facts.Single().Value);
+        Assert.Contains("TestRule", factoryArgs.Rule.Name);
+        Assert.Contains("TestRule", sessionArgs.Rule.Name);
+    }
+
+    [Fact]
+    public void Fire_RuleFires_RaisesRuleFiredEvent()
+    {
+        //Arrange
+        var factory = CreateTarget();
+        var session = factory.CreateSession();
+
+        var fact = new FactType { TestProperty = "Valid Value" };
+        session.Insert(fact);
+
+        object factorySender = null;
+        AgendaEventArgs factoryArgs = null;
+        object sessionSender = null;
+        AgendaEventArgs sessionArgs = null;
+        factory.Events.RuleFiredEvent += (sender, args) =>
+        {
+            factorySender = sender;
+            factoryArgs = args;
+        };
+        session.Events.RuleFiredEvent += (sender, args) =>
+        {
+            sessionSender = sender;
+            sessionArgs = args;
+        };
+
+        //Act
+        session.Fire();
+
+        //Assert
+        Assert.Same(session, factorySender);
+        Assert.Same(session, sessionSender);
+        Assert.Same(fact, factoryArgs.Facts.Single().Value);
+        Assert.Same(fact, sessionArgs.Facts.Single().Value);
+        Assert.Contains("TestRule", factoryArgs.Rule.Name);
+        Assert.Contains("TestRule", sessionArgs.Rule.Name);
+    }
+
+    private ISessionFactory CreateTarget()
+    {
+        var repository = new RuleRepository();
+        repository.Load(x => x.NestedTypes().From(typeof(TestRule)));
+        return repository.Compile();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
+        {
+            FactType fact = null;
+
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/LinkedFactsErrorTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/LinkedFactsErrorTest.cs
@@ -4,64 +4,63 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class LinkedFactsErrorTest : BaseRuleTestFixture
 {
-    public class LinkedFactsErrorTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_YieldThrowsThenUpdatedToValid_YieldsOnUpdate()
     {
-        [Fact]
-        public void Fire_YieldThrowsThenUpdatedToValid_YieldsOnUpdate()
+        //Arrange
+        var fact1 = new FactType1 { ChainProperty = "Value", ShouldThrow = true};
+        Session.Insert(fact1);
+
+        Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
+
+        fact1.ShouldThrow = false;
+
+        //Act
+        Session.Update(fact1);
+        Session.Fire();
+
+        //Assert
+        var linkedFacts = Session.Query<FactType2>();
+        Assert.Equal(1, linkedFacts.Count());
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<ForwardChainingFirstRule>();
+    }
+
+    public class FactType1
+    {
+        public string ChainProperty { get; set; }
+        public bool ShouldThrow { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class ForwardChainingFirstRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 { ChainProperty = "Value", ShouldThrow = true};
-            Session.Insert(fact1);
+            FactType1 fact1 = null;
 
-            Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
-
-            fact1.ShouldThrow = false;
-
-            //Act
-            Session.Update(fact1);
-            Session.Fire();
-
-            //Assert
-            var linkedFacts = Session.Query<FactType2>();
-            Assert.Equal(1, linkedFacts.Count());
+            When()
+                .Match<FactType1>(() => fact1);
+            Then()
+                .Yield(ctx => Create(fact1));
         }
 
-        protected override void SetUpRules()
+        private static FactType2 Create(FactType1 fact1)
         {
-            SetUpRule<ForwardChainingFirstRule>();
-        }
-
-        public class FactType1
-        {
-            public string ChainProperty { get; set; }
-            public bool ShouldThrow { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class ForwardChainingFirstRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-
-                When()
-                    .Match<FactType1>(() => fact1);
-                Then()
-                    .Yield(ctx => Create(fact1));
-            }
-
-            private static FactType2 Create(FactType1 fact1)
-            {
-                if (fact1.ShouldThrow) throw new InvalidOperationException();
-                var fact2 = new FactType2 {TestProperty = fact1.ChainProperty};
-                return fact2;
-            }
+            if (fact1.ShouldThrow) throw new InvalidOperationException();
+            var fact2 = new FactType2 {TestProperty = fact1.ChainProperty};
+            return fact2;
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/MultipleQueriesSingleJoinRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/MultipleQueriesSingleJoinRuleTest.cs
@@ -4,123 +4,122 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class MultipleQueriesSingleJoinRuleTest : BaseRuleTestFixture
 {
-    public class MultipleQueriesSingleJoinRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFactSet_FiresOnce()
     {
-        [Fact]
-        public void Fire_OneMatchingFactSet_FiresOnce()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact4 = new FactType4 {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+        Session.Insert(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+    
+    [Fact]
+    public void Fire_OneMatchingFactSetOneNotMatching_FiresOnce()
+    {
+        //Arrange
+        var fact1A = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact1B = new FactType1 {TestProperty = "Valid Value 2"};
+        var fact4A = new FactType4 {TestProperty = "Valid Value 1"};
+        var fact4B = new FactType4 {TestProperty = "Valid Value 3"};
+
+        Session.Insert(fact1A);
+        Session.Insert(fact1B);
+        Session.Insert(fact4A);
+        Session.Insert(fact4B);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+    
+    [Fact]
+    public void Fire_TwoMatchingFactSets_FiresTwice()
+    {
+        //Arrange
+        var fact1A = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact1B = new FactType1 {TestProperty = "Valid Value 2"};
+        var fact4A = new FactType4 {TestProperty = "Valid Value 1"};
+        var fact4B = new FactType4 {TestProperty = "Valid Value 2"};
+
+        Session.Insert(fact1A);
+        Session.Insert(fact1B);
+        Session.Insert(fact4A);
+        Session.Insert(fact4B);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType3
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType4
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact4 = new FactType4 {TestProperty = "Valid Value 1"};
+            FactType1 fact1 = null;
+            IEnumerable<FactType2> collection2 = null;
+            IEnumerable<FactType3> collection3 = null;
+            IEnumerable<FactType4> collection4 = null;
 
-            Session.Insert(fact1);
-            Session.Insert(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
+            When()
+                .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                .Query(() => collection2, q => q
+                    .Match<FactType2>(f => f.TestProperty.StartsWith("Valid"))
+                    .Collect())
+                .Query(() => collection3, q => q
+                    .Match<FactType3>(f => f.TestProperty.StartsWith("Valid"))
+                    .Collect())
+                .Query(() => collection4, q => q
+                    .Match<FactType4>(f => f.TestProperty.StartsWith("Valid"))
+                    .Collect()
+                    .Where(x => IsMatch(fact1, collection2, collection3, x)));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
-        
-        [Fact]
-        public void Fire_OneMatchingFactSetOneNotMatching_FiresOnce()
+
+        private bool IsMatch(FactType1 fact1, IEnumerable<FactType2> collection2, IEnumerable<FactType3> collection3, IEnumerable<FactType4> collection4)
         {
-            //Arrange
-            var fact1A = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact1B = new FactType1 {TestProperty = "Valid Value 2"};
-            var fact4A = new FactType4 {TestProperty = "Valid Value 1"};
-            var fact4B = new FactType4 {TestProperty = "Valid Value 3"};
-
-            Session.Insert(fact1A);
-            Session.Insert(fact1B);
-            Session.Insert(fact4A);
-            Session.Insert(fact4B);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-        
-        [Fact]
-        public void Fire_TwoMatchingFactSets_FiresTwice()
-        {
-            //Arrange
-            var fact1A = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact1B = new FactType1 {TestProperty = "Valid Value 2"};
-            var fact4A = new FactType4 {TestProperty = "Valid Value 1"};
-            var fact4B = new FactType4 {TestProperty = "Valid Value 2"};
-
-            Session.Insert(fact1A);
-            Session.Insert(fact1B);
-            Session.Insert(fact4A);
-            Session.Insert(fact4B);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType3
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType4
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-                IEnumerable<FactType2> collection2 = null;
-                IEnumerable<FactType3> collection3 = null;
-                IEnumerable<FactType4> collection4 = null;
-
-                When()
-                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                    .Query(() => collection2, q => q
-                        .Match<FactType2>(f => f.TestProperty.StartsWith("Valid"))
-                        .Collect())
-                    .Query(() => collection3, q => q
-                        .Match<FactType3>(f => f.TestProperty.StartsWith("Valid"))
-                        .Collect())
-                    .Query(() => collection4, q => q
-                        .Match<FactType4>(f => f.TestProperty.StartsWith("Valid"))
-                        .Collect()
-                        .Where(x => IsMatch(fact1, collection2, collection3, x)));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-
-            private bool IsMatch(FactType1 fact1, IEnumerable<FactType2> collection2, IEnumerable<FactType3> collection3, IEnumerable<FactType4> collection4)
-            {
-                return collection4.Any(x => x.TestProperty == fact1.TestProperty);
-            }
+            return collection4.Any(x => x.TestProperty == fact1.TestProperty);
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/NRules.IntegrationTests.csproj
+++ b/src/NRules/Tests/NRules.IntegrationTests/NRules.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NRules/Tests/NRules.IntegrationTests/NestedPatternsNoAliasTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/NestedPatternsNoAliasTest.cs
@@ -2,85 +2,84 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class NestedPatternsNoAliasTest : BaseRuleTestFixture
 {
-    public class NestedPatternsNoAliasTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_EmptySession_DoesNotFire()
     {
-        [Fact]
-        public void Fire_EmptySession_DoesNotFire()
+        // Arrange - Act
+        Session.Fire();
+
+        // Assert
+        AssertDidNotFire();
+    }
+    
+    [Fact]
+    public void Fire_FactTypeOneTwoThreeInserted_FiresOnce()
+    {
+        // Arrange
+        Session.Insert(new FactType1());
+        Session.Insert(new FactType2());
+        Session.Insert(new FactType3());
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+    }
+    
+    [Fact]
+    public void Fire_FactTypeOneTwoFourInserted_FiresOnce()
+    {
+        // Arrange
+        Session.Insert(new FactType1());
+        Session.Insert(new FactType2());
+        Session.Insert(new FactType4());
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+    }
+
+    public class FactType2
+    {
+    }
+
+    public class FactType3
+    {
+    }
+
+    public class FactType4
+    {
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            // Arrange - Act
-            Session.Fire();
-
-            // Assert
-            AssertDidNotFire();
-        }
-        
-        [Fact]
-        public void Fire_FactTypeOneTwoThreeInserted_FiresOnce()
-        {
-            // Arrange
-            Session.Insert(new FactType1());
-            Session.Insert(new FactType2());
-            Session.Insert(new FactType3());
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-        }
-        
-        [Fact]
-        public void Fire_FactTypeOneTwoFourInserted_FiresOnce()
-        {
-            // Arrange
-            Session.Insert(new FactType1());
-            Session.Insert(new FactType2());
-            Session.Insert(new FactType4());
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-        }
-
-        public class FactType2
-        {
-        }
-
-        public class FactType3
-        {
-        }
-
-        public class FactType4
-        {
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                When()
-                    .Match<FactType1>()
-                    .Match<FactType2>()
-                    .Or(x => x
-                        .Match<FactType3>()
-                        .Match<FactType4>());
-                
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType1>()
+                .Match<FactType2>()
+                .Or(x => x
+                    .Match<FactType3>()
+                    .Match<FactType4>());
+            
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/NodeSharingNonEquivalentExpressionsTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/NodeSharingNonEquivalentExpressionsTest.cs
@@ -4,189 +4,188 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class NodeSharingNonEquivalentExpressionsTest : BaseRuleTestFixture
 {
-    public class NodeSharingNonEquivalentExpressionsTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_FirstRuleMatchesFacts_OnlyMatchingRuleFires()
     {
-        [Fact]
-        public void Fire_FirstRuleMatchesFacts_OnlyMatchingRuleFires()
+        //Arrange
+        var thisNameFact = new NameFact { Name = "ThisName" };
+        var otherNameFact = new NameFact { Name = "OtherName" };
+        var referenceFact = new ReferenceFact { Reference = thisNameFact };
+
+        Session.Insert(thisNameFact);
+        Session.Insert(otherNameFact);
+        Session.Insert(referenceFact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce<TestRule1>();
+        AssertDidNotFire<TestRule2>();
+    }
+    
+    [Fact]
+    public void Fire_SecondRuleMatchesFacts_OnlyMatchingRuleFires()
+    {
+        //Arrange
+        var thisNameFact = new NameFact { Name = "ThisName" };
+        var otherNameFact = new NameFact { Name = "OtherName" };
+        var referenceFact = new ReferenceFact { Reference = otherNameFact };
+
+        Session.Insert(thisNameFact);
+        Session.Insert(otherNameFact);
+        Session.Insert(referenceFact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire<TestRule1>();
+        AssertFiredOnce<TestRule2>();
+    }
+    
+    [Fact]
+    public void Fire_ThirdRuleMatchesFacts_OnlyMatchingRuleFires()
+    {
+        //Arrange
+        var thisNameFact = new NameFact { Name = "ThisName" };
+        var otherNameFact = new NameFact { Name = "OtherName" };
+        var referenceFact = new ReferenceFact { Reference = thisNameFact };
+
+        Session.Insert(thisNameFact);
+        Session.Insert(otherNameFact);
+        Session.Insert(referenceFact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce<TestRule3>();
+        AssertDidNotFire<TestRule4>();
+    }
+    
+    [Fact]
+    public void Fire_FourthRuleMatchesFacts_OnlyMatchingRuleFires()
+    {
+        //Arrange
+        var thisNameFact = new NameFact { Name = "ThisName" };
+        var otherNameFact = new NameFact { Name = "OtherName" };
+        var referenceFact = new ReferenceFact { Reference = otherNameFact };
+
+        Session.Insert(thisNameFact);
+        Session.Insert(otherNameFact);
+        Session.Insert(referenceFact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire<TestRule3>();
+        AssertFiredOnce<TestRule4>();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule1>();
+        SetUpRule<TestRule2>();
+        SetUpRule<TestRule3>();
+        SetUpRule<TestRule4>();
+    }
+    
+    public class NameFact
+    {
+        public string Name { get; set; }
+    }
+
+    public class ReferenceFact
+    {
+        public NameFact Reference { get; set; }
+
+        public NameFact GetKey(NameFact nameFact)
         {
-            //Arrange
-            var thisNameFact = new NameFact { Name = "ThisName" };
-            var otherNameFact = new NameFact { Name = "OtherName" };
-            var referenceFact = new ReferenceFact { Reference = thisNameFact };
-
-            Session.Insert(thisNameFact);
-            Session.Insert(otherNameFact);
-            Session.Insert(referenceFact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce<TestRule1>();
-            AssertDidNotFire<TestRule2>();
+            return nameFact;
         }
-        
-        [Fact]
-        public void Fire_SecondRuleMatchesFacts_OnlyMatchingRuleFires()
+    }   
+    
+    public class TestRule1 : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var thisNameFact = new NameFact { Name = "ThisName" };
-            var otherNameFact = new NameFact { Name = "OtherName" };
-            var referenceFact = new ReferenceFact { Reference = otherNameFact };
+            NameFact thisNameFact = null;
+            NameFact otherNameFact = null;
+            ReferenceFact referenceFact = null;
 
-            Session.Insert(thisNameFact);
-            Session.Insert(otherNameFact);
-            Session.Insert(referenceFact);
+            When()
+                .Match(() => thisNameFact, f => f.Name == "ThisName")
+                .Match(() => otherNameFact, f => f.Name == "OtherName")
+                .Match(() => referenceFact, rf => rf.Reference == thisNameFact);
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire<TestRule1>();
-            AssertFiredOnce<TestRule2>();
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
-        
-        [Fact]
-        public void Fire_ThirdRuleMatchesFacts_OnlyMatchingRuleFires()
+    }
+    
+    public class TestRule2 : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var thisNameFact = new NameFact { Name = "ThisName" };
-            var otherNameFact = new NameFact { Name = "OtherName" };
-            var referenceFact = new ReferenceFact { Reference = thisNameFact };
+            NameFact thisNameFact = null;
+            NameFact otherNameFact = null;
+            ReferenceFact referenceFact = null;
 
-            Session.Insert(thisNameFact);
-            Session.Insert(otherNameFact);
-            Session.Insert(referenceFact);
+            When()
+                .Match(() => thisNameFact, f => f.Name == "ThisName")
+                .Match(() => otherNameFact, f => f.Name == "OtherName")
+                .Match(() => referenceFact, rf => rf.Reference == otherNameFact);
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce<TestRule3>();
-            AssertDidNotFire<TestRule4>();
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
-        
-        [Fact]
-        public void Fire_FourthRuleMatchesFacts_OnlyMatchingRuleFires()
+    }
+    
+    public class TestRule3 : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var thisNameFact = new NameFact { Name = "ThisName" };
-            var otherNameFact = new NameFact { Name = "OtherName" };
-            var referenceFact = new ReferenceFact { Reference = otherNameFact };
+            NameFact thisNameFact = null;
+            NameFact otherNameFact = null;
+            IEnumerable<ReferenceFact> referenceFacts = null;
 
-            Session.Insert(thisNameFact);
-            Session.Insert(otherNameFact);
-            Session.Insert(referenceFact);
+            When()
+                .Match(() => thisNameFact, f => f.Name == "ThisName")
+                .Match(() => otherNameFact, f => f.Name == "OtherName")
+                .Query(() => referenceFacts, q => q
+                    .Match<ReferenceFact>()
+                    .GroupBy(x => x.GetKey(thisNameFact))
+                    .Where(g => g.All(x => x.Reference == g.Key)));
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire<TestRule3>();
-            AssertFiredOnce<TestRule4>();
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
-
-        protected override void SetUpRules()
+    }
+    
+    public class TestRule4 : Rule
+    {
+        public override void Define()
         {
-            SetUpRule<TestRule1>();
-            SetUpRule<TestRule2>();
-            SetUpRule<TestRule3>();
-            SetUpRule<TestRule4>();
-        }
-        
-        public class NameFact
-        {
-            public string Name { get; set; }
-        }
+            NameFact thisNameFact = null;
+            NameFact otherNameFact = null;
+            IEnumerable<ReferenceFact> referenceFacts = null;
 
-        public class ReferenceFact
-        {
-            public NameFact Reference { get; set; }
+            When()
+                .Match(() => thisNameFact, f => f.Name == "ThisName")
+                .Match(() => otherNameFact, f => f.Name == "OtherName")
+                .Query(() => referenceFacts, q => q
+                    .Match<ReferenceFact>()
+                    .GroupBy(x => x.GetKey(otherNameFact))
+                    .Where(g => g.All(x => x.Reference == g.Key)));
 
-            public NameFact GetKey(NameFact nameFact)
-            {
-                return nameFact;
-            }
-        }   
-        
-        public class TestRule1 : Rule
-        {
-            public override void Define()
-            {
-                NameFact thisNameFact = null;
-                NameFact otherNameFact = null;
-                ReferenceFact referenceFact = null;
-
-                When()
-                    .Match(() => thisNameFact, f => f.Name == "ThisName")
-                    .Match(() => otherNameFact, f => f.Name == "OtherName")
-                    .Match(() => referenceFact, rf => rf.Reference == thisNameFact);
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-        }
-        
-        public class TestRule2 : Rule
-        {
-            public override void Define()
-            {
-                NameFact thisNameFact = null;
-                NameFact otherNameFact = null;
-                ReferenceFact referenceFact = null;
-
-                When()
-                    .Match(() => thisNameFact, f => f.Name == "ThisName")
-                    .Match(() => otherNameFact, f => f.Name == "OtherName")
-                    .Match(() => referenceFact, rf => rf.Reference == otherNameFact);
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-        }
-        
-        public class TestRule3 : Rule
-        {
-            public override void Define()
-            {
-                NameFact thisNameFact = null;
-                NameFact otherNameFact = null;
-                IEnumerable<ReferenceFact> referenceFacts = null;
-
-                When()
-                    .Match(() => thisNameFact, f => f.Name == "ThisName")
-                    .Match(() => otherNameFact, f => f.Name == "OtherName")
-                    .Query(() => referenceFacts, q => q
-                        .Match<ReferenceFact>()
-                        .GroupBy(x => x.GetKey(thisNameFact))
-                        .Where(g => g.All(x => x.Reference == g.Key)));
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-        }
-        
-        public class TestRule4 : Rule
-        {
-            public override void Define()
-            {
-                NameFact thisNameFact = null;
-                NameFact otherNameFact = null;
-                IEnumerable<ReferenceFact> referenceFacts = null;
-
-                When()
-                    .Match(() => thisNameFact, f => f.Name == "ThisName")
-                    .Match(() => otherNameFact, f => f.Name == "OtherName")
-                    .Query(() => referenceFacts, q => q
-                        .Match<ReferenceFact>()
-                        .GroupBy(x => x.GetKey(otherNameFact))
-                        .Where(g => g.All(x => x.Reference == g.Key)));
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/NodeSharingTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/NodeSharingTest.cs
@@ -5,169 +5,168 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class NodeSharingTest : BaseRuleTestFixture
 {
-    public class NodeSharingTest : BaseRuleTestFixture
+    [Fact]
+    public void Session_AlphaSelectionNodes_OnePerIntraCondition()
     {
-        [Fact]
-        public void Session_AlphaSelectionNodes_OnePerIntraCondition()
+        //Arrange
+        var schema = Session.GetSchema();
+
+        //Act
+        var count = schema.Nodes.Count(x => x.NodeType == NodeType.Selection);
+
+        //Assert
+        Assert.Equal(5, count);
+    }
+
+    [Fact]
+    public void Session_BetaJoinNodes_CorrectCount()
+    {
+        //Arrange
+        var schema = Session.GetSchema();
+
+        //Act
+        var count = schema.Nodes.Count(x => x.NodeType == NodeType.Join);
+
+        //Assert
+        Assert.Equal(4, count);
+    }
+
+    [Fact]
+    public void Session_AggregateNodes_CorrectCount()
+    {
+        //Arrange
+        var schema = Session.GetSchema();
+
+        //Act
+        var count = schema.Nodes.Count(x => x.NodeType == NodeType.Aggregate);
+
+        //Assert
+        Assert.Equal(3, count);
+    }
+
+    [Fact]
+    public void Session_NotNodes_CorrectCount()
+    {
+        //Arrange
+        var schema = Session.GetSchema();
+
+        //Act
+        var count = schema.Nodes.Count(x => x.NodeType == NodeType.Not);
+
+        //Assert
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void Session_ExistsNodes_CorrectCount()
+    {
+        //Arrange
+        var schema = Session.GetSchema();
+
+        //Act
+        var count = schema.Nodes.Count(x => x.NodeType == NodeType.Exists);
+
+        //Assert
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void Session_BindingNodes_CorrectCount()
+    {
+        //Arrange
+        var schema = Session.GetSchema();
+
+        //Act
+        var count = schema.Nodes.Count(x => x.NodeType == NodeType.Binding);
+
+        //Assert
+        Assert.Equal(1, count);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TwinRuleOne>();
+        SetUpRule<TwinRuleTwo>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class FactType3
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType4
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TwinRuleOne : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var schema = Session.GetSchema();
+            FactType1 fact1 = null;
+            string joinValue = null;
+            FactType2 fact2 = null;
+            IEnumerable<FactType4> group = null;
 
-            //Act
-            var count = schema.Nodes.Count(x => x.NodeType == NodeType.Selection);
+            When()
+                .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                .Let(() => joinValue, () => fact1.TestProperty)
+                .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == joinValue)
+                .Not<FactType3>(f => f.TestProperty.StartsWith("Invalid"))
+                .Exists<FactType3>(f => f.TestProperty.StartsWith("Valid"))
+                .Query(() => group, q => q
+                    .Match<FactType4>()
+                    .Where(f => f.TestProperty.StartsWith("Valid"))
+                    .GroupBy(f => f.TestProperty)
+                    .SelectMany(x => x)
+                    .Collect()
+                    .Where(c => c.Any()));
 
-            //Assert
-            Assert.Equal(5, count);
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
+    }
 
-        [Fact]
-        public void Session_BetaJoinNodes_CorrectCount()
+    public class TwinRuleTwo : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var schema = Session.GetSchema();
+            FactType1 fact1 = null;
+            string joinValue = null;
+            FactType2 fact2 = null;
+            IEnumerable<FactType4> group = null;
 
-            //Act
-            var count = schema.Nodes.Count(x => x.NodeType == NodeType.Join);
+            When()
+                .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                .Let(() => joinValue, () => fact1.TestProperty)
+                .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == joinValue)
+                .Not<FactType3>(f => f.TestProperty.StartsWith("Invalid"))
+                .Exists<FactType3>(f => f.TestProperty.StartsWith("Valid"))
+                .Query(() => group, q => q
+                    .Match<FactType4>()
+                    .Where(f => f.TestProperty.StartsWith("Valid"))
+                    .GroupBy(f => f.TestProperty)
+                    .SelectMany(x => x)
+                    .Collect()
+                    .Where(c => c.Any()));
 
-            //Assert
-            Assert.Equal(4, count);
-        }
-
-        [Fact]
-        public void Session_AggregateNodes_CorrectCount()
-        {
-            //Arrange
-            var schema = Session.GetSchema();
-
-            //Act
-            var count = schema.Nodes.Count(x => x.NodeType == NodeType.Aggregate);
-
-            //Assert
-            Assert.Equal(3, count);
-        }
-
-        [Fact]
-        public void Session_NotNodes_CorrectCount()
-        {
-            //Arrange
-            var schema = Session.GetSchema();
- 
-            //Act
-            var count = schema.Nodes.Count(x => x.NodeType == NodeType.Not);
-
-            //Assert
-            Assert.Equal(1, count);
-        }
-
-        [Fact]
-        public void Session_ExistsNodes_CorrectCount()
-        {
-            //Arrange
-            var schema = Session.GetSchema();
-
-            //Act
-            var count = schema.Nodes.Count(x => x.NodeType == NodeType.Exists);
-
-            //Assert
-            Assert.Equal(1, count);
-        }
-
-        [Fact]
-        public void Session_BindingNodes_CorrectCount()
-        {
-            //Arrange
-            var schema = Session.GetSchema();
-
-            //Act
-            var count = schema.Nodes.Count(x => x.NodeType == NodeType.Binding);
-
-            //Assert
-            Assert.Equal(1, count);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TwinRuleOne>();
-            SetUpRule<TwinRuleTwo>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class FactType3
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType4
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TwinRuleOne : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-                string joinValue = null;
-                FactType2 fact2 = null;
-                IEnumerable<FactType4> group = null;
-
-                When()
-                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                    .Let(() => joinValue, () => fact1.TestProperty)
-                    .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == joinValue)
-                    .Not<FactType3>(f => f.TestProperty.StartsWith("Invalid"))
-                    .Exists<FactType3>(f => f.TestProperty.StartsWith("Valid"))
-                    .Query(() => group, q => q
-                        .Match<FactType4>()
-                        .Where(f => f.TestProperty.StartsWith("Valid"))
-                        .GroupBy(f => f.TestProperty)
-                        .SelectMany(x => x)
-                        .Collect()
-                        .Where(c => c.Any()));
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-        }
-
-        public class TwinRuleTwo : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-                string joinValue = null;
-                FactType2 fact2 = null;
-                IEnumerable<FactType4> group = null;
-
-                When()
-                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                    .Let(() => joinValue, () => fact1.TestProperty)
-                    .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == joinValue)
-                    .Not<FactType3>(f => f.TestProperty.StartsWith("Invalid"))
-                    .Exists<FactType3>(f => f.TestProperty.StartsWith("Valid"))
-                    .Query(() => group, q => q
-                        .Match<FactType4>()
-                        .Where(f => f.TestProperty.StartsWith("Valid"))
-                        .GroupBy(f => f.TestProperty)
-                        .SelectMany(x => x)
-                        .Collect()
-                        .Where(c => c.Any()));
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneEquatableFactOneCollectionRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneEquatableFactOneCollectionRuleTest.cs
@@ -5,200 +5,199 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneEquatableFactOneCollectionRuleTest : BaseRuleTestFixture
 {
-    public class OneEquatableFactOneCollectionRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_TwoMatchingFactsAndOneInvalid_FiresOnceWithTwoFactsInCollection()
     {
-        [Fact]
-        public void Fire_TwoMatchingFactsAndOneInvalid_FiresOnceWithTwoFactsInCollection()
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType(2) {TestProperty = "Valid Value 2"};
+        var fact3 = new FactType(3) {TestProperty = "Invalid Value 3"};
+
+        var facts = new[] {fact1, fact2, fact3};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
+    }
+    
+    [Fact]
+    public void Fire_OneMatchingFactInsertedThenUpdated_FiresOnceWithOneFactInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact11 = new FactType(1) {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+        Session.Update(fact11);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Single(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithTwoFactsInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType(2) {TestProperty = "Valid Value 2"};
+        var fact21 = new FactType(2) {TestProperty = "Valid Value 2"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+        Session.Update(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithOneFactInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType(2) {TestProperty = "Valid Value 2"};
+        var fact21 = new FactType(2) {TestProperty = "Valid Value 2"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+        Session.Retract(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Single(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedTwoRetracted_FiresOnceWithEmptyCollection()
+    {
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact11 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType(2) {TestProperty = "Valid Value 2"};
+        var fact21 = new FactType(2) {TestProperty = "Valid Value 2"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+        Session.Retract(fact11);
+        Session.Retract(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneUpdatedToInvalid_FiresOnceWithOneFactInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType(2) {TestProperty = "Valid Value 2"};
+        var fact21 = new FactType(2) {TestProperty = "Invalid Value"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        Session.Update(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Single(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactsAndOneInvalidInsertedTheInvalidUpdatedToValid_FiresOnceWithTwoFactInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType(2) {TestProperty = "Invalid Value"};
+        var fact21 = new FactType(2) {TestProperty = "Valid Value 2"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        Session.Update(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType : IEquatable<FactType>
+    {
+        public FactType(int id)
         {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType(2) {TestProperty = "Valid Value 2"};
-            var fact3 = new FactType(3) {TestProperty = "Invalid Value 3"};
-
-            var facts = new[] {fact1, fact2, fact3};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
-        }
-        
-        [Fact]
-        public void Fire_OneMatchingFactInsertedThenUpdated_FiresOnceWithOneFactInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact11 = new FactType(1) {TestProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-            Session.Update(fact11);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Single(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithTwoFactsInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType(2) {TestProperty = "Valid Value 2"};
-            var fact21 = new FactType(2) {TestProperty = "Valid Value 2"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-            Session.Update(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithOneFactInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType(2) {TestProperty = "Valid Value 2"};
-            var fact21 = new FactType(2) {TestProperty = "Valid Value 2"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-            Session.Retract(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Single(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedTwoRetracted_FiresOnceWithEmptyCollection()
-        {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact11 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType(2) {TestProperty = "Valid Value 2"};
-            var fact21 = new FactType(2) {TestProperty = "Valid Value 2"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-            Session.Retract(fact11);
-            Session.Retract(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneUpdatedToInvalid_FiresOnceWithOneFactInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType(2) {TestProperty = "Valid Value 2"};
-            var fact21 = new FactType(2) {TestProperty = "Invalid Value"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            Session.Update(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Single(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactsAndOneInvalidInsertedTheInvalidUpdatedToValid_FiresOnceWithTwoFactInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType(2) {TestProperty = "Invalid Value"};
-            var fact21 = new FactType(2) {TestProperty = "Valid Value 2"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            Session.Update(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType : IEquatable<FactType>
-        {
-            public FactType(int id)
-            {
-                Id = id;
-            }
-
-            public int Id { get; }
-            public string TestProperty { get; set; }
-
-            public bool Equals(FactType other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return Id == other.Id;
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((FactType)obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return Id;
-            }
+            Id = id;
         }
 
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                IEnumerable<FactType> collection = null;
+        public int Id { get; }
+        public string TestProperty { get; set; }
 
-                When()
-                    .Query(() => collection, q => q
-                        .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
-                        .Collect());
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+        public bool Equals(FactType other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Id == other.Id;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((FactType)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Id;
+        }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
+        {
+            IEnumerable<FactType> collection = null;
+
+            When()
+                .Query(() => collection, q => q
+                    .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
+                    .Collect());
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneEquatableFactRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneEquatableFactRuleTest.cs
@@ -3,181 +3,180 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneEquatableFactRuleTest : BaseRuleTestFixture
 {
-    public class OneEquatableFactRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFact_FiresOnce()
     {
-        [Fact]
-        public void Fire_OneMatchingFact_FiresOnce()
+        //Arrange
+        var fact = new FactType(1) {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFacts_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType(2) {TestProperty = "Valid Value 2"};
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType(1) {TestProperty = "Valid Value 1"};
+        Session.Insert(fact1);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneFactUpdatedFromInvalidToMatching_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Invalid Value 1"};
+        var fact2 = new FactType(1) {TestProperty = "Valid Value 1"};
+        Session.Insert(fact1);
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndRetractedAndAssertedAgain_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact3 = new FactType(1) {TestProperty = "Valid Value 1"};
+        Session.Insert(fact1);
+        Session.Retract(fact2);
+        Session.Insert(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndUpdatedToInvalid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType(1) {TestProperty = "Invalid Value 1"};
+        Session.Insert(fact1);
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndModifiedAndRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType(1) {TestProperty = "Invalid Value 1"};
+        Session.Insert(fact1);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_DuplicateInsert_Throws()
+    {
+        //Arrange
+        var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType(1) {TestProperty = "Valid Value 2"};
+
+        //Act - Assert
+        Session.Insert(fact1);
+        Assert.Throws<ArgumentException>(() => Session.Insert(fact2));
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType : IEquatable<FactType>
+    {
+        public FactType(int id)
         {
-            //Arrange
-            var fact = new FactType(1) {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
+            Id = id;
         }
 
-        [Fact]
-        public void Fire_TwoMatchingFacts_FiresTwice()
+        public int Id { get; }
+        public string TestProperty { get; set; }
+
+        public bool Equals(FactType other)
         {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType(2) {TestProperty = "Valid Value 2"};
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Id == other.Id;
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactAssertedAndRetracted_DoesNotFire()
+        public override bool Equals(object obj)
         {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType(1) {TestProperty = "Valid Value 1"};
-            Session.Insert(fact1);
-            Session.Retract(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((FactType)obj);
         }
 
-        [Fact]
-        public void Fire_OneFactUpdatedFromInvalidToMatching_FiresOnce()
+        public override int GetHashCode()
         {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Invalid Value 1"};
-            var fact2 = new FactType(1) {TestProperty = "Valid Value 1"};
-            Session.Insert(fact1);
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
+            return Id;
         }
+    }
 
-        [Fact]
-        public void Fire_OneMatchingFactAssertedAndRetractedAndAssertedAgain_FiresOnce()
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact3 = new FactType(1) {TestProperty = "Valid Value 1"};
-            Session.Insert(fact1);
-            Session.Retract(fact2);
-            Session.Insert(fact3);
+            FactType fact = null;
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactAssertedAndUpdatedToInvalid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType(1) {TestProperty = "Invalid Value 1"};
-            Session.Insert(fact1);
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactAssertedAndModifiedAndRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType(1) {TestProperty = "Invalid Value 1"};
-            Session.Insert(fact1);
-            Session.Retract(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_DuplicateInsert_Throws()
-        {
-            //Arrange
-            var fact1 = new FactType(1) {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType(1) {TestProperty = "Valid Value 2"};
-
-            //Act - Assert
-            Session.Insert(fact1);
-            Assert.Throws<ArgumentException>(() => Session.Insert(fact2));
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType : IEquatable<FactType>
-        {
-            public FactType(int id)
-            {
-                Id = id;
-            }
-
-            public int Id { get; }
-            public string TestProperty { get; set; }
-
-            public bool Equals(FactType other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return Id == other.Id;
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((FactType)obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return Id;
-            }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactAggregateJoinRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactAggregateJoinRuleTest.cs
@@ -4,96 +4,95 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactAggregateJoinRuleTest : BaseRuleTestFixture
 {
-    public class OneFactAggregateJoinRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_NoMatchingFacts_DoesNotFire()
     {
-        [Fact]
-        public void Fire_NoMatchingFacts_DoesNotFire()
+        //Arrange - Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFact_FiresOnceWithOneFactInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Single(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactTwoFactsToAggregate_FiresOnceWithTwoFactsInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Invalid Value 2"};
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsTwoFactsToAggregate_FiresTwiceWithTwoFactsInEachCollection()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>(0).Count());
+        Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>(1).Count());
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange - Act
-            Session.Fire();
+            FactType fact = null;
+            IEnumerable<FactType> collection = null;
 
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFact_FiresOnceWithOneFactInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Single(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactTwoFactsToAggregate_FiresOnceWithTwoFactsInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Invalid Value 2"};
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsTwoFactsToAggregate_FiresTwiceWithTwoFactsInEachCollection()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>(0).Count());
-            Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>(1).Count());
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-                IEnumerable<FactType> collection = null;
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"))
-                    .Query(() => collection, x => x
-                        .Match<FactType>()
-                        .Collect()
-                        .Where(c => c.Contains(fact)));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"))
+                .Query(() => collection, x => x
+                    .Match<FactType>()
+                    .Collect()
+                    .Where(c => c.Contains(fact)));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactFirstFactRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactFirstFactRuleTest.cs
@@ -4,112 +4,111 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactFirstFactRuleTest : BaseRuleTestFixture
 {
-    public class OneFactFirstFactRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_FiveMatchingFactsInserted_FiresOnceWithFirstFact()
     {
-        [Fact]
-        public void Fire_FiveMatchingFactsInserted_FiresOnceWithFirstFact()
+        // Arrange
+        var fact1 = new FactType { TestProperty = 3 };
+        var fact2 = new FactType { TestProperty = 5 };
+        var fact3 = new FactType { TestProperty = 1 };
+        var fact4 = new FactType { TestProperty = 4 };
+        var fact5 = new FactType { TestProperty = 2 };
+
+        var facts = new[] { fact1, fact2, fact3, fact4, fact5 };
+        Session.InsertAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+        Assert.Equal(fact3, GetFiredFact<FactType>());
+    }
+
+
+    [Fact]
+    public void Fire_NoMatchingFacts_DoesNotFire()
+    {
+        // Arrange 
+        var fact = new FactType { TestProperty = 0 };
+        Session.Insert(fact);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithFirstFact()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 0 };
+        var fact2 = new FactType { TestProperty = 10 };
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        fact1.TestProperty = 5;
+        Session.Update(fact1);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+        Assert.Equal(fact1, GetFiredFact<FactType>());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithFirstFact()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 10 };
+        var fact2 = new FactType { TestProperty = 20 };
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+        Session.Retract(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+        Assert.Equal(fact1, GetFiredFact<FactType>());
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public int TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 3 };
-            var fact2 = new FactType { TestProperty = 5 };
-            var fact3 = new FactType { TestProperty = 1 };
-            var fact4 = new FactType { TestProperty = 4 };
-            var fact5 = new FactType { TestProperty = 2 };
+            FactType fact = null;
 
-            var facts = new[] { fact1, fact2, fact3, fact4, fact5 };
-            Session.InsertAll(facts);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-            Assert.Equal(fact3, GetFiredFact<FactType>());
-        }
-
-
-        [Fact]
-        public void Fire_NoMatchingFacts_DoesNotFire()
-        {
-            // Arrange 
-            var fact = new FactType { TestProperty = 0 };
-            Session.Insert(fact);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithFirstFact()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 0 };
-            var fact2 = new FactType { TestProperty = 10 };
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            fact1.TestProperty = 5;
-            Session.Update(fact1);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-            Assert.Equal(fact1, GetFiredFact<FactType>());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithFirstFact()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 10 };
-            var fact2 = new FactType { TestProperty = 20 };
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-            Session.Retract(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-            Assert.Equal(fact1, GetFiredFact<FactType>());
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public int TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Query(() => fact, x => x
-                        .Match<FactType>(f => f.TestProperty > 0)
-                        .Collect()
-                        .OrderBy(f => f.TestProperty)
-                        .Where(f => f.Any())
-                        .Select(f => f.First()));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => fact, x => x
+                    .Match<FactType>(f => f.TestProperty > 0)
+                    .Collect()
+                    .OrderBy(f => f.TestProperty)
+                    .Where(f => f.Any())
+                    .Select(f => f.First()));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactNoBindingRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactNoBindingRuleTest.cs
@@ -5,67 +5,66 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactNoBindingRuleTest : BaseRuleTestFixture
 {
-    public class OneFactNoBindingRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFact_FiresOnce()
     {
-        [Fact]
-        public void Fire_OneMatchingFact_FiresOnce()
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFact_FactInContext()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+
+        IFactMatch[] matches = null;
+        GetRuleInstance<TestRule>().Action = ctx =>
         {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
+            matches = ctx.Match.Facts.ToArray();
+        };
 
-            //Act
-            Session.Fire();
+        //Act
+        Session.Fire();
 
-            //Assert
-            AssertFiredOnce();
-        }
+        //Assert
+        AssertFiredOnce();
+        Assert.Single(matches);
+        Assert.Same(fact, matches[0].Value);
+    }
 
-        [Fact]
-        public void Fire_OneMatchingFact_FactInContext()
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public Action<IContext> Action = ctx => { };
+
+        public override void Define()
         {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
-
-            IFactMatch[] matches = null;
-            GetRuleInstance<TestRule>().Action = ctx =>
-            {
-                matches = ctx.Match.Facts.ToArray();
-            };
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Single(matches);
-            Assert.Same(fact, matches[0].Value);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public Action<IContext> Action = ctx => { };
-
-            public override void Define()
-            {
-                When()
-                    .Match<FactType>(f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => Action(ctx));
-            }
+            When()
+                .Match<FactType>(f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => Action(ctx));
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactNonRepeatableRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactNonRepeatableRuleTest.cs
@@ -3,67 +3,66 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactNonRepeatableRuleTest : BaseRuleTestFixture
 {
-    public class OneFactNonRepeatableRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFactEligibleForOneIncrement_FiresOnce()
     {
-        [Fact]
-        public void Fire_OneMatchingFactEligibleForOneIncrement_FiresOnce()
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1", TestCount = 2};
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+    
+    [Fact]
+    public void Fire_OneMatchingFactEligibleForTwoIncrements_FiresOnce()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1", TestCount = 1};
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+    
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+        public int TestCount { get; set; }
+
+        public void IncrementCount()
         {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1", TestCount = 2};
-            Session.Insert(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
+            TestCount++;
         }
-        
-        [Fact]
-        public void Fire_OneMatchingFactEligibleForTwoIncrements_FiresOnce()
+    }
+
+    [Repeatability(RuleRepeatability.NonRepeatable)]
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1", TestCount = 1};
-            Session.Insert(fact);
+            FactType fact = null;
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-        
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-            public int TestCount { get; set; }
-
-            public void IncrementCount()
-            {
-                TestCount++;
-            }
-        }
-
-        [Repeatability(RuleRepeatability.NonRepeatable)]
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"), f => f.TestCount <= 2);
-                Then()
-                    .Do(ctx => fact.IncrementCount())
-                    .Do(ctx => ctx.Update(fact));
-            }
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"), f => f.TestCount <= 2);
+            Then()
+                .Do(ctx => fact.IncrementCount())
+                .Do(ctx => ctx.Update(fact));
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactOneCollectToLookupRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactOneCollectToLookupRuleTest.cs
@@ -4,244 +4,243 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactOneCollectToLookupRuleTest : BaseRuleTestFixture
 {
-    public class OneFactOneCollectToLookupRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_NoMatchingFacts_FiresOnceWithEmptyLookup()
     {
-        [Fact]
-        public void Fire_NoMatchingFacts_FiresOnceWithEmptyLookup()
+        //Arrange - Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<ILookup<long, string>>());
+    }
+    
+    [Fact]
+    public void Fire_TwoFactsForOneGroup_FiresOnceWithFactsInOneGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Single(GetFiredFact<IKeyedLookup<long, string>>());
+        Assert.Equal(2, GetFiredFact<IKeyedLookup<long, string>>()[1].Count());
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndThreeForAnother_FiresOnceWithFactsInCorrectGroups()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+        var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+        var fact5 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+
+        var facts = new[] {fact1, fact2, fact3, fact4, fact5};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<ILookup<long, string>>().Count());
+        Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[1].Count());
+        Assert.Equal(3, GetFiredFact<ILookup<long, string>>()[2].Count());
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndThreeForAnotherOneRetracted_FiresOnceWithTwoFactsInEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+        var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+        var fact5 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+
+        var facts = new[] {fact1, fact2, fact3, fact4, fact5};
+        Session.InsertAll(facts);
+
+        Session.Retract(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<ILookup<long, string>>().Count());
+        Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[1].Count());
+        Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[2].Count());
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndOneForAnotherOneUpdatedToInvalid_FiresOnceWithTwoFactsInOneGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+
+        var facts = new[] {fact1, fact2, fact3};
+        Session.InsertAll(facts);
+
+        fact3.TestProperty = "Invalid Value";
+        Session.Update(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Single(GetFiredFact<ILookup<long, string>>());
+        Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[1].Count());
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneUpdatedToFirstGroup_FiresOnceWithThreeFactsInOneGroupAndOneInAnother()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+        var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+
+        var facts = new[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact4.GroupProperty = 1;
+        Session.Update(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<ILookup<long, string>>().Count());
+        Assert.Equal(3, GetFiredFact<ILookup<long, string>>()[1].Count());
+        Assert.Single(GetFiredFact<ILookup<long, string>>()[2]);
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndOneForAnotherAndOneInvalidTheInvalidUpdatedToValid_FiresOnceWithTwoFactsInEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+        var fact4 = new FactType {GroupProperty = 2, TestProperty = "Invalid Value"};
+
+        var facts = new[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact4.TestProperty = "Valid Value";
+        Session.Update(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<ILookup<long, string>>().Count());
+        Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[1].Count());
+        Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[2].Count());
+    }
+    
+    [Fact]
+    public void Fire_TwoFactGroupsKeyChangedGroupRemovedAndReAddedThenNewFactInserted_FiresOnceWithFactsInEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+
+        var facts = new[] {fact1, fact2, fact3};
+        Session.InsertAll(facts);
+
+        fact1.GroupProperty = 2;
+        fact3.GroupProperty = 1;
+        Session.UpdateAll(new object[] {fact1, fact3});
+
+        var fact4 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        Session.Insert(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<ILookup<long, string>>().Count());
+        Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[1].Count());
+        Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[2].Count());
+    }
+
+    [Fact]
+    public void Fire_TwoFactsOneGroupAnotherFactFilteredOut_FiresOnceAggregateHasSource()
+    {
+        //Arrange
+        IFact matchedGroup = null;
+        Session.Events.RuleFiredEvent += (_, args) =>
         {
-            //Arrange - Act
-            Session.Fire();
+            matchedGroup = args.Facts.Single();
+        };
 
-            //Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<ILookup<long, string>>());
-        }
-        
-        [Fact]
-        public void Fire_TwoFactsForOneGroup_FiresOnceWithFactsInOneGroup()
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Invalid Value"};
+
+        var facts = new[] {fact1, fact2, fact3};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.NotNull(matchedGroup);
+        Assert.NotNull(matchedGroup.Source);
+        Assert.Equal(FactSourceType.Aggregate, matchedGroup.Source.SourceType);
+        Assert.Collection(matchedGroup.Source.Facts,
+            item => Assert.Same(fact1, item.Value),
+            item => Assert.Same(fact2, item.Value));
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public long GroupProperty { get; set; }
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+            IKeyedLookup<long, string> lookup = null;
 
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Single(GetFiredFact<IKeyedLookup<long, string>>());
-            Assert.Equal(2, GetFiredFact<IKeyedLookup<long, string>>()[1].Count());
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndThreeForAnother_FiresOnceWithFactsInCorrectGroups()
-        {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-            var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-            var fact5 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-
-            var facts = new[] {fact1, fact2, fact3, fact4, fact5};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<ILookup<long, string>>().Count());
-            Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[1].Count());
-            Assert.Equal(3, GetFiredFact<ILookup<long, string>>()[2].Count());
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndThreeForAnotherOneRetracted_FiresOnceWithTwoFactsInEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-            var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-            var fact5 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-
-            var facts = new[] {fact1, fact2, fact3, fact4, fact5};
-            Session.InsertAll(facts);
-
-            Session.Retract(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<ILookup<long, string>>().Count());
-            Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[1].Count());
-            Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[2].Count());
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndOneForAnotherOneUpdatedToInvalid_FiresOnceWithTwoFactsInOneGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-
-            var facts = new[] {fact1, fact2, fact3};
-            Session.InsertAll(facts);
-
-            fact3.TestProperty = "Invalid Value";
-            Session.Update(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Single(GetFiredFact<ILookup<long, string>>());
-            Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[1].Count());
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneUpdatedToFirstGroup_FiresOnceWithThreeFactsInOneGroupAndOneInAnother()
-        {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-            var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-
-            var facts = new[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact4.GroupProperty = 1;
-            Session.Update(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<ILookup<long, string>>().Count());
-            Assert.Equal(3, GetFiredFact<ILookup<long, string>>()[1].Count());
-            Assert.Single(GetFiredFact<ILookup<long, string>>()[2]);
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndOneForAnotherAndOneInvalidTheInvalidUpdatedToValid_FiresOnceWithTwoFactsInEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-            var fact4 = new FactType {GroupProperty = 2, TestProperty = "Invalid Value"};
-
-            var facts = new[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact4.TestProperty = "Valid Value";
-            Session.Update(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<ILookup<long, string>>().Count());
-            Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[1].Count());
-            Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[2].Count());
-        }
-        
-        [Fact]
-        public void Fire_TwoFactGroupsKeyChangedGroupRemovedAndReAddedThenNewFactInserted_FiresOnceWithFactsInEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-
-            var facts = new[] {fact1, fact2, fact3};
-            Session.InsertAll(facts);
-
-            fact1.GroupProperty = 2;
-            fact3.GroupProperty = 1;
-            Session.UpdateAll(new object[] {fact1, fact3});
-
-            var fact4 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            Session.Insert(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<ILookup<long, string>>().Count());
-            Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[1].Count());
-            Assert.Equal(2, GetFiredFact<ILookup<long, string>>()[2].Count());
-        }
-
-        [Fact]
-        public void Fire_TwoFactsOneGroupAnotherFactFilteredOut_FiresOnceAggregateHasSource()
-        {
-            //Arrange
-            IFact matchedGroup = null;
-            Session.Events.RuleFiredEvent += (_, args) =>
-            {
-                matchedGroup = args.Facts.Single();
-            };
-
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Invalid Value"};
-
-            var facts = new[] {fact1, fact2, fact3};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.NotNull(matchedGroup);
-            Assert.NotNull(matchedGroup.Source);
-            Assert.Equal(FactSourceType.Aggregate, matchedGroup.Source.SourceType);
-            Assert.Collection(matchedGroup.Source.Facts,
-                item => Assert.Same(fact1, item.Value),
-                item => Assert.Same(fact2, item.Value));
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public long GroupProperty { get; set; }
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                IKeyedLookup<long, string> lookup = null;
-
-                When()
-                    .Query(() => lookup, x => x
-                        .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
-                        .Collect()
-                        .ToLookup(f => f.GroupProperty, f => f.TestProperty));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => lookup, x => x
+                    .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
+                    .Collect()
+                    .ToLookup(f => f.GroupProperty, f => f.TestProperty));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactOneCollectionRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactOneCollectionRuleTest.cs
@@ -4,163 +4,162 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactOneCollectionRuleTest : BaseRuleTestFixture
 {
-    public class OneFactOneCollectionRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_NoMatchingFacts_FiresOnceWithEmptyCollection()
     {
-        [Fact]
-        public void Fire_NoMatchingFacts_FiresOnceWithEmptyCollection()
+        //Arrange - Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsAndOneInvalid_FiresOnceWithTwoFactsInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+        var fact3 = new FactType {TestProperty = "Invalid Value 3"};
+
+        var facts = new[] {fact1, fact2, fact3};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithTwoFactsInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithOneFactInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Single(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedTwoRetracted_FiresOnceWithEmptyCollection()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+        Session.Retract(fact1);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneUpdatedToInvalid_FiresOnceWithOneFactInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        fact2.TestProperty = "Invalid Value";
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Single(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactsAndOneInvalidInsertedTheInvalidUpdatedToValid_FiresOnceWithTwoFactInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Invalid Value"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        fact2.TestProperty = "Valid Value 2";
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange - Act
-            Session.Fire();
+            IEnumerable<FactType> collection = null;
 
-            //Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsAndOneInvalid_FiresOnceWithTwoFactsInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
-            var fact3 = new FactType {TestProperty = "Invalid Value 3"};
-
-            var facts = new[] {fact1, fact2, fact3};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithTwoFactsInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithOneFactInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-            Session.Retract(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Single(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedTwoRetracted_FiresOnceWithEmptyCollection()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-            Session.Retract(fact1);
-            Session.Retract(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneUpdatedToInvalid_FiresOnceWithOneFactInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            fact2.TestProperty = "Invalid Value";
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Single(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactsAndOneInvalidInsertedTheInvalidUpdatedToValid_FiresOnceWithTwoFactInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Invalid Value"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            fact2.TestProperty = "Valid Value 2";
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<IEnumerable<FactType>>().Count());
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                IEnumerable<FactType> collection = null;
-
-                When()
-                    .Query(() => collection, x => x
-                        .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
-                        .Collect());
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => collection, x => x
+                    .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
+                    .Collect());
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactOneGroupByFlattenRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactOneGroupByFlattenRuleTest.cs
@@ -3,251 +3,250 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactOneGroupByFlattenRuleTest : BaseRuleTestFixture
 {
-    public class OneFactOneGroupByFlattenRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_NoMatchingFacts_DoesNotFire()
     {
-        [Fact]
-        public void Fire_NoMatchingFacts_DoesNotFire()
+        //Arrange - Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroup_FiresTwiceWithFactsFromGroupOne()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact2 = new FactType {TestProperty = "Valid Value Group1"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(fact1, GetFiredFact<FactType>(0));
+        Assert.Equal(fact2, GetFiredFact<FactType>(1));
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupInsertedThenOneUpdated_FiresTwiceWithFactsFromGroupOne()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact2 = new FactType {TestProperty = "Valid Value Group1"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(fact1, GetFiredFact<FactType>(0));
+        Assert.Equal(fact2, GetFiredFact<FactType>(1));
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndOneForAnother_FiresTwiceWithFactsFromGroupOne()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact2 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact3 = new FactType {TestProperty = "Valid Value Group2"};
+
+        var facts = new[] {fact1, fact2, fact3};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(fact1, GetFiredFact<FactType>(0));
+        Assert.Equal(fact2, GetFiredFact<FactType>(1));
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndTwoForAnother_FiresWithEachFactFromEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact2 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact3 = new FactType {TestProperty = "Valid Value Group2"};
+        var fact4 = new FactType {TestProperty = "Valid Value Group2"};
+
+        var facts = new[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTimes(4);
+        Assert.Equal(fact1, GetFiredFact<FactType>(0));
+        Assert.Equal(fact2, GetFiredFact<FactType>(1));
+        Assert.Equal(fact3, GetFiredFact<FactType>(2));
+        Assert.Equal(fact4, GetFiredFact<FactType>(3));
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneRetracted_FiresTwiceWithFactsFromGroupOne()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact2 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact3 = new FactType {TestProperty = "Valid Value Group2"};
+        var fact4 = new FactType {TestProperty = "Valid Value Group2"};
+
+        var facts = new[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        Session.Retract(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(fact1, GetFiredFact<FactType>(0));
+        Assert.Equal(fact2, GetFiredFact<FactType>(1));
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneUpdatedToInvalid_FiresTwiceWithFactsFromGroupOne()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact2 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact3 = new FactType {TestProperty = "Valid Value Group2"};
+        var fact4 = new FactType {TestProperty = "Valid Value Group2"};
+
+        var facts = new[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact4.TestProperty = "Invalid Value";
+        Session.Update(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(fact1, GetFiredFact<FactType>(0));
+        Assert.Equal(fact2, GetFiredFact<FactType>(1));
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneUpdatedToFirstGroup_FiresThreeTimesWithFactsFromGroupOne()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact2 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact3 = new FactType {TestProperty = "Valid Value Group2"};
+        var fact4 = new FactType {TestProperty = "Valid Value Group2"};
+
+        var facts = new[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact4.TestProperty = "Valid Value Group1";
+        Session.Update(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTimes(3);
+        var firedFacts = new[] {GetFiredFact<FactType>(0), GetFiredFact<FactType>(1), GetFiredFact<FactType>(2)};
+        var valid1 = firedFacts.Any(x => Equals(fact1, x));
+        var valid2 = firedFacts.Any(x => Equals(fact2, x));
+        var valid4 = firedFacts.Any(x => Equals(fact4, x));
+        Assert.True(valid1 && valid2 && valid4);
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndOneForAnotherAndOneInvalidTheInvalidUpdatedToSecondGroup_FiresWithEachFactFromEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact2 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact3 = new FactType {TestProperty = "Valid Value Group2"};
+        var fact4 = new FactType { TestProperty = "Invalid Value" };
+
+        var facts = new[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact4.TestProperty = "Valid Value Group2";
+        Session.Update(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTimes(4);
+        Assert.Equal(fact1, GetFiredFact<FactType>(0));
+        Assert.Equal(fact2, GetFiredFact<FactType>(1));
+        Assert.Equal(fact3, GetFiredFact<FactType>(2));
+        Assert.Equal(fact4, GetFiredFact<FactType>(3));
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAssertedThenOneRetractedAnotherUpdatedThenOneAssertedBack_FiresTwiceWithFactsFromOneGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value Group1"};
+        var fact2 = new FactType {TestProperty = "Valid Value Group1"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        Session.Retract(fact2);
+        
+        Session.Update(fact1);
+        Session.Insert(fact2);
+        
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTimes(2);
+        Assert.Equal(fact1, GetFiredFact<FactType>(0));
+        Assert.Equal(fact2, GetFiredFact<FactType>(1));
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange - Act
-            Session.Fire();
+            FactType fact = null;
 
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroup_FiresTwiceWithFactsFromGroupOne()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact2 = new FactType {TestProperty = "Valid Value Group1"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(fact1, GetFiredFact<FactType>(0));
-            Assert.Equal(fact2, GetFiredFact<FactType>(1));
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupInsertedThenOneUpdated_FiresTwiceWithFactsFromGroupOne()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact2 = new FactType {TestProperty = "Valid Value Group1"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(fact1, GetFiredFact<FactType>(0));
-            Assert.Equal(fact2, GetFiredFact<FactType>(1));
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndOneForAnother_FiresTwiceWithFactsFromGroupOne()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact2 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact3 = new FactType {TestProperty = "Valid Value Group2"};
-
-            var facts = new[] {fact1, fact2, fact3};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(fact1, GetFiredFact<FactType>(0));
-            Assert.Equal(fact2, GetFiredFact<FactType>(1));
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndTwoForAnother_FiresWithEachFactFromEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact2 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact3 = new FactType {TestProperty = "Valid Value Group2"};
-            var fact4 = new FactType {TestProperty = "Valid Value Group2"};
-
-            var facts = new[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTimes(4);
-            Assert.Equal(fact1, GetFiredFact<FactType>(0));
-            Assert.Equal(fact2, GetFiredFact<FactType>(1));
-            Assert.Equal(fact3, GetFiredFact<FactType>(2));
-            Assert.Equal(fact4, GetFiredFact<FactType>(3));
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneRetracted_FiresTwiceWithFactsFromGroupOne()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact2 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact3 = new FactType {TestProperty = "Valid Value Group2"};
-            var fact4 = new FactType {TestProperty = "Valid Value Group2"};
-
-            var facts = new[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            Session.Retract(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(fact1, GetFiredFact<FactType>(0));
-            Assert.Equal(fact2, GetFiredFact<FactType>(1));
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneUpdatedToInvalid_FiresTwiceWithFactsFromGroupOne()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact2 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact3 = new FactType {TestProperty = "Valid Value Group2"};
-            var fact4 = new FactType {TestProperty = "Valid Value Group2"};
-
-            var facts = new[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact4.TestProperty = "Invalid Value";
-            Session.Update(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(fact1, GetFiredFact<FactType>(0));
-            Assert.Equal(fact2, GetFiredFact<FactType>(1));
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneUpdatedToFirstGroup_FiresThreeTimesWithFactsFromGroupOne()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact2 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact3 = new FactType {TestProperty = "Valid Value Group2"};
-            var fact4 = new FactType {TestProperty = "Valid Value Group2"};
-
-            var facts = new[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact4.TestProperty = "Valid Value Group1";
-            Session.Update(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTimes(3);
-            var firedFacts = new[] {GetFiredFact<FactType>(0), GetFiredFact<FactType>(1), GetFiredFact<FactType>(2)};
-            var valid1 = firedFacts.Any(x => Equals(fact1, x));
-            var valid2 = firedFacts.Any(x => Equals(fact2, x));
-            var valid4 = firedFacts.Any(x => Equals(fact4, x));
-            Assert.True(valid1 && valid2 && valid4);
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndOneForAnotherAndOneInvalidTheInvalidUpdatedToSecondGroup_FiresWithEachFactFromEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact2 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact3 = new FactType {TestProperty = "Valid Value Group2"};
-            var fact4 = new FactType { TestProperty = "Invalid Value" };
-
-            var facts = new[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact4.TestProperty = "Valid Value Group2";
-            Session.Update(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTimes(4);
-            Assert.Equal(fact1, GetFiredFact<FactType>(0));
-            Assert.Equal(fact2, GetFiredFact<FactType>(1));
-            Assert.Equal(fact3, GetFiredFact<FactType>(2));
-            Assert.Equal(fact4, GetFiredFact<FactType>(3));
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAssertedThenOneRetractedAnotherUpdatedThenOneAssertedBack_FiresTwiceWithFactsFromOneGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value Group1"};
-            var fact2 = new FactType {TestProperty = "Valid Value Group1"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            Session.Retract(fact2);
-            
-            Session.Update(fact1);
-            Session.Insert(fact2);
-            
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTimes(2);
-            Assert.Equal(fact1, GetFiredFact<FactType>(0));
-            Assert.Equal(fact2, GetFiredFact<FactType>(1));
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Query(() => fact, q => q
-                        .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
-                        .GroupBy(f => f.TestProperty)
-                        .Where(g => g.Count() > 1)
-                        .SelectMany(x => x));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => fact, q => q
+                    .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
+                    .GroupBy(f => f.TestProperty)
+                    .Where(g => g.Count() > 1)
+                    .SelectMany(x => x));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactOneGroupByFlattenWithIdentityRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactOneGroupByFlattenWithIdentityRuleTest.cs
@@ -5,92 +5,91 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactOneGroupByFlattenWithIdentityRuleTest : BaseRuleTestFixture
 {
-    public class OneFactOneGroupByFlattenWithIdentityRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_UpdatesWithSameIdButDifferentCount_FiresWithNewCount2()
     {
-        [Fact]
-        public void Fire_UpdatesWithSameIdButDifferentCount_FiresWithNewCount2()
+        //Arrange
+        var factsToInsert = new object[]
         {
-            //Arrange
-            var factsToInsert = new object[]
-            {
-                new FactType {Id = 1, TestCount = 1, GroupingProperty = "GP1", GroupingProperty2 = "Group"},
-                new FactType {Id = 2, TestCount = 1, GroupingProperty = "GP2", GroupingProperty2 = "Group"},
-                new FactType {Id = 3, TestCount = 1, GroupingProperty = "GP2", GroupingProperty2 = "Group3"},
-                new FactType {Id = 4, TestCount = 1, GroupingProperty = "GP1", GroupingProperty2 = "Group2"}
-            };
-            var factsToUpdate = new object[]
-            {
-                new FactType {Id = 1, TestCount = 2, GroupingProperty = "GP1", GroupingProperty2 = "Group"},
-                new FactType {Id = 2, TestCount = 3, GroupingProperty = "GP2", GroupingProperty2 = "Group"},
-                new FactType {Id = 3, TestCount = 1, GroupingProperty = "GP2", GroupingProperty2 = "Group"},
-                new FactType {Id = 4, TestCount = 1, GroupingProperty = "GP1", GroupingProperty2 = "Group"}
-            };
-            Session.InsertAll(factsToInsert);
-            Session.UpdateAll(factsToUpdate);
+            new FactType {Id = 1, TestCount = 1, GroupingProperty = "GP1", GroupingProperty2 = "Group"},
+            new FactType {Id = 2, TestCount = 1, GroupingProperty = "GP2", GroupingProperty2 = "Group"},
+            new FactType {Id = 3, TestCount = 1, GroupingProperty = "GP2", GroupingProperty2 = "Group3"},
+            new FactType {Id = 4, TestCount = 1, GroupingProperty = "GP1", GroupingProperty2 = "Group2"}
+        };
+        var factsToUpdate = new object[]
+        {
+            new FactType {Id = 1, TestCount = 2, GroupingProperty = "GP1", GroupingProperty2 = "Group"},
+            new FactType {Id = 2, TestCount = 3, GroupingProperty = "GP2", GroupingProperty2 = "Group"},
+            new FactType {Id = 3, TestCount = 1, GroupingProperty = "GP2", GroupingProperty2 = "Group"},
+            new FactType {Id = 4, TestCount = 1, GroupingProperty = "GP1", GroupingProperty2 = "Group"}
+        };
+        Session.InsertAll(factsToInsert);
+        Session.UpdateAll(factsToUpdate);
 
-            //Act
-            Session.Fire();
+        //Act
+        Session.Fire();
 
-            //Assert
-            AssertFiredOnce();
-            var firedFacts = GetFiredFact<IGrouping<string, FactType>>();
-            Assert.Equal(4, firedFacts.Count());
-            Assert.Equal(1, firedFacts.Count(x => x.TestCount == 3));
-            Assert.Equal(1, firedFacts.Count(x => x.TestCount == 2));
-            Assert.Equal(2, firedFacts.Count(x => x.TestCount == 1));
+        //Assert
+        AssertFiredOnce();
+        var firedFacts = GetFiredFact<IGrouping<string, FactType>>();
+        Assert.Equal(4, firedFacts.Count());
+        Assert.Equal(1, firedFacts.Count(x => x.TestCount == 3));
+        Assert.Equal(1, firedFacts.Count(x => x.TestCount == 2));
+        Assert.Equal(2, firedFacts.Count(x => x.TestCount == 1));
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType : IEquatable<FactType>
+    {
+        public long Id { get; set; }
+        public int TestCount { get; set; }
+        public string GroupingProperty { get; set; }
+        public string GroupingProperty2 { get; set; }
+
+        public bool Equals(FactType other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Id == other.Id;
         }
 
-        protected override void SetUpRules()
+        public override bool Equals(object obj)
         {
-            SetUpRule<TestRule>();
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((FactType) obj);
         }
 
-        public class FactType : IEquatable<FactType>
+        public override int GetHashCode()
         {
-            public long Id { get; set; }
-            public int TestCount { get; set; }
-            public string GroupingProperty { get; set; }
-            public string GroupingProperty2 { get; set; }
-
-            public bool Equals(FactType other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return Id == other.Id;
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((FactType) obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return Id.GetHashCode();
-            }
+            return Id.GetHashCode();
         }
+    }
 
-        public class TestRule : Rule
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            public override void Define()
-            {
-                IEnumerable<FactType> facts = null;
+            IEnumerable<FactType> facts = null;
 
-                When()
-                    .Query(() => facts, q => q
-                        .Match<FactType>(f => f.Id != 0)
-                        .GroupBy(f => f.GroupingProperty)
-                        .Where(x => x.Select(xx => xx.Id).Distinct().Count() > 1)
-                        .SelectMany(x => x)
-                        .GroupBy(x => x.GroupingProperty2));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => facts, q => q
+                    .Match<FactType>(f => f.Id != 0)
+                    .GroupBy(f => f.GroupingProperty)
+                    .Where(x => x.Select(xx => xx.Id).Distinct().Count() > 1)
+                    .SelectMany(x => x)
+                    .GroupBy(x => x.GroupingProperty2));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactOneGroupByRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactOneGroupByRuleTest.cs
@@ -5,235 +5,234 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactOneGroupByRuleTest : BaseRuleTestFixture
 {
-    public class OneFactOneGroupByRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_NoMatchingFacts_DoesNotFire()
     {
-        [Fact]
-        public void Fire_NoMatchingFacts_DoesNotFire()
+        //Arrange - Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndOneForAnother_FiresOnceWithTwoFactsInOneGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+
+        var facts = new[] {fact1, fact2, fact3};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<IGrouping<long, string>>().Count());
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndTwoForAnother_FiresTwiceWithTwoFactsInEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+        var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+
+        var facts = new[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(2, GetFiredFact<IGrouping<long, string>>(0).Count());
+        Assert.Equal(2, GetFiredFact<IGrouping<long, string>>(1).Count());
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneRetracted_FiresOnceWithTwoFactsInOneGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+        var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+
+        var facts = new[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        Session.Retract(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<IGrouping<long, string>>().Count());
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneUpdatedToInvalid_FiresOnceWithTwoFactsInOneGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+        var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+
+        var facts = new[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact4.TestProperty = "Invalid Value";
+        Session.Update(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<IGrouping<long, string>>().Count());
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneUpdatedToFirstGroup_FiresOnceWithThreeFactsInOneGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+        var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+
+        var facts = new[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact4.GroupProperty = 1;
+        Session.Update(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        var actual = GetFiredFact<IGrouping<long, string>>().Count();
+        Assert.Equal(3, actual);
+    }
+
+    [Fact]
+    public void Fire_TwoFactsForOneGroupAndOneForAnotherAndOneInvalidTheInvalidUpdatedToSecondGroup_FiresTwiceWithTwoFactsInEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+        var fact4 = new FactType {GroupProperty = 2, TestProperty = "Invalid Value"};
+
+        var facts = new[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact4.TestProperty = "Valid Value";
+        Session.Update(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(2, GetFiredFact<IGrouping<long, string>>(0).Count());
+        Assert.Equal(2, GetFiredFact<IGrouping<long, string>>(1).Count());
+    }
+    
+    [Fact]
+    public void Fire_TwoFactGroupsKeyChangedGroupRemovedAndReAddedThenNewFactInserted_FiresTwiceWithFactsInEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+
+        var facts = new[] {fact1, fact2, fact3};
+        Session.InsertAll(facts);
+
+        fact1.GroupProperty = 2;
+        fact3.GroupProperty = 1;
+        Session.UpdateAll(new object[] {fact1, fact3});
+
+        var fact4 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        Session.Insert(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(2, GetFiredFact<IGrouping<long, string>>(0).Count());
+        Assert.Equal(2, GetFiredFact<IGrouping<long, string>>(1).Count());
+    }
+
+    [Fact]
+    public void Fire_TwoFactsOneGroupAnotherFactFilteredOut_FiresOnceAggregateHasSource()
+    {
+        //Arrange
+        IFact matchedGroup = null;
+        Session.Events.RuleFiredEvent += (sender, args) =>
         {
-            //Arrange - Act
-            Session.Fire();
+            matchedGroup = args.Facts.Single();
+        };
 
-            //Assert
-            AssertDidNotFire();
-        }
+        var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
+        var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
 
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndOneForAnother_FiresOnceWithTwoFactsInOneGroup()
+        var facts = new[] {fact1, fact2, fact3};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.NotNull(matchedGroup);
+        Assert.NotNull(matchedGroup.Source);
+        Assert.Equal(FactSourceType.Aggregate, matchedGroup.Source.SourceType);
+        Assert.Collection(matchedGroup.Source.Facts,
+            item => Assert.Same(fact1, item.Value),
+            item => Assert.Same(fact2, item.Value));
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public long GroupProperty { get; set; }
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
+            IEnumerable<string> group = null;
 
-            var facts = new[] {fact1, fact2, fact3};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<IGrouping<long, string>>().Count());
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndTwoForAnother_FiresTwiceWithTwoFactsInEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-            var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-
-            var facts = new[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(2, GetFiredFact<IGrouping<long, string>>(0).Count());
-            Assert.Equal(2, GetFiredFact<IGrouping<long, string>>(1).Count());
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneRetracted_FiresOnceWithTwoFactsInOneGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-            var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-
-            var facts = new[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            Session.Retract(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<IGrouping<long, string>>().Count());
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneUpdatedToInvalid_FiresOnceWithTwoFactsInOneGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-            var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-
-            var facts = new[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact4.TestProperty = "Invalid Value";
-            Session.Update(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<IGrouping<long, string>>().Count());
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndTwoForAnotherOneUpdatedToFirstGroup_FiresOnceWithThreeFactsInOneGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-            var fact4 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-
-            var facts = new[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact4.GroupProperty = 1;
-            Session.Update(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            var actual = GetFiredFact<IGrouping<long, string>>().Count();
-            Assert.Equal(3, actual);
-        }
-
-        [Fact]
-        public void Fire_TwoFactsForOneGroupAndOneForAnotherAndOneInvalidTheInvalidUpdatedToSecondGroup_FiresTwiceWithTwoFactsInEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-            var fact4 = new FactType {GroupProperty = 2, TestProperty = "Invalid Value"};
-
-            var facts = new[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact4.TestProperty = "Valid Value";
-            Session.Update(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(2, GetFiredFact<IGrouping<long, string>>(0).Count());
-            Assert.Equal(2, GetFiredFact<IGrouping<long, string>>(1).Count());
-        }
-        
-        [Fact]
-        public void Fire_TwoFactGroupsKeyChangedGroupRemovedAndReAddedThenNewFactInserted_FiresTwiceWithFactsInEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-
-            var facts = new[] {fact1, fact2, fact3};
-            Session.InsertAll(facts);
-
-            fact1.GroupProperty = 2;
-            fact3.GroupProperty = 1;
-            Session.UpdateAll(new object[] {fact1, fact3});
-
-            var fact4 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            Session.Insert(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(2, GetFiredFact<IGrouping<long, string>>(0).Count());
-            Assert.Equal(2, GetFiredFact<IGrouping<long, string>>(1).Count());
-        }
-
-        [Fact]
-        public void Fire_TwoFactsOneGroupAnotherFactFilteredOut_FiresOnceAggregateHasSource()
-        {
-            //Arrange
-            IFact matchedGroup = null;
-            Session.Events.RuleFiredEvent += (sender, args) =>
-            {
-                matchedGroup = args.Facts.Single();
-            };
-
-            var fact1 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact2 = new FactType {GroupProperty = 1, TestProperty = "Valid Value"};
-            var fact3 = new FactType {GroupProperty = 2, TestProperty = "Valid Value"};
-
-            var facts = new[] {fact1, fact2, fact3};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.NotNull(matchedGroup);
-            Assert.NotNull(matchedGroup.Source);
-            Assert.Equal(FactSourceType.Aggregate, matchedGroup.Source.SourceType);
-            Assert.Collection(matchedGroup.Source.Facts,
-                item => Assert.Same(fact1, item.Value),
-                item => Assert.Same(fact2, item.Value));
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public long GroupProperty { get; set; }
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                IEnumerable<string> group = null;
-
-                When()
-                    .Query(() => group, x => x
-                        .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
-                        .GroupBy(f => f.GroupProperty, f => f.TestProperty)
-                        .Where(g => g.Count() > 1));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => group, x => x
+                    .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
+                    .GroupBy(f => f.GroupProperty, f => f.TestProperty)
+                    .Where(g => g.Count() > 1));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactOneMultiKeySortedCollectionAscendingThenDescendingRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactOneMultiKeySortedCollectionAscendingThenDescendingRuleTest.cs
@@ -4,196 +4,195 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactOneMultiKeySortedCollectionDescendingThenAscendingRuleTest : BaseRuleTestFixture
 {
-    public class OneFactOneMultiKeySortedCollectionDescendingThenAscendingRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_NoMatchingFacts_FiresOnceWithEmptyCollection()
     {
-        [Fact]
-        public void Fire_NoMatchingFacts_FiresOnceWithEmptyCollection()
-        {
-            // Arrange - Act
-            Session.Fire();
+        // Arrange - Act
+        Session.Fire();
 
-            // Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
+        // Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_FourMatchingFactsAndOneInvalid_FiresOnceWithFourSortedFactsInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType(0, null);
+        var fact2 = new FactType(50, "A");
+        var fact3 = new FactType(10, "A");
+        var fact4 = new FactType(50, "B");
+        var fact5 = new FactType(10, "B");
+
+        var facts = new[] { fact1, fact2, fact3, fact4, fact5 };
+        Session.InsertAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(4, firedFacts.Count());
+        Assert.Equal(fact2, firedFacts.ElementAt(0));
+        Assert.Equal(fact4, firedFacts.ElementAt(1));
+        Assert.Equal(fact3, firedFacts.ElementAt(2));
+        Assert.Equal(fact5, firedFacts.ElementAt(3));
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithTwoSortedFactsInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType(0, "B");
+        var fact2 = new FactType(10, "A");
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        fact1.TestPropertyInt = 10;
+        Session.Update(fact1);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(2, firedFacts.Count());
+        Assert.Equal(fact2, firedFacts.ElementAt(0));
+        Assert.Equal(fact1, firedFacts.ElementAt(1));
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithOneFactInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType(5, "A");
+        var fact2 = new FactType(10, "A");
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+        Session.Retract(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Single(firedFacts);
+        Assert.Equal(fact1, firedFacts.ElementAt(0));
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedTwoRetracted_FiresOnceWithEmptyCollection()
+    {
+        // Arrange
+        var fact1 = new FactType(5, "A");
+        var fact2 = new FactType(10, "A");
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+        Session.Retract(fact1);
+        Session.Retract(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneUpdatedToInvalid_FiresOnceWithOneFactInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType(5, "A");
+        var fact2 = new FactType(10, "A");
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        fact2.TestPropertyInt = 0;
+        Session.Update(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Single(firedFacts);
+        Assert.Equal(fact1, firedFacts.ElementAt(0));
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactsAndOneInvalidInsertedTheInvalidUpdatedToValid_FiresOnceWithTwoSortedFactInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType(2, "A");
+        var fact2 = new FactType(0, "B");
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        fact2.TestPropertyInt = 2;
+        Session.Update(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(2, firedFacts.Count());
+        Assert.Equal(fact1, firedFacts.ElementAt(0));
+        Assert.Equal(fact2, firedFacts.ElementAt(1));
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public FactType(int testInt, string testString)
+        {
+            TestPropertyInt = testInt;
+            TestPropertyString = testString;
         }
 
-        [Fact]
-        public void Fire_FourMatchingFactsAndOneInvalid_FiresOnceWithFourSortedFactsInCollection()
+        public int TestPropertyInt { get; set; }
+        public string TestPropertyString { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            // Arrange
-            var fact1 = new FactType(0, null);
-            var fact2 = new FactType(50, "A");
-            var fact3 = new FactType(10, "A");
-            var fact4 = new FactType(50, "B");
-            var fact5 = new FactType(10, "B");
+            IEnumerable<FactType> collection = null;
 
-            var facts = new[] { fact1, fact2, fact3, fact4, fact5 };
-            Session.InsertAll(facts);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(4, firedFacts.Count());
-            Assert.Equal(fact2, firedFacts.ElementAt(0));
-            Assert.Equal(fact4, firedFacts.ElementAt(1));
-            Assert.Equal(fact3, firedFacts.ElementAt(2));
-            Assert.Equal(fact5, firedFacts.ElementAt(3));
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithTwoSortedFactsInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType(0, "B");
-            var fact2 = new FactType(10, "A");
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            fact1.TestPropertyInt = 10;
-            Session.Update(fact1);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(2, firedFacts.Count());
-            Assert.Equal(fact2, firedFacts.ElementAt(0));
-            Assert.Equal(fact1, firedFacts.ElementAt(1));
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithOneFactInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType(5, "A");
-            var fact2 = new FactType(10, "A");
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-            Session.Retract(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Single(firedFacts);
-            Assert.Equal(fact1, firedFacts.ElementAt(0));
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedTwoRetracted_FiresOnceWithEmptyCollection()
-        {
-            // Arrange
-            var fact1 = new FactType(5, "A");
-            var fact2 = new FactType(10, "A");
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-            Session.Retract(fact1);
-            Session.Retract(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneUpdatedToInvalid_FiresOnceWithOneFactInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType(5, "A");
-            var fact2 = new FactType(10, "A");
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            fact2.TestPropertyInt = 0;
-            Session.Update(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Single(firedFacts);
-            Assert.Equal(fact1, firedFacts.ElementAt(0));
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactsAndOneInvalidInsertedTheInvalidUpdatedToValid_FiresOnceWithTwoSortedFactInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType(2, "A");
-            var fact2 = new FactType(0, "B");
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            fact2.TestPropertyInt = 2;
-            Session.Update(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(2, firedFacts.Count());
-            Assert.Equal(fact1, firedFacts.ElementAt(0));
-            Assert.Equal(fact2, firedFacts.ElementAt(1));
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public FactType(int testInt, string testString)
-            {
-                TestPropertyInt = testInt;
-                TestPropertyString = testString;
-            }
-
-            public int TestPropertyInt { get; set; }
-            public string TestPropertyString { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                IEnumerable<FactType> collection = null;
-
-                When()
-                    .Query(() => collection, x => x
-                        .Match<FactType>(f => f.TestPropertyInt > 0)
-                        .Collect()
-                        .OrderByDescending(f => f.TestPropertyInt)
-                        .ThenBy(f => f.TestPropertyString));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => collection, x => x
+                    .Match<FactType>(f => f.TestPropertyInt > 0)
+                    .Collect()
+                    .OrderByDescending(f => f.TestPropertyInt)
+                    .ThenBy(f => f.TestPropertyString));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactOneMultiKeySortedCollectionDescendingThenAscendingRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactOneMultiKeySortedCollectionDescendingThenAscendingRuleTest.cs
@@ -4,196 +4,195 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactOneMultiKeySortedCollectionAscendingThenDescendingRuleTest : BaseRuleTestFixture
 {
-    public class OneFactOneMultiKeySortedCollectionAscendingThenDescendingRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_NoMatchingFacts_FiresOnceWithEmptyCollection()
     {
-        [Fact]
-        public void Fire_NoMatchingFacts_FiresOnceWithEmptyCollection()
-        {
-            // Arrange - Act
-            Session.Fire();
+        // Arrange - Act
+        Session.Fire();
 
-            // Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
+        // Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_FourMatchingFactsAndOneInvalid_FiresOnceWithFourSortedFactsInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType(0, null);
+        var fact2 = new FactType(50, "A");
+        var fact3 = new FactType(10, "A");
+        var fact4 = new FactType(50, "B");
+        var fact5 = new FactType(10, "B");
+
+        var facts = new[] { fact1, fact2, fact3, fact4, fact5 };
+        Session.InsertAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(4, firedFacts.Count());
+        Assert.Equal(fact5, firedFacts.ElementAt(0));
+        Assert.Equal(fact3, firedFacts.ElementAt(1));
+        Assert.Equal(fact4, firedFacts.ElementAt(2));
+        Assert.Equal(fact2, firedFacts.ElementAt(3));
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithTwoSortedFactsInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType(0, "B");
+        var fact2 = new FactType(10, "A");
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        fact1.TestPropertyInt = 10;
+        Session.Update(fact1);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(2, firedFacts.Count());
+        Assert.Equal(fact1, firedFacts.ElementAt(0));
+        Assert.Equal(fact2, firedFacts.ElementAt(1));
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithOneFactInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType(5, "A");
+        var fact2 = new FactType(10, "A");
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+        Session.Retract(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Single(firedFacts);
+        Assert.Equal(fact1, firedFacts.ElementAt(0));
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedTwoRetracted_FiresOnceWithEmptyCollection()
+    {
+        // Arrange
+        var fact1 = new FactType(5, "A");
+        var fact2 = new FactType(10, "A");
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+        Session.Retract(fact1);
+        Session.Retract(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneUpdatedToInvalid_FiresOnceWithOneFactInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType(5, "A");
+        var fact2 = new FactType(10, "A");
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        fact2.TestPropertyInt = 0;
+        Session.Update(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Single(firedFacts);
+        Assert.Equal(fact1, firedFacts.ElementAt(0));
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactsAndOneInvalidInsertedTheInvalidUpdatedToValid_FiresOnceWithTwoSortedFactInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType(2, "A");
+        var fact2 = new FactType(0, "B");
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        fact2.TestPropertyInt = 2;
+        Session.Update(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(2, firedFacts.Count());
+        Assert.Equal(fact2, firedFacts.ElementAt(0));
+        Assert.Equal(fact1, firedFacts.ElementAt(1));
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public FactType(int testInt, string testString)
+        {
+            TestPropertyInt = testInt;
+            TestPropertyString = testString;
         }
 
-        [Fact]
-        public void Fire_FourMatchingFactsAndOneInvalid_FiresOnceWithFourSortedFactsInCollection()
+        public int TestPropertyInt { get; set; }
+        public string TestPropertyString { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            // Arrange
-            var fact1 = new FactType(0, null);
-            var fact2 = new FactType(50, "A");
-            var fact3 = new FactType(10, "A");
-            var fact4 = new FactType(50, "B");
-            var fact5 = new FactType(10, "B");
+            IEnumerable<FactType> collection = null;
 
-            var facts = new[] { fact1, fact2, fact3, fact4, fact5 };
-            Session.InsertAll(facts);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(4, firedFacts.Count());
-            Assert.Equal(fact5, firedFacts.ElementAt(0));
-            Assert.Equal(fact3, firedFacts.ElementAt(1));
-            Assert.Equal(fact4, firedFacts.ElementAt(2));
-            Assert.Equal(fact2, firedFacts.ElementAt(3));
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithTwoSortedFactsInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType(0, "B");
-            var fact2 = new FactType(10, "A");
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            fact1.TestPropertyInt = 10;
-            Session.Update(fact1);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(2, firedFacts.Count());
-            Assert.Equal(fact1, firedFacts.ElementAt(0));
-            Assert.Equal(fact2, firedFacts.ElementAt(1));
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithOneFactInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType(5, "A");
-            var fact2 = new FactType(10, "A");
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-            Session.Retract(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Single(firedFacts);
-            Assert.Equal(fact1, firedFacts.ElementAt(0));
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedTwoRetracted_FiresOnceWithEmptyCollection()
-        {
-            // Arrange
-            var fact1 = new FactType(5, "A");
-            var fact2 = new FactType(10, "A");
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-            Session.Retract(fact1);
-            Session.Retract(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneUpdatedToInvalid_FiresOnceWithOneFactInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType(5, "A");
-            var fact2 = new FactType(10, "A");
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            fact2.TestPropertyInt = 0;
-            Session.Update(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Single(firedFacts);
-            Assert.Equal(fact1, firedFacts.ElementAt(0));
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactsAndOneInvalidInsertedTheInvalidUpdatedToValid_FiresOnceWithTwoSortedFactInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType(2, "A");
-            var fact2 = new FactType(0, "B");
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            fact2.TestPropertyInt = 2;
-            Session.Update(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(2, firedFacts.Count());
-            Assert.Equal(fact2, firedFacts.ElementAt(0));
-            Assert.Equal(fact1, firedFacts.ElementAt(1));
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public FactType(int testInt, string testString)
-            {
-                TestPropertyInt = testInt;
-                TestPropertyString = testString;
-            }
-
-            public int TestPropertyInt { get; set; }
-            public string TestPropertyString { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                IEnumerable<FactType> collection = null;
-
-                When()
-                    .Query(() => collection, x => x
-                        .Match<FactType>(f => f.TestPropertyInt > 0)
-                        .Collect()
-                        .OrderBy(f => f.TestPropertyInt)
-                        .ThenByDescending(f => f.TestPropertyString));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => collection, x => x
+                    .Match<FactType>(f => f.TestPropertyInt > 0)
+                    .Collect()
+                    .OrderBy(f => f.TestPropertyInt)
+                    .ThenByDescending(f => f.TestPropertyString));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactOneMultiKeySortedCollectionManyChainedThenByRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactOneMultiKeySortedCollectionManyChainedThenByRuleTest.cs
@@ -4,113 +4,112 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactOneMultiKeySortedCollectionManyChainedThenByRuleTest : BaseRuleTestFixture
 {
-    public class OneFactOneMultiKeySortedCollectionManyChainedThenByRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_FourMatchingFactsAndOneInvalid_FiresOnceWithFourSortedFactsInCollection()
     {
-        [Fact]
-        public void Fire_FourMatchingFactsAndOneInvalid_FiresOnceWithFourSortedFactsInCollection()
+        // Arrange
+        var facts = new List<FactType>();
+        facts.Add(new FactType(0, 0, 0, 0, 0));
+        facts.Add(new FactType(0, 0, 0, 0, 1));
+        facts.Add(new FactType(0, 0, 0, 1, 0));
+        facts.Add(new FactType(0, 0, 0, 1, 1));
+        facts.Add(new FactType(0, 0, 1, 0, 0));
+        facts.Add(new FactType(0, 0, 1, 0, 1));
+        facts.Add(new FactType(0, 0, 1, 1, 0));
+        facts.Add(new FactType(0, 0, 1, 1, 1));
+        facts.Add(new FactType(0, 1, 0, 0, 0));
+        facts.Add(new FactType(0, 1, 0, 0, 1));
+        facts.Add(new FactType(0, 1, 0, 1, 0));
+        facts.Add(new FactType(0, 1, 0, 1, 1));
+        facts.Add(new FactType(0, 1, 1, 0, 0));
+        facts.Add(new FactType(0, 1, 1, 0, 1));
+        facts.Add(new FactType(0, 1, 1, 1, 0));
+        facts.Add(new FactType(0, 1, 1, 1, 1));
+        facts.Add(new FactType(1, 0, 0, 0, 0));
+        facts.Add(new FactType(1, 0, 0, 0, 1));
+        facts.Add(new FactType(1, 0, 0, 1, 0));
+        facts.Add(new FactType(1, 0, 0, 1, 1));
+        facts.Add(new FactType(1, 0, 1, 0, 0));
+        facts.Add(new FactType(1, 0, 1, 0, 1));
+        facts.Add(new FactType(1, 0, 1, 1, 0));
+        facts.Add(new FactType(1, 0, 1, 1, 1));
+        facts.Add(new FactType(1, 1, 0, 0, 0));
+        facts.Add(new FactType(1, 1, 0, 0, 1));
+        facts.Add(new FactType(1, 1, 0, 1, 0));
+        facts.Add(new FactType(1, 1, 0, 1, 1));
+        facts.Add(new FactType(1, 1, 1, 0, 0));
+        facts.Add(new FactType(1, 1, 1, 0, 1));
+        facts.Add(new FactType(1, 1, 1, 1, 0));
+        facts.Add(new FactType(1, 1, 1, 1, 1));
+
+        Session.InsertAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(32, firedFacts.Count());
+
+        var expectedOrder = facts
+            .OrderBy(f => f.TestPropertyInt1)
+            .ThenByDescending(f => f.TestPropertyInt2)
+            .ThenBy(f => f.TestPropertyInt3)
+            .ThenByDescending(f => f.TestPropertyInt4)
+            .ThenBy(f => f.TestPropertyInt5)
+            .ToArray();
+
+        for (int i = 0; i < expectedOrder.Length; i++)
         {
-            // Arrange
-            var facts = new List<FactType>();
-            facts.Add(new FactType(0, 0, 0, 0, 0));
-            facts.Add(new FactType(0, 0, 0, 0, 1));
-            facts.Add(new FactType(0, 0, 0, 1, 0));
-            facts.Add(new FactType(0, 0, 0, 1, 1));
-            facts.Add(new FactType(0, 0, 1, 0, 0));
-            facts.Add(new FactType(0, 0, 1, 0, 1));
-            facts.Add(new FactType(0, 0, 1, 1, 0));
-            facts.Add(new FactType(0, 0, 1, 1, 1));
-            facts.Add(new FactType(0, 1, 0, 0, 0));
-            facts.Add(new FactType(0, 1, 0, 0, 1));
-            facts.Add(new FactType(0, 1, 0, 1, 0));
-            facts.Add(new FactType(0, 1, 0, 1, 1));
-            facts.Add(new FactType(0, 1, 1, 0, 0));
-            facts.Add(new FactType(0, 1, 1, 0, 1));
-            facts.Add(new FactType(0, 1, 1, 1, 0));
-            facts.Add(new FactType(0, 1, 1, 1, 1));
-            facts.Add(new FactType(1, 0, 0, 0, 0));
-            facts.Add(new FactType(1, 0, 0, 0, 1));
-            facts.Add(new FactType(1, 0, 0, 1, 0));
-            facts.Add(new FactType(1, 0, 0, 1, 1));
-            facts.Add(new FactType(1, 0, 1, 0, 0));
-            facts.Add(new FactType(1, 0, 1, 0, 1));
-            facts.Add(new FactType(1, 0, 1, 1, 0));
-            facts.Add(new FactType(1, 0, 1, 1, 1));
-            facts.Add(new FactType(1, 1, 0, 0, 0));
-            facts.Add(new FactType(1, 1, 0, 0, 1));
-            facts.Add(new FactType(1, 1, 0, 1, 0));
-            facts.Add(new FactType(1, 1, 0, 1, 1));
-            facts.Add(new FactType(1, 1, 1, 0, 0));
-            facts.Add(new FactType(1, 1, 1, 0, 1));
-            facts.Add(new FactType(1, 1, 1, 1, 0));
-            facts.Add(new FactType(1, 1, 1, 1, 1));
+            Assert.Equal(expectedOrder[i], firedFacts.ElementAt(i));
+        }
+    }
 
-            Session.InsertAll(facts);
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
 
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(32, firedFacts.Count());
-
-            var expectedOrder = facts
-                .OrderBy(f => f.TestPropertyInt1)
-                .ThenByDescending(f => f.TestPropertyInt2)
-                .ThenBy(f => f.TestPropertyInt3)
-                .ThenByDescending(f => f.TestPropertyInt4)
-                .ThenBy(f => f.TestPropertyInt5)
-                .ToArray();
-
-            for (int i = 0; i < expectedOrder.Length; i++)
-            {
-                Assert.Equal(expectedOrder[i], firedFacts.ElementAt(i));
-            }
+    public class FactType
+    {
+        public FactType(int testInt1, int testInt2, int testInt3, int testInt4, int testInt5)
+        {
+            TestPropertyInt1 = testInt1;
+            TestPropertyInt2 = testInt2;
+            TestPropertyInt3 = testInt3;
+            TestPropertyInt4 = testInt4;
+            TestPropertyInt5 = testInt5;
         }
 
-        protected override void SetUpRules()
+        public int TestPropertyInt1 { get; set; }
+        public int TestPropertyInt2 { get; set; }
+        public int TestPropertyInt3 { get; set; }
+        public int TestPropertyInt4 { get; set; }
+        public int TestPropertyInt5 { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            SetUpRule<TestRule>();
-        }
+            IEnumerable<FactType> collection = null;
 
-        public class FactType
-        {
-            public FactType(int testInt1, int testInt2, int testInt3, int testInt4, int testInt5)
-            {
-                TestPropertyInt1 = testInt1;
-                TestPropertyInt2 = testInt2;
-                TestPropertyInt3 = testInt3;
-                TestPropertyInt4 = testInt4;
-                TestPropertyInt5 = testInt5;
-            }
-
-            public int TestPropertyInt1 { get; set; }
-            public int TestPropertyInt2 { get; set; }
-            public int TestPropertyInt3 { get; set; }
-            public int TestPropertyInt4 { get; set; }
-            public int TestPropertyInt5 { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                IEnumerable<FactType> collection = null;
-
-                When()
-                    .Query(() => collection, x => x
-                        .Match<FactType>()
-                        .Collect()
-                        .OrderBy(f => f.TestPropertyInt1)
-                        .ThenByDescending(f => f.TestPropertyInt2)
-                        .ThenBy(f => f.TestPropertyInt3)
-                        .ThenByDescending(f => f.TestPropertyInt4)
-                        .ThenBy(f => f.TestPropertyInt5));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => collection, x => x
+                    .Match<FactType>()
+                    .Collect()
+                    .OrderBy(f => f.TestPropertyInt1)
+                    .ThenByDescending(f => f.TestPropertyInt2)
+                    .ThenBy(f => f.TestPropertyInt3)
+                    .ThenByDescending(f => f.TestPropertyInt4)
+                    .ThenBy(f => f.TestPropertyInt5));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactOneNotRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactOneNotRuleTest.cs
@@ -2,89 +2,88 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactOneNotRuleTest : BaseRuleTestFixture
 {
-    public class OneFactOneNotRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchingNotPatternFact_DoesNotFire()
     {
-        [Fact]
-        public void Fire_MatchingNotPatternFact_DoesNotFire()
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+    
+    [Fact]
+    public void Fire_MatchingNotPatternFactAssertedThenRetracted_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+        Session.Retract(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+    
+    [Fact]
+    public void Fire_MatchingNotPatternFactAssertedThenUpdatedToInvalid_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+
+        fact1.TestProperty = "Invalid Value 1";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_NoFactMatchingNotPattern_FiresOnce()
+    {
+        //Arrange
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-        
-        [Fact]
-        public void Fire_MatchingNotPatternFactAssertedThenRetracted_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-            Session.Retract(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-        
-        [Fact]
-        public void Fire_MatchingNotPatternFactAssertedThenUpdatedToInvalid_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-
-            fact1.TestProperty = "Invalid Value 1";
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_NoFactMatchingNotPattern_FiresOnce()
-        {
-            //Arrange
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                When()
-                    .Not<FactType>(f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Not<FactType>(f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactOneSelectRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactOneSelectRuleTest.cs
@@ -3,194 +3,193 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactOneSelectRuleTest : BaseRuleTestFixture
 {
-    public class OneFactOneSelectRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFact_FiresOnce()
     {
-        [Fact]
-        public void Fire_OneMatchingFact_FiresOnce()
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(fact.TestProperty, GetFiredFact<FactProjection>().Value);
+    }
+    
+    [Fact]
+    public void Fire_OneMatchingFactInsertedThenUpdated_FiresOnce()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+        Session.Update(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(fact.TestProperty, GetFiredFact<FactProjection>().Value);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFacts_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(fact1.TestProperty, GetFiredFact<FactProjection>(0).Value);
+        Assert.Equal(fact2.TestProperty, GetFiredFact<FactProjection>(1).Value);
+    }
+
+    [Fact]
+    public void Fire_ConditionDoesNotMatch_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Invalid Value 1"};
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+        Session.Retract(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneFactUpdatedFromInvalidToMatching_FiresOnce()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Invalid Value 1"};
+        Session.Insert(fact);
+
+        fact.TestProperty = "Valid Value 1";
+        Session.Update(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(fact.TestProperty, GetFiredFact<FactProjection>().Value);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndRetractedAndAssertedAgain_FiresOnce()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+        Session.Retract(fact);
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(fact.TestProperty, GetFiredFact<FactProjection>().Value);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndUpdatedToInvalid_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+
+        fact.TestProperty = "Invalid Value 1";
+        Session.Update(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactProjection : IEquatable<FactProjection>
+    {
+        public FactProjection(FactType fact)
         {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(fact.TestProperty, GetFiredFact<FactProjection>().Value);
-        }
-        
-        [Fact]
-        public void Fire_OneMatchingFactInsertedThenUpdated_FiresOnce()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
-            Session.Update(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(fact.TestProperty, GetFiredFact<FactProjection>().Value);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFacts_FiresTwice()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(fact1.TestProperty, GetFiredFact<FactProjection>(0).Value);
-            Assert.Equal(fact2.TestProperty, GetFiredFact<FactProjection>(1).Value);
-        }
-
-        [Fact]
-        public void Fire_ConditionDoesNotMatch_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Invalid Value 1"};
-            Session.Insert(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactAssertedAndRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
-            Session.Retract(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_OneFactUpdatedFromInvalidToMatching_FiresOnce()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Invalid Value 1"};
-            Session.Insert(fact);
-
-            fact.TestProperty = "Valid Value 1";
-            Session.Update(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(fact.TestProperty, GetFiredFact<FactProjection>().Value);
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactAssertedAndRetractedAndAssertedAgain_FiresOnce()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
-            Session.Retract(fact);
-            Session.Insert(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(fact.TestProperty, GetFiredFact<FactProjection>().Value);
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactAssertedAndUpdatedToInvalid_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
-
-            fact.TestProperty = "Invalid Value 1";
-            Session.Update(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactProjection : IEquatable<FactProjection>
-        {
-            public FactProjection(FactType fact)
-            {
-                Value = fact.TestProperty;
-            }
-
-            public string Value { get; }
-
-            public bool Equals(FactProjection other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return string.Equals(Value, other.Value);
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((FactProjection)obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return (Value != null ? Value.GetHashCode() : 0);
-            }
+            Value = fact.TestProperty;
         }
 
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactProjection projection = null;
+        public string Value { get; }
 
-                When()
-                    .Query(() => projection, x => x
-                        .Match<FactType>()
-                        .Select(f => new FactProjection(f))
-                        .Where(p => p.Value.StartsWith("Valid")));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+        public bool Equals(FactProjection other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(Value, other.Value);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((FactProjection)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Value != null ? Value.GetHashCode() : 0);
+        }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
+        {
+            FactProjection projection = null;
+
+            When()
+                .Query(() => projection, x => x
+                    .Match<FactType>()
+                    .Select(f => new FactProjection(f))
+                    .Where(p => p.Value.StartsWith("Valid")));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactOneSortedCollectionRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactOneSortedCollectionRuleTest.cs
@@ -4,212 +4,211 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactOneSortedCollectionRuleTest : BaseRuleTestFixture
 {
-    public class OneFactOneSortedCollectionRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_NoMatchingFacts_FiresOnceWithEmptyCollection()
     {
-        [Fact]
-        public void Fire_NoMatchingFacts_FiresOnceWithEmptyCollection()
+        // Arrange - Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsAndOneInvalid_FiresOnceWithTwoSortedFactsInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 0 };
+        var fact2 = new FactType { TestProperty = 10 };
+        var fact3 = new FactType { TestProperty = 5 };
+
+        var facts = new[] { fact1, fact2, fact3 };
+        Session.InsertAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(2, firedFacts.Count());
+        Assert.Equal(fact3, firedFacts.ElementAt(0));
+        Assert.Equal(fact2, firedFacts.ElementAt(1));
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithTwoSortedFactsInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 0 };
+        var fact2 = new FactType { TestProperty = 10 };
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        fact1.TestProperty = 5;
+        Session.Update(fact1);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(2, firedFacts.Count());
+        Assert.Equal(fact1, firedFacts.ElementAt(0));
+        Assert.Equal(fact2, firedFacts.ElementAt(1));
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithOneFactInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 10 };
+        var fact2 = new FactType { TestProperty = 5 };
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+        Session.Retract(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Single(firedFacts);
+        Assert.Equal(fact1, firedFacts.ElementAt(0));
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedTwoRetracted_FiresOnceWithEmptyCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 10 };
+        var fact2 = new FactType { TestProperty = 5 };
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+        Session.Retract(fact1);
+        Session.Retract(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneUpdatedToInvalid_FiresOnceWithOneFactInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 10 };
+        var fact2 = new FactType { TestProperty = 5 };
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        fact2.TestProperty = 0;
+        Session.Update(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Single(firedFacts);
+        Assert.Equal(fact1, firedFacts.ElementAt(0));
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactsAndOneInvalidInsertedTheInvalidUpdatedToValid_FiresOnceWithTwoSortedFactInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 2 };
+        var fact2 = new FactType { TestProperty = 0 };
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        fact2.TestProperty = 1;
+        Session.Update(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(2, firedFacts.Count());
+        Assert.Equal(fact2, firedFacts.ElementAt(0));
+        Assert.Equal(fact1, firedFacts.ElementAt(1));
+    }
+
+    [Fact]
+    public void Fire_FiveMatchingFactsInserted_FiresOnceWithFiveSortedFactsInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 3 };
+        var fact2 = new FactType { TestProperty = 5 };
+        var fact3 = new FactType { TestProperty = 1 };
+        var fact4 = new FactType { TestProperty = 4 };
+        var fact5 = new FactType { TestProperty = 2 };
+
+        var facts = new[] { fact1, fact2, fact3, fact4, fact5 };
+        Session.InsertAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(5, firedFacts.Count());
+        Assert.Equal(fact3, firedFacts.ElementAt(0));
+        Assert.Equal(fact5, firedFacts.ElementAt(1));
+        Assert.Equal(fact1, firedFacts.ElementAt(2));
+        Assert.Equal(fact4, firedFacts.ElementAt(3));
+        Assert.Equal(fact2, firedFacts.ElementAt(4));
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public int TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            // Arrange - Act
-            Session.Fire();
+            IEnumerable<FactType> collection = null;
 
-            // Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsAndOneInvalid_FiresOnceWithTwoSortedFactsInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 0 };
-            var fact2 = new FactType { TestProperty = 10 };
-            var fact3 = new FactType { TestProperty = 5 };
-
-            var facts = new[] { fact1, fact2, fact3 };
-            Session.InsertAll(facts);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(2, firedFacts.Count());
-            Assert.Equal(fact3, firedFacts.ElementAt(0));
-            Assert.Equal(fact2, firedFacts.ElementAt(1));
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithTwoSortedFactsInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 0 };
-            var fact2 = new FactType { TestProperty = 10 };
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            fact1.TestProperty = 5;
-            Session.Update(fact1);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(2, firedFacts.Count());
-            Assert.Equal(fact1, firedFacts.ElementAt(0));
-            Assert.Equal(fact2, firedFacts.ElementAt(1));
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithOneFactInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 10 };
-            var fact2 = new FactType { TestProperty = 5 };
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-            Session.Retract(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Single(firedFacts);
-            Assert.Equal(fact1, firedFacts.ElementAt(0));
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedTwoRetracted_FiresOnceWithEmptyCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 10 };
-            var fact2 = new FactType { TestProperty = 5 };
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-            Session.Retract(fact1);
-            Session.Retract(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneUpdatedToInvalid_FiresOnceWithOneFactInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 10 };
-            var fact2 = new FactType { TestProperty = 5 };
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            fact2.TestProperty = 0;
-            Session.Update(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Single(firedFacts);
-            Assert.Equal(fact1, firedFacts.ElementAt(0));
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactsAndOneInvalidInsertedTheInvalidUpdatedToValid_FiresOnceWithTwoSortedFactInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 2 };
-            var fact2 = new FactType { TestProperty = 0 };
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            fact2.TestProperty = 1;
-            Session.Update(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(2, firedFacts.Count());
-            Assert.Equal(fact2, firedFacts.ElementAt(0));
-            Assert.Equal(fact1, firedFacts.ElementAt(1));
-        }
-
-        [Fact]
-        public void Fire_FiveMatchingFactsInserted_FiresOnceWithFiveSortedFactsInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 3 };
-            var fact2 = new FactType { TestProperty = 5 };
-            var fact3 = new FactType { TestProperty = 1 };
-            var fact4 = new FactType { TestProperty = 4 };
-            var fact5 = new FactType { TestProperty = 2 };
-
-            var facts = new[] { fact1, fact2, fact3, fact4, fact5 };
-            Session.InsertAll(facts);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(5, firedFacts.Count());
-            Assert.Equal(fact3, firedFacts.ElementAt(0));
-            Assert.Equal(fact5, firedFacts.ElementAt(1));
-            Assert.Equal(fact1, firedFacts.ElementAt(2));
-            Assert.Equal(fact4, firedFacts.ElementAt(3));
-            Assert.Equal(fact2, firedFacts.ElementAt(4));
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public int TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                IEnumerable<FactType> collection = null;
-
-                When()
-                    .Query(() => collection, x => x
-                        .Match<FactType>(f => f.TestProperty > 0)
-                        .Collect()
-                        .OrderBy(f => f.TestProperty));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => collection, x => x
+                    .Match<FactType>(f => f.TestProperty > 0)
+                    .Collect()
+                    .OrderBy(f => f.TestProperty));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactOneSortedDescendingCollectionRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactOneSortedDescendingCollectionRuleTest.cs
@@ -4,212 +4,211 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactOneSortedDescendingCollectionRuleTest : BaseRuleTestFixture
 {
-    public class OneFactOneSortedDescendingCollectionRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_NoMatchingFacts_FiresOnceWithEmptyCollection()
     {
-        [Fact]
-        public void Fire_NoMatchingFacts_FiresOnceWithEmptyCollection()
+        // Arrange - Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsAndOneInvalid_FiresOnceWithTwoSortedFactsInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 0 };
+        var fact2 = new FactType { TestProperty = 10 };
+        var fact3 = new FactType { TestProperty = 5 };
+
+        var facts = new[] { fact1, fact2, fact3 };
+        Session.InsertAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(2, firedFacts.Count());
+        Assert.Equal(fact2, firedFacts.ElementAt(0));
+        Assert.Equal(fact3, firedFacts.ElementAt(1));
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithTwoSortedFactsInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 0 };
+        var fact2 = new FactType { TestProperty = 10 };
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        fact1.TestProperty = 5;
+        Session.Update(fact1);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(2, firedFacts.Count());
+        Assert.Equal(fact2, firedFacts.ElementAt(0));
+        Assert.Equal(fact1, firedFacts.ElementAt(1));
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithOneFactInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 10 };
+        var fact2 = new FactType { TestProperty = 5 };
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+        Session.Retract(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Single(firedFacts);
+        Assert.Equal(fact1, firedFacts.ElementAt(0));
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedTwoRetracted_FiresOnceWithEmptyCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 10 };
+        var fact2 = new FactType { TestProperty = 5 };
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+        Session.Retract(fact1);
+        Session.Retract(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsInsertedOneUpdatedToInvalid_FiresOnceWithOneFactInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 10 };
+        var fact2 = new FactType { TestProperty = 5 };
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        fact2.TestProperty = 0;
+        Session.Update(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Single(firedFacts);
+        Assert.Equal(fact1, firedFacts.ElementAt(0));
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactsAndOneInvalidInsertedTheInvalidUpdatedToValid_FiresOnceWithTwoSortedFactInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 2 };
+        var fact2 = new FactType { TestProperty = 0 };
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        fact2.TestProperty = 1;
+        Session.Update(fact2);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(2, firedFacts.Count());
+        Assert.Equal(fact1, firedFacts.ElementAt(0));
+        Assert.Equal(fact2, firedFacts.ElementAt(1));
+    }
+
+    [Fact]
+    public void Fire_FiveMatchingFactsInserted_FiresOnceWithFiveSortedFactsInCollection()
+    {
+        // Arrange
+        var fact1 = new FactType { TestProperty = 3 };
+        var fact2 = new FactType { TestProperty = 5 };
+        var fact3 = new FactType { TestProperty = 1 };
+        var fact4 = new FactType { TestProperty = 4 };
+        var fact5 = new FactType { TestProperty = 2 };
+
+        var facts = new[] { fact1, fact2, fact3, fact4, fact5 };
+        Session.InsertAll(facts);
+
+        // Act
+        Session.Fire();
+
+        // Assert
+        AssertFiredOnce();
+
+        var firedFacts = GetFiredFact<IEnumerable<FactType>>();
+        Assert.Equal(5, firedFacts.Count());
+        Assert.Equal(fact2, firedFacts.ElementAt(0));
+        Assert.Equal(fact4, firedFacts.ElementAt(1));
+        Assert.Equal(fact1, firedFacts.ElementAt(2));
+        Assert.Equal(fact5, firedFacts.ElementAt(3));
+        Assert.Equal(fact3, firedFacts.ElementAt(4));
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public int TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            // Arrange - Act
-            Session.Fire();
+            IEnumerable<FactType> collection = null;
 
-            // Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsAndOneInvalid_FiresOnceWithTwoSortedFactsInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 0 };
-            var fact2 = new FactType { TestProperty = 10 };
-            var fact3 = new FactType { TestProperty = 5 };
-
-            var facts = new[] { fact1, fact2, fact3 };
-            Session.InsertAll(facts);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(2, firedFacts.Count());
-            Assert.Equal(fact2, firedFacts.ElementAt(0));
-            Assert.Equal(fact3, firedFacts.ElementAt(1));
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneUpdated_FiresOnceWithTwoSortedFactsInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 0 };
-            var fact2 = new FactType { TestProperty = 10 };
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            fact1.TestProperty = 5;
-            Session.Update(fact1);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(2, firedFacts.Count());
-            Assert.Equal(fact2, firedFacts.ElementAt(0));
-            Assert.Equal(fact1, firedFacts.ElementAt(1));
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneRetracted_FiresOnceWithOneFactInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 10 };
-            var fact2 = new FactType { TestProperty = 5 };
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-            Session.Retract(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Single(firedFacts);
-            Assert.Equal(fact1, firedFacts.ElementAt(0));
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedTwoRetracted_FiresOnceWithEmptyCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 10 };
-            var fact2 = new FactType { TestProperty = 5 };
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-            Session.Retract(fact1);
-            Session.Retract(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<IEnumerable<FactType>>());
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsInsertedOneUpdatedToInvalid_FiresOnceWithOneFactInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 10 };
-            var fact2 = new FactType { TestProperty = 5 };
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            fact2.TestProperty = 0;
-            Session.Update(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Single(firedFacts);
-            Assert.Equal(fact1, firedFacts.ElementAt(0));
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactsAndOneInvalidInsertedTheInvalidUpdatedToValid_FiresOnceWithTwoSortedFactInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 2 };
-            var fact2 = new FactType { TestProperty = 0 };
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            fact2.TestProperty = 1;
-            Session.Update(fact2);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(2, firedFacts.Count());
-            Assert.Equal(fact1, firedFacts.ElementAt(0));
-            Assert.Equal(fact2, firedFacts.ElementAt(1));
-        }
-
-        [Fact]
-        public void Fire_FiveMatchingFactsInserted_FiresOnceWithFiveSortedFactsInCollection()
-        {
-            // Arrange
-            var fact1 = new FactType { TestProperty = 3 };
-            var fact2 = new FactType { TestProperty = 5 };
-            var fact3 = new FactType { TestProperty = 1 };
-            var fact4 = new FactType { TestProperty = 4 };
-            var fact5 = new FactType { TestProperty = 2 };
-
-            var facts = new[] { fact1, fact2, fact3, fact4, fact5 };
-            Session.InsertAll(facts);
-
-            // Act
-            Session.Fire();
-
-            // Assert
-            AssertFiredOnce();
-
-            var firedFacts = GetFiredFact<IEnumerable<FactType>>();
-            Assert.Equal(5, firedFacts.Count());
-            Assert.Equal(fact2, firedFacts.ElementAt(0));
-            Assert.Equal(fact4, firedFacts.ElementAt(1));
-            Assert.Equal(fact1, firedFacts.ElementAt(2));
-            Assert.Equal(fact5, firedFacts.ElementAt(3));
-            Assert.Equal(fact3, firedFacts.ElementAt(4));
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public int TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                IEnumerable<FactType> collection = null;
-
-                When()
-                    .Query(() => collection, x => x
-                        .Match<FactType>(f => f.TestProperty > 0)
-                        .Collect()
-                        .OrderByDescending(f => f.TestProperty));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => collection, x => x
+                    .Match<FactType>(f => f.TestProperty > 0)
+                    .Collect()
+                    .OrderByDescending(f => f.TestProperty));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactRepeatableRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactRepeatableRuleTest.cs
@@ -3,67 +3,66 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactRepeatableRuleTest : BaseRuleTestFixture
 {
-    public class OneFactRepeatableRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFactEligibleForOneIncrement_FiresOnce()
     {
-        [Fact]
-        public void Fire_OneMatchingFactEligibleForOneIncrement_FiresOnce()
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1", TestCount = 2};
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+    
+    [Fact]
+    public void Fire_OneMatchingFactEligibleForTwoIncrements_FiresTwice()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1", TestCount = 1};
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+    
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+        public int TestCount { get; set; }
+
+        public void IncrementCount()
         {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1", TestCount = 2};
-            Session.Insert(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
+            TestCount++;
         }
-        
-        [Fact]
-        public void Fire_OneMatchingFactEligibleForTwoIncrements_FiresTwice()
+    }
+
+    [Repeatability(RuleRepeatability.Repeatable)]
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1", TestCount = 1};
-            Session.Insert(fact);
+            FactType fact = null;
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-        
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-            public int TestCount { get; set; }
-
-            public void IncrementCount()
-            {
-                TestCount++;
-            }
-        }
-
-        [Repeatability(RuleRepeatability.Repeatable)]
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"), f => f.TestCount <= 2);
-                Then()
-                    .Do(ctx => fact.IncrementCount())
-                    .Do(ctx => ctx.Update(fact));
-            }
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"), f => f.TestCount <= 2);
+            Then()
+                .Do(ctx => fact.IncrementCount())
+                .Do(ctx => ctx.Update(fact));
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactRetractingRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactRetractingRuleTest.cs
@@ -3,46 +3,45 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactRetractingRuleTest : BaseRuleTestFixture
 {
-    public class OneFactRetractingRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFact_FiresOnceAndRetractsFact()
     {
-        [Fact]
-        public void Fire_OneMatchingFact_FiresOnceAndRetractsFact()
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(0, Session.Query<FactType>().Count());
+    }
+    
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
+            FactType fact = null;
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(0, Session.Query<FactType>().Count());
-        }
-        
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.Retract(fact));
-            }
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.Retract(fact));
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactRuleTest.cs
@@ -3,249 +3,248 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactRuleTest : BaseRuleTestFixture
 {
-    public class OneFactRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFact_FiresOnce()
     {
-        [Fact]
-        public void Fire_OneMatchingFact_FiresOnce()
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFacts_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void Fire_ConditionDoesNotMatch_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Invalid Value 1"};
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+        Session.Retract(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneFactUpdatedFromInvalidToMatching_FiresOnce()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Invalid Value 1"};
+        Session.Insert(fact);
+
+        fact.TestProperty = "Valid Value 1";
+        Session.Update(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndRetractedAndAssertedAgain_FiresOnce()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+        Session.Retract(fact);
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndUpdatedToInvalid_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+
+        fact.TestProperty = "Invalid Value 1";
+        Session.Update(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndModifiedAndRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+
+        fact.TestProperty = "Invalid Value 1";
+        Session.Retract(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Insert_Null_Throws()
+    {
+        //Arrange - Act - Assert
+        Assert.Throws<ArgumentNullException>(() => Session.Insert(null));
+    }
+
+    [Fact]
+    public void Insert_DuplicateInsert_Throws()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+
+        //Act - Assert
+        Session.Insert(fact);
+        Assert.Throws<ArgumentException>(() => Session.Insert(fact));
+    }
+
+    [Fact]
+    public void TryInsert_DuplicateInsert_False()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+
+        //Act
+        Session.Insert(fact);
+        bool actual = Session.TryInsert(fact);
+
+        //Assert
+        Assert.False(actual);
+    }
+
+    [Fact]
+    public void Update_Null_Throws()
+    {
+        //Arrange - Act - Assert
+        Assert.Throws<ArgumentNullException>(() => Session.Update(null));
+    }
+
+    [Fact]
+    public void Update_UpdateWithoutInsert_Throws()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+
+        //Act - Assert
+        Assert.Throws<ArgumentException>(() => Session.Update(fact));
+    }
+
+    [Fact]
+    public void TryUpdate_UpdateWithoutInsert_False()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+
+        //Act
+        bool actual = Session.TryUpdate(fact);
+
+        //Assert
+        Assert.False(actual);
+    }
+
+    [Fact]
+    public void Retract_Null_Throws()
+    {
+        //Arrange - Act - Assert
+        Assert.Throws<ArgumentNullException>(() => Session.Retract(null));
+    }
+
+    [Fact]
+    public void Retract_RetractWithoutInsert_Throws()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+
+        //Act - Assert
+        Assert.Throws<ArgumentException>(() => Session.Retract(fact));
+    }
+
+    [Fact]
+    public void TryRetract_RetractWithoutInsert_False()
+    {
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+
+        //Act
+        bool actual = Session.TryRetract(fact);
+
+        //Assert
+        Assert.False(actual);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
+            FactType fact = null;
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFacts_FiresTwice()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        [Fact]
-        public void Fire_ConditionDoesNotMatch_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Invalid Value 1"};
-            Session.Insert(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactAssertedAndRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
-            Session.Retract(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_OneFactUpdatedFromInvalidToMatching_FiresOnce()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Invalid Value 1"};
-            Session.Insert(fact);
-
-            fact.TestProperty = "Valid Value 1";
-            Session.Update(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactAssertedAndRetractedAndAssertedAgain_FiresOnce()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
-            Session.Retract(fact);
-            Session.Insert(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactAssertedAndUpdatedToInvalid_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
-
-            fact.TestProperty = "Invalid Value 1";
-            Session.Update(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactAssertedAndModifiedAndRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
-
-            fact.TestProperty = "Invalid Value 1";
-            Session.Retract(fact);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Insert_Null_Throws()
-        {
-            //Arrange - Act - Assert
-            Assert.Throws<ArgumentNullException>(() => Session.Insert(null));
-        }
-
-        [Fact]
-        public void Insert_DuplicateInsert_Throws()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-
-            //Act - Assert
-            Session.Insert(fact);
-            Assert.Throws<ArgumentException>(() => Session.Insert(fact));
-        }
-
-        [Fact]
-        public void TryInsert_DuplicateInsert_False()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-
-            //Act
-            Session.Insert(fact);
-            bool actual = Session.TryInsert(fact);
-
-            //Assert
-            Assert.False(actual);
-        }
-
-        [Fact]
-        public void Update_Null_Throws()
-        {
-            //Arrange - Act - Assert
-            Assert.Throws<ArgumentNullException>(() => Session.Update(null));
-        }
-
-        [Fact]
-        public void Update_UpdateWithoutInsert_Throws()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-
-            //Act - Assert
-            Assert.Throws<ArgumentException>(() => Session.Update(fact));
-        }
-
-        [Fact]
-        public void TryUpdate_UpdateWithoutInsert_False()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-
-            //Act
-            bool actual = Session.TryUpdate(fact);
-
-            //Assert
-            Assert.False(actual);
-        }
-
-        [Fact]
-        public void Retract_Null_Throws()
-        {
-            //Arrange - Act - Assert
-            Assert.Throws<ArgumentNullException>(() => Session.Retract(null));
-        }
-
-        [Fact]
-        public void Retract_RetractWithoutInsert_Throws()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-
-            //Act - Assert
-            Assert.Throws<ArgumentException>(() => Session.Retract(fact));
-        }
-
-        [Fact]
-        public void TryRetract_RetractWithoutInsert_False()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-
-            //Act
-            bool actual = Session.TryRetract(fact);
-
-            //Assert
-            Assert.False(actual);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactRuleWithDependencyTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactRuleWithDependencyTest.cs
@@ -5,162 +5,161 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactRuleWithDependencyTest : BaseRuleTestFixture
 {
-    public class OneFactRuleWithDependencyTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_DefaultResolver_Throws()
     {
-        [Fact]
-        public void Fire_DefaultResolver_Throws()
-        {
-            //Arrange
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
+        //Arrange
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
 
-            //Act - Assert
-            var ex = Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
-            Assert.IsType<InvalidOperationException>(ex.InnerException);
+        //Act - Assert
+        var ex = Assert.Throws<RuleRhsExpressionEvaluationException>(() => Session.Fire());
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFact_FiresOnceAndCallsDependency()
+    {
+        //Arrange
+        var service1 = new TestService1();
+        bool service1Called = false;
+        service1.ServiceCalled += (sender, args) => service1Called = true;
+
+        var service2 = new TestService2();
+        bool service2Called = false;
+        service2.ServiceCalled += (sender, args) => service2Called = true;
+
+        Session.DependencyResolver = new TestDependencyResolver(service1, service2);
+
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.True(service1Called);
+        Assert.True(service2Called);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFact_CanResolveDependencyFromContext()
+    {
+        //Arrange
+        var service1 = new TestService1();
+        var service2 = new TestService2();
+        Session.DependencyResolver = new TestDependencyResolver(service1, service2);
+
+        var fact = new FactType {TestProperty = "Valid Value 1"};
+        Session.Insert(fact);
+
+        ITestService1 resolvedService1 = null;
+        GetRuleInstance<TestRule>().Action = ctx =>
+        {
+            resolvedService1 = ctx.Resolve<ITestService1>();
+        };
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Same(service1, resolvedService1);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public interface ITestService1
+    {
+        void Action(string value);
+    }
+
+    private class TestService1 : ITestService1
+    {
+        public event EventHandler ServiceCalled;
+
+        public void Action(string value)
+        {
+            ServiceCalled?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public interface ITestService2
+    {
+        void Action(string value);
+    }
+
+    private class TestService2 : ITestService2
+    {
+        public event EventHandler ServiceCalled;
+
+        public void Action(string value)
+        {
+            ServiceCalled?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    private class TestDependencyResolver : IDependencyResolver
+    {
+        private readonly TestService1 _service1;
+        private readonly TestService2 _service2;
+
+        public TestDependencyResolver(TestService1 service1, TestService2 service2)
+        {
+            _service1 = service1;
+            _service2 = service2;
         }
 
-        [Fact]
-        public void Fire_OneMatchingFact_FiresOnceAndCallsDependency()
+        public object Resolve(IResolutionContext context, Type serviceType)
         {
-            //Arrange
-            var service1 = new TestService1();
-            bool service1Called = false;
-            service1.ServiceCalled += (sender, args) => service1Called = true;
+            if (serviceType == typeof(ITestService1))
+                return _service1;
+            if (serviceType == typeof(ITestService2))
+                return _service2;
+            throw new ArgumentException();
+        }
+    }
 
-            var service2 = new TestService2();
-            bool service2Called = false;
-            service2.ServiceCalled += (sender, args) => service2Called = true;
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
 
-            Session.DependencyResolver = new TestDependencyResolver(service1, service2);
+    public class TestRule : Rule
+    {
+        public Action<IContext> Action = ctx => { };
 
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
+        public override void Define()
+        {
+            FactType fact = null;
+            ITestService1 service1 = null;
+            ITestService2 service2 = null;
 
-            //Act
-            Session.Fire();
+            Dependency()
+                .Resolve(() => service1)
+                .Resolve(() => service2);
 
-            //Assert
-            AssertFiredOnce();
-            Assert.True(service1Called);
-            Assert.True(service2Called);
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => Action(ctx))
+                .Do(ctx => service1.Action(fact.TestProperty))
+                .Do(ctx => service2.Action(fact.TestProperty))
+                .Do(ctx => SomeAction(fact, service1, service2));
         }
 
-        [Fact]
-        public void Fire_OneMatchingFact_CanResolveDependencyFromContext()
+        private void SomeAction(FactType fact, ITestService1 service1, ITestService2 service2)
         {
-            //Arrange
-            var service1 = new TestService1();
-            var service2 = new TestService2();
-            Session.DependencyResolver = new TestDependencyResolver(service1, service2);
-
-            var fact = new FactType {TestProperty = "Valid Value 1"};
-            Session.Insert(fact);
-
-            ITestService1 resolvedService1 = null;
-            GetRuleInstance<TestRule>().Action = ctx =>
-            {
-                resolvedService1 = ctx.Resolve<ITestService1>();
-            };
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Same(service1, resolvedService1);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public interface ITestService1
-        {
-            void Action(string value);
-        }
-
-        private class TestService1 : ITestService1
-        {
-            public event EventHandler ServiceCalled;
-
-            public void Action(string value)
-            {
-                ServiceCalled?.Invoke(this, EventArgs.Empty);
-            }
-        }
-
-        public interface ITestService2
-        {
-            void Action(string value);
-        }
-
-        private class TestService2 : ITestService2
-        {
-            public event EventHandler ServiceCalled;
-
-            public void Action(string value)
-            {
-                ServiceCalled?.Invoke(this, EventArgs.Empty);
-            }
-        }
-
-        private class TestDependencyResolver : IDependencyResolver
-        {
-            private readonly TestService1 _service1;
-            private readonly TestService2 _service2;
-
-            public TestDependencyResolver(TestService1 service1, TestService2 service2)
-            {
-                _service1 = service1;
-                _service2 = service2;
-            }
-
-            public object Resolve(IResolutionContext context, Type serviceType)
-            {
-                if (serviceType == typeof(ITestService1))
-                    return _service1;
-                if (serviceType == typeof(ITestService2))
-                    return _service2;
-                throw new ArgumentException();
-            }
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public Action<IContext> Action = ctx => { };
-
-            public override void Define()
-            {
-                FactType fact = null;
-                ITestService1 service1 = null;
-                ITestService2 service2 = null;
-
-                Dependency()
-                    .Resolve(() => service1)
-                    .Resolve(() => service2);
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => Action(ctx))
-                    .Do(ctx => service1.Action(fact.TestProperty))
-                    .Do(ctx => service2.Action(fact.TestProperty))
-                    .Do(ctx => SomeAction(fact, service1, service2));
-            }
-
-            private void SomeAction(FactType fact, ITestService1 service1, ITestService2 service2)
-            {
-                service1.Action(fact.TestProperty);
-                service2.Action(fact.TestProperty);
-            }
+            service1.Action(fact.TestProperty);
+            service2.Action(fact.TestProperty);
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactSimpleGroupByRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactSimpleGroupByRuleTest.cs
@@ -3,165 +3,164 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class OneFactSimpleGroupByRuleTest : BaseRuleTestFixture
 {
-    public class OneFactSimpleGroupByRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_NoMatchingFacts_DoesNotFire()
     {
-        [Fact]
-        public void Fire_NoMatchingFacts_DoesNotFire()
+        //Arrange - Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoFactsWithNullKey_FiresOnceWithBothFactsInOneGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = null};
+        var fact2 = new FactType {TestProperty = null};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<IGrouping<string, FactType>>().Count());
+    }
+
+    [Fact]
+    public void Fire_TwoFactsWithNullKeyOneKeyUpdatedToValue_FiresTwiceWithOneFactInEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = null};
+        var fact2 = new FactType {TestProperty = null};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        fact2.TestProperty = "Value";
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Single(GetFiredFact<IGrouping<string, FactType>>(0));
+        Assert.Single(GetFiredFact<IGrouping<string, FactType>>(1));
+    }
+
+    [Fact]
+    public void Fire_TwoFactsWithValueKeyOneKeyUpdatedToNull_FiresTwiceWithOneFactInEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Value"};
+        var fact2 = new FactType {TestProperty = "Value"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        fact2.TestProperty = null;
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Single(GetFiredFact<IGrouping<string, FactType>>(0));
+        Assert.Single(GetFiredFact<IGrouping<string, FactType>>(1));
+    }
+
+    [Fact]
+    public void Fire_OneFactWithValueAnotherWithNullThenNullUpdated_FiresTwiceWithOneFactInEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Value"};
+        var fact2 = new FactType {TestProperty = null};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Single(GetFiredFact<IGrouping<string, FactType>>(0));
+        Assert.Single(GetFiredFact<IGrouping<string, FactType>>(1));
+    }
+
+    [Fact]
+    public void Fire_TwoFactsWithNullBothRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = null};
+        var fact2 = new FactType {TestProperty = null};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        Session.Retract(fact1);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneFactInsertedThenUpdatedToAnotherGroup_FiresOnceWithOneFactInSecondGroup()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value Group1"};
+        Session.Insert(fact1);
+        
+        fact1.TestProperty = "Valid Value Group2";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        var firedGroup = GetFiredFact<IGrouping<string, FactType>>();
+        Assert.Single(firedGroup);
+        Assert.Equal("Valid Value Group2", firedGroup.Key);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange - Act
-            Session.Fire();
+            IGrouping<string, FactType> group = null;
 
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoFactsWithNullKey_FiresOnceWithBothFactsInOneGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = null};
-            var fact2 = new FactType {TestProperty = null};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<IGrouping<string, FactType>>().Count());
-        }
-
-        [Fact]
-        public void Fire_TwoFactsWithNullKeyOneKeyUpdatedToValue_FiresTwiceWithOneFactInEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = null};
-            var fact2 = new FactType {TestProperty = null};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            fact2.TestProperty = "Value";
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Single(GetFiredFact<IGrouping<string, FactType>>(0));
-            Assert.Single(GetFiredFact<IGrouping<string, FactType>>(1));
-        }
-
-        [Fact]
-        public void Fire_TwoFactsWithValueKeyOneKeyUpdatedToNull_FiresTwiceWithOneFactInEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Value"};
-            var fact2 = new FactType {TestProperty = "Value"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            fact2.TestProperty = null;
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Single(GetFiredFact<IGrouping<string, FactType>>(0));
-            Assert.Single(GetFiredFact<IGrouping<string, FactType>>(1));
-        }
-
-        [Fact]
-        public void Fire_OneFactWithValueAnotherWithNullThenNullUpdated_FiresTwiceWithOneFactInEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Value"};
-            var fact2 = new FactType {TestProperty = null};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Single(GetFiredFact<IGrouping<string, FactType>>(0));
-            Assert.Single(GetFiredFact<IGrouping<string, FactType>>(1));
-        }
-
-        [Fact]
-        public void Fire_TwoFactsWithNullBothRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = null};
-            var fact2 = new FactType {TestProperty = null};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            Session.Retract(fact1);
-            Session.Retract(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_OneFactInsertedThenUpdatedToAnotherGroup_FiresOnceWithOneFactInSecondGroup()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value Group1"};
-            Session.Insert(fact1);
-            
-            fact1.TestProperty = "Valid Value Group2";
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            var firedGroup = GetFiredFact<IGrouping<string, FactType>>();
-            Assert.Single(firedGroup);
-            Assert.Equal("Valid Value Group2", firedGroup.Key);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                IGrouping<string, FactType> group = null;
-
-                When()
-                    .Query(() => group, x => x
-                        .Match<FactType>()
-                        .GroupBy(f => f.TestProperty));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => group, x => x
+                    .Match<FactType>()
+                    .GroupBy(f => f.TestProperty));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/PriorityTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/PriorityTest.cs
@@ -3,86 +3,85 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class PriorityTest : BaseRuleTestFixture
 {
-    public class PriorityTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_LowPriorityActivatesTwiceTriggersHighPriority_HighPriorityPreemptsLowPriority()
     {
-        [Fact]
-        public void Fire_LowPriorityActivatesTwiceTriggersHighPriority_HighPriorityPreemptsLowPriority()
+        //Arrange
+        var invokedRules = new List<string>();
+
+        Session.Events.RuleFiredEvent += (sender, args) => invokedRules.Add(args.Rule.Name);
+
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType1 {TestProperty = "Valid Value 2"};
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+            //low priority activates twice
+            //it runs once, activates high priority rule, which preempts low priority and fires once
+            //low priority fires second time, which activates high priority which also fires second time
+        Assert.Equal(4, invokedRules.Count);
+        Assert.Equal("PriorityLowRule", invokedRules[0]);
+        Assert.Equal("PriorityHighRule", invokedRules[1]);
+        Assert.Equal("PriorityLowRule", invokedRules[2]);
+        Assert.Equal("PriorityHighRule", invokedRules[3]);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<PriorityLowRule>();
+        SetUpRule<PriorityHighRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    [Name("PriorityLowRule")]
+    [Priority(10)]
+    public class PriorityLowRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var invokedRules = new List<string>();
+            FactType1 fact1 = null;
 
-            Session.Events.RuleFiredEvent += (sender, args) => invokedRules.Add(args.Rule.Name);
-
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType1 {TestProperty = "Valid Value 2"};
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-                //low priority activates twice
-                //it runs once, activates high priority rule, which preempts low priority and fires once
-                //low priority fires second time, which activates high priority which also fires second time
-            Assert.Equal(4, invokedRules.Count);
-            Assert.Equal("PriorityLowRule", invokedRules[0]);
-            Assert.Equal("PriorityHighRule", invokedRules[1]);
-            Assert.Equal("PriorityLowRule", invokedRules[2]);
-            Assert.Equal("PriorityHighRule", invokedRules[3]);
+            When()
+                .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.Insert(new FactType2()
+                {
+                    TestProperty = "Valid Value",
+                    JoinProperty = fact1.TestProperty
+                }));
         }
+    }
 
-        protected override void SetUpRules()
+    [Name("PriorityHighRule")]
+    [Priority(100)]
+    public class PriorityHighRule : Rule
+    {
+        public override void Define()
         {
-            SetUpRule<PriorityLowRule>();
-            SetUpRule<PriorityHighRule>();
-        }
+            FactType2 fact2 = null;
 
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        [Name("PriorityLowRule")]
-        [Priority(10)]
-        public class PriorityLowRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-
-                When()
-                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.Insert(new FactType2()
-                    {
-                        TestProperty = "Valid Value",
-                        JoinProperty = fact1.TestProperty
-                    }));
-            }
-        }
-
-        [Name("PriorityHighRule")]
-        [Priority(100)]
-        public class PriorityHighRule : Rule
-        {
-            public override void Define()
-            {
-                FactType2 fact2 = null;
-
-                When()
-                    .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/RuleMetadataTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/RuleMetadataTest.cs
@@ -5,313 +5,312 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class RuleMetadataTest
 {
-    public class RuleMetadataTest
+    private readonly RuleRepository _repository;
+
+    public RuleMetadataTest()
     {
-        private readonly RuleRepository _repository;
+        _repository = new RuleRepository();
+    }
 
-        public RuleMetadataTest()
+    [Fact]
+    public void Property_RuleClrType_Same()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadata)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        var actual = rule.Properties[RuleProperties.ClrType];
+
+        //Assert
+        Assert.Equal(typeof(RuleWithMetadata), actual);
+    }
+
+    [Fact]
+    public void Name_NameAttributePresent_CustomValue()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadata)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        string actual = rule.Name;
+
+        //Assert
+        Assert.Equal("Rule with metadata", actual);
+    }
+
+    [Fact]
+    public void Name_NameAttributeOverriden_CustomValue()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadataAndOverride)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        string actual = rule.Name;
+
+        //Assert
+        Assert.Equal("Programmatic name", actual);
+    }
+
+    [Fact]
+    public void Description_DescriptionAttributePresent_CustomValue()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadata)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        string actual = rule.Description;
+
+        //Assert
+        Assert.Equal("Rule description", actual);
+    }
+
+    [Fact]
+    public void Tags_TagAttributesPresent_CustomValues()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadata)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        string[] actual = rule.Tags.ToArray();
+
+        //Assert
+        Assert.Equal(2, actual.Length);
+        Assert.Contains("Test", actual);
+        Assert.Contains("Metadata", actual);
+    }
+
+    [Fact]
+    public void Priority_PriorityAttributePresent_CustomValue()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadata)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        int actual = rule.Priority;
+
+        //Assert
+        Assert.Equal(100, actual);
+    }
+
+    [Fact]
+    public void Tags_TagAttributesAndParentAttributesPresent_CustomValues()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadataAndParentMetadata)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        string[] actual = rule.Tags.ToArray();
+
+        //Assert
+        Assert.Equal(4, actual.Length);
+        Assert.Contains("ChildTag", actual);
+        Assert.Contains("ChildMetadata", actual);
+        Assert.Contains("ParentTag", actual);
+        Assert.Contains("ParentMetadata", actual);
+    }
+
+    [Fact]
+    public void Priority_PriorityParentAttributePresent_CustomValue()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadataAndParentMetadata)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        int actual = rule.Priority;
+
+        //Assert
+        Assert.Equal(200, actual);
+    }
+
+    [Fact]
+    public void Priority_PriorityAttributeOverriden_CustomValue()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadataAndParentMetadataAndOverrides)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        int actual = rule.Priority;
+
+        //Assert
+        Assert.Equal(500, actual);
+    }
+
+    [Fact]
+    public void Priority_PriorityAttributeOverridenProgrammatically_CustomValue()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadataAndOverride)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        int actual = rule.Priority;
+
+        //Assert
+        Assert.Equal(1000, actual);
+    }
+
+    [Fact]
+    public void Name_NoAttributes_TypeName()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithoutMetadata)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        string actual = rule.Name;
+
+        //Assert
+        Assert.Equal(typeof(RuleWithoutMetadata).FullName, actual);
+    }
+
+    [Fact]
+    public void Description_NoAttributes_Empty()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithoutMetadata)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        string actual = rule.Description;
+
+        //Assert
+        Assert.Equal(string.Empty, actual);
+    }
+
+    [Fact]
+    public void Tags_NoAttributes_Empty()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithoutMetadata)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        string[] actual = rule.Tags.ToArray();
+
+        //Assert
+        Assert.Empty(actual);
+    }
+
+    [Fact]
+    public void Priority_NoAttribute_Default()
+    {
+        //Arrange
+        _repository.Load(x => x.NestedTypes().From(typeof(RuleWithoutMetadata)));
+        IRuleDefinition rule = _repository.GetRules().Single();
+
+        //Act
+        int actual = rule.Priority;
+
+        //Assert
+        Assert.Equal(0, actual);
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class RuleWithoutMetadata : Rule
+    {
+        public override void Define()
         {
-            _repository = new RuleRepository();
-        }
+            FactType fact = null;
 
-        [Fact]
-        public void Property_RuleClrType_Same()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadata)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            var actual = rule.Properties[RuleProperties.ClrType];
-
-            //Assert
-            Assert.Equal(typeof(RuleWithMetadata), actual);
-        }
-
-        [Fact]
-        public void Name_NameAttributePresent_CustomValue()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadata)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            string actual = rule.Name;
-
-            //Assert
-            Assert.Equal("Rule with metadata", actual);
-        }
-
-        [Fact]
-        public void Name_NameAttributeOverriden_CustomValue()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadataAndOverride)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            string actual = rule.Name;
-
-            //Assert
-            Assert.Equal("Programmatic name", actual);
-        }
-
-        [Fact]
-        public void Description_DescriptionAttributePresent_CustomValue()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadata)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            string actual = rule.Description;
-
-            //Assert
-            Assert.Equal("Rule description", actual);
-        }
-
-        [Fact]
-        public void Tags_TagAttributesPresent_CustomValues()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadata)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            string[] actual = rule.Tags.ToArray();
-
-            //Assert
-            Assert.Equal(2, actual.Length);
-            Assert.Contains("Test", actual);
-            Assert.Contains("Metadata", actual);
-        }
-
-        [Fact]
-        public void Priority_PriorityAttributePresent_CustomValue()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadata)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            int actual = rule.Priority;
-
-            //Assert
-            Assert.Equal(100, actual);
-        }
-
-        [Fact]
-        public void Tags_TagAttributesAndParentAttributesPresent_CustomValues()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadataAndParentMetadata)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            string[] actual = rule.Tags.ToArray();
-
-            //Assert
-            Assert.Equal(4, actual.Length);
-            Assert.Contains("ChildTag", actual);
-            Assert.Contains("ChildMetadata", actual);
-            Assert.Contains("ParentTag", actual);
-            Assert.Contains("ParentMetadata", actual);
-        }
-
-        [Fact]
-        public void Priority_PriorityParentAttributePresent_CustomValue()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadataAndParentMetadata)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            int actual = rule.Priority;
-
-            //Assert
-            Assert.Equal(200, actual);
-        }
-
-        [Fact]
-        public void Priority_PriorityAttributeOverriden_CustomValue()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadataAndParentMetadataAndOverrides)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            int actual = rule.Priority;
-
-            //Assert
-            Assert.Equal(500, actual);
-        }
-
-        [Fact]
-        public void Priority_PriorityAttributeOverridenProgrammatically_CustomValue()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithMetadataAndOverride)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            int actual = rule.Priority;
-
-            //Assert
-            Assert.Equal(1000, actual);
-        }
-
-        [Fact]
-        public void Name_NoAttributes_TypeName()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithoutMetadata)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            string actual = rule.Name;
-
-            //Assert
-            Assert.Equal(typeof(RuleWithoutMetadata).FullName, actual);
-        }
-
-        [Fact]
-        public void Description_NoAttributes_Empty()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithoutMetadata)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            string actual = rule.Description;
-
-            //Assert
-            Assert.Equal(string.Empty, actual);
-        }
-
-        [Fact]
-        public void Tags_NoAttributes_Empty()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithoutMetadata)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            string[] actual = rule.Tags.ToArray();
-
-            //Assert
-            Assert.Empty(actual);
-        }
-
-        [Fact]
-        public void Priority_NoAttribute_Default()
-        {
-            //Arrange
-            _repository.Load(x => x.NestedTypes().From(typeof(RuleWithoutMetadata)));
-            IRuleDefinition rule = _repository.GetRules().Single();
-
-            //Act
-            int actual = rule.Priority;
-
-            //Assert
-            Assert.Equal(0, actual);
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class RuleWithoutMetadata : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-        }
-
-        [Tag("ParentTag"), Tag("ParentMetadata")]
-        [Priority(200)]
-        public abstract class ParentRuleWithMetadata : Rule
-        {
-        }
-
-        [Name("Rule with metadata"), Fluent.Dsl.Description("Rule description")]
-        [TestTag, Tag("Metadata")]
-        [Priority(100)]
-        public class RuleWithMetadata : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-        }
-
-        [Name("Declarative name")]
-        [Priority(500)]
-        public class RuleWithMetadataAndOverride : ParentRuleWithMetadata
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                Name("Programmatic name");
-                Priority(1000);
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-        }
-
-        [Name("Rule with metadata"), Fluent.Dsl.Description("Rule description")]
-        [Tag("ChildTag"), Tag("ChildMetadata")]
-        public class RuleWithMetadataAndParentMetadata : ParentRuleWithMetadata
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-        }
-
-        [Name("Rule with metadata"), Fluent.Dsl.Description("Rule description")]
-        [Tag("ChildTag"), Tag("ChildMetadata")]
-        [Priority(500)]
-        public class RuleWithMetadataAndParentMetadataAndOverrides : ParentRuleWithMetadata
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 
-    public class TestTagAttribute : TagAttribute
+    [Tag("ParentTag"), Tag("ParentMetadata")]
+    [Priority(200)]
+    public abstract class ParentRuleWithMetadata : Rule
     {
-        public TestTagAttribute() : base("Test")
+    }
+
+    [Name("Rule with metadata"), Fluent.Dsl.Description("Rule description")]
+    [TestTag, Tag("Metadata")]
+    [Priority(100)]
+    public class RuleWithMetadata : Rule
+    {
+        public override void Define()
         {
+            FactType fact = null;
+
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
+    }
+
+    [Name("Declarative name")]
+    [Priority(500)]
+    public class RuleWithMetadataAndOverride : ParentRuleWithMetadata
+    {
+        public override void Define()
+        {
+            FactType fact = null;
+
+            Name("Programmatic name");
+            Priority(1000);
+
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
+        }
+    }
+
+    [Name("Rule with metadata"), Fluent.Dsl.Description("Rule description")]
+    [Tag("ChildTag"), Tag("ChildMetadata")]
+    public class RuleWithMetadataAndParentMetadata : ParentRuleWithMetadata
+    {
+        public override void Define()
+        {
+            FactType fact = null;
+
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
+        }
+    }
+
+    [Name("Rule with metadata"), Fluent.Dsl.Description("Rule description")]
+    [Tag("ChildTag"), Tag("ChildMetadata")]
+    [Priority(500)]
+    public class RuleWithMetadataAndParentMetadataAndOverrides : ParentRuleWithMetadata
+    {
+        public override void Define()
+        {
+            FactType fact = null;
+
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
+        }
+    }
+}
+
+public class TestTagAttribute : TagAttribute
+{
+    public TestTagAttribute() : base("Test")
+    {
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/SelfRetractRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/SelfRetractRuleTest.cs
@@ -3,79 +3,78 @@ using NRules.IntegrationTests.TestAssets;
 using Xunit;
 using System.Linq;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class SelfRetractRuleTest : BaseRuleTestFixture
 {
-    public class SelfRetractRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFact_FiresOnceAndRetractsFact()
     {
-        [Fact]
-        public void Fire_OneMatchingFact_FiresOnceAndRetractsFact()
+        //Arrange
+        var fact1 = new FactType { TestProperty = "Valid Value 1" };
+        var facts = new[] { fact1 };
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(0, Session.Query<FactType>().Count());
+    }
+
+    [Fact]
+    public void Fire_NoMatchingFact_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType { TestProperty = "Invalid Value 1" };
+        var facts = new[] { fact1 };
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFacts_FiresTwiceAndRetractsFacts()
+    {
+        //Arrange
+        var fact1 = new FactType { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType { TestProperty = "Valid Value 2" };
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(0, Session.Query<FactType>().Count());
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType { TestProperty = "Valid Value 1" };
-            var facts = new[] { fact1 };
-            Session.InsertAll(facts);
+            FactType fact = null;
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(0, Session.Query<FactType>().Count());
-        }
-
-        [Fact]
-        public void Fire_NoMatchingFact_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType { TestProperty = "Invalid Value 1" };
-            var facts = new[] { fact1 };
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFacts_FiresTwiceAndRetractsFacts()
-        {
-            //Arrange
-            var fact1 = new FactType { TestProperty = "Valid Value 1" };
-            var fact2 = new FactType { TestProperty = "Valid Value 2" };
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(0, Session.Query<FactType>().Count());
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
-
-                When()
-                    .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.TryRetract(fact));
-            }
+            When()
+                .Match<FactType>(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.TryRetract(fact));
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/SessionQueryTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/SessionQueryTest.cs
@@ -3,103 +3,102 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class SessionQueryTest : BaseRuleTestFixture
 {
-    public class SessionQueryTest : BaseRuleTestFixture
+    [Fact]
+    public void Query_NoFacts_Empty()
     {
-        [Fact]
-        public void Query_NoFacts_Empty()
+        //Arrange
+        //Act
+        var query = Session.Query<object>();
+        var facts = query.ToList();
+
+        //Assert
+        Assert.Empty(facts);
+    }
+
+    [Fact]
+    public void Query_OneFact_RetrievesFactFromQuery()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Valid Value 1"};
+        Session.Insert(fact1);
+
+        //Act
+        var query = Session.Query<object>();
+        var facts = query.ToList();
+
+        //Assert
+        Assert.Single(facts);
+        Assert.Same(fact1, facts[0]);
+    }
+
+    [Fact]
+    public void Query_RuleInsertsSecondFact_TwoFactsInMemory()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Valid Value 1"};
+        Session.Insert(fact1);
+        Session.Fire();
+
+        //Act
+        var query = Session.Query<object>();
+        var facts = query.ToList();
+
+        //Assert
+        Assert.Equal(2, facts.Count);
+    }
+
+    [Fact]
+    public void Query_QueryFactsByType_OnlyReturnsFactsOfThatType()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Valid Value 1"};
+        Session.Insert(fact1);
+        Session.Fire();
+
+        //Act
+        var query = Session.Query<FactType2>();
+        var facts = query.ToList();
+
+        //Assert
+        Assert.Single(facts);
+        Assert.Equal(fact1.TestProperty, facts[0].JoinProperty);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            //Act
-            var query = Session.Query<object>();
-            var facts = query.ToList();
+            FactType1 fact1 = null;
 
-            //Assert
-            Assert.Empty(facts);
-        }
-
-        [Fact]
-        public void Query_OneFact_RetrievesFactFromQuery()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Valid Value 1"};
-            Session.Insert(fact1);
-
-            //Act
-            var query = Session.Query<object>();
-            var facts = query.ToList();
-
-            //Assert
-            Assert.Single(facts);
-            Assert.Same(fact1, facts[0]);
-        }
-
-        [Fact]
-        public void Query_RuleInsertsSecondFact_TwoFactsInMemory()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Valid Value 1"};
-            Session.Insert(fact1);
-            Session.Fire();
-
-            //Act
-            var query = Session.Query<object>();
-            var facts = query.ToList();
-
-            //Assert
-            Assert.Equal(2, facts.Count);
-        }
-
-        [Fact]
-        public void Query_QueryFactsByType_OnlyReturnsFactsOfThatType()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Valid Value 1"};
-            Session.Insert(fact1);
-            Session.Fire();
-
-            //Act
-            var query = Session.Query<FactType2>();
-            var facts = query.ToList();
-
-            //Assert
-            Assert.Single(facts);
-            Assert.Equal(fact1.TestProperty, facts[0].JoinProperty);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-
-                When()
-                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.Insert(new FactType2()
-                    {
-                        TestProperty = fact1.JoinProperty,
-                        JoinProperty = fact1.TestProperty
-                    }));
-            }
+            When()
+                .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.Insert(new FactType2()
+                {
+                    TestProperty = fact1.JoinProperty,
+                    JoinProperty = fact1.TestProperty
+                }));
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/SingleOrDefaultEquatableFactRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/SingleOrDefaultEquatableFactRuleTest.cs
@@ -4,168 +4,167 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class SingleOrDefaultEquatableFactRuleTest : BaseRuleTestFixture
 {
-    public class SingleOrDefaultEquatableFactRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFactsAndOneInvalid_FiresOnceWithValidFact()
     {
-        [Fact]
-        public void Fire_OneMatchingFactsAndOneInvalid_FiresOnceWithValidFact()
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Invalid Value 1", ValueProperty = "Original 1"};
+        var fact2 = new FactType(2) { TestProperty = "Valid Value 2", ValueProperty = "Original 2"};
+
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        var firedFact = GetFiredFact<FactType>();
+        Assert.Equal(2, firedFact.Id);
+        Assert.Equal("Original 2", firedFact.ValueProperty);
+    }
+    
+    [Fact]
+    public void Fire_NoValidFacts_FiresOnceWithDefault()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Invalid Value 1", ValueProperty = "Original 1"};
+
+        var facts = new[] { fact1 };
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        var firedFact = GetFiredFact<FactType>();
+        Assert.Equal(0, firedFact.Id);
+        Assert.Null(firedFact.ValueProperty);
+    }
+    
+    [Fact]
+    public void Fire_NoValidFactsUpdatedToValid_FiresOnceWithValidFact()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Invalid Value 1", ValueProperty = "Original 1"};
+
+        var facts = new[] { fact1 };
+        Session.InsertAll(facts);
+
+        var fact11 = new FactType(1) { TestProperty = "Valid Value 1", ValueProperty = "Original 1" };
+        Session.Update(fact11);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        var firedFact = GetFiredFact<FactType>();
+        Assert.Equal(1, firedFact.Id);
+        Assert.Equal("Original 1", firedFact.ValueProperty);
+    }
+    
+    [Fact]
+    public void Fire_ValidFactInsertedThenUpdated_FiresOnceWithUpdatedValue()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1", ValueProperty = "Original 1"};
+
+        var facts = new[] {fact1};
+        Session.InsertAll(facts);
+
+        var fact11 = new FactType(1) { TestProperty = "Valid Value 1", ValueProperty = "Updated 1" };
+        Session.Update(fact11);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        var firedFact = GetFiredFact<FactType>();
+        Assert.Equal(1, firedFact.Id);
+        Assert.Equal("Updated 1", firedFact.ValueProperty);
+    }
+            
+    [Fact]
+    public void Fire_TwoValidFactsInsertedThenUpdated_FiresOnceThenFiresOnceAgain()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1"};
+        var fact2 = new FactType(2) { TestProperty = "Valid Value 2"};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredOnce();
+
+        //Act - 2
+        Session.Update(fact1);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTwice();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType : IEquatable<FactType>
+    {
+        public FactType(int id)
         {
-            //Arrange
-            var fact1 = new FactType(1) { TestProperty = "Invalid Value 1", ValueProperty = "Original 1"};
-            var fact2 = new FactType(2) { TestProperty = "Valid Value 2", ValueProperty = "Original 2"};
-
-            var facts = new[] { fact1, fact2 };
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            var firedFact = GetFiredFact<FactType>();
-            Assert.Equal(2, firedFact.Id);
-            Assert.Equal("Original 2", firedFact.ValueProperty);
-        }
-        
-        [Fact]
-        public void Fire_NoValidFacts_FiresOnceWithDefault()
-        {
-            //Arrange
-            var fact1 = new FactType(1) { TestProperty = "Invalid Value 1", ValueProperty = "Original 1"};
-
-            var facts = new[] { fact1 };
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            var firedFact = GetFiredFact<FactType>();
-            Assert.Equal(0, firedFact.Id);
-            Assert.Null(firedFact.ValueProperty);
-        }
-        
-        [Fact]
-        public void Fire_NoValidFactsUpdatedToValid_FiresOnceWithValidFact()
-        {
-            //Arrange
-            var fact1 = new FactType(1) { TestProperty = "Invalid Value 1", ValueProperty = "Original 1"};
-
-            var facts = new[] { fact1 };
-            Session.InsertAll(facts);
-
-            var fact11 = new FactType(1) { TestProperty = "Valid Value 1", ValueProperty = "Original 1" };
-            Session.Update(fact11);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            var firedFact = GetFiredFact<FactType>();
-            Assert.Equal(1, firedFact.Id);
-            Assert.Equal("Original 1", firedFact.ValueProperty);
-        }
-        
-        [Fact]
-        public void Fire_ValidFactInsertedThenUpdated_FiresOnceWithUpdatedValue()
-        {
-            //Arrange
-            var fact1 = new FactType(1) { TestProperty = "Valid Value 1", ValueProperty = "Original 1"};
-
-            var facts = new[] {fact1};
-            Session.InsertAll(facts);
-
-            var fact11 = new FactType(1) { TestProperty = "Valid Value 1", ValueProperty = "Updated 1" };
-            Session.Update(fact11);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            var firedFact = GetFiredFact<FactType>();
-            Assert.Equal(1, firedFact.Id);
-            Assert.Equal("Updated 1", firedFact.ValueProperty);
-        }
-                
-        [Fact]
-        public void Fire_TwoValidFactsInsertedThenUpdated_FiresOnceThenFiresOnceAgain()
-        {
-            //Arrange
-            var fact1 = new FactType(1) { TestProperty = "Valid Value 1"};
-            var fact2 = new FactType(2) { TestProperty = "Valid Value 2"};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredOnce();
-
-            //Act - 2
-            Session.Update(fact1);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTwice();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType : IEquatable<FactType>
-        {
-            public FactType(int id)
-            {
-                Id = id;
-            }
-
-            public int Id { get; }
-            public string TestProperty { get; set; }
-            public string ValueProperty { get; set; }
-
-            public bool Equals(FactType other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return Id == other.Id;
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((FactType)obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return Id;
-            }
+            Id = id;
         }
 
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact = null;
+        public int Id { get; }
+        public string TestProperty { get; set; }
+        public string ValueProperty { get; set; }
 
-                When()
-                    .Query(() => fact, q => q
-                        .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
-                        .Collect()
-                        .Select(x => x.OrderBy(f => f.Id).FirstOrDefault() ?? new FactType(0)));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+        public bool Equals(FactType other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Id == other.Id;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((FactType)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Id;
+        }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
+        {
+            FactType fact = null;
+
+            When()
+                .Query(() => fact, q => q
+                    .Match<FactType>(f => f.TestProperty.StartsWith("Valid"))
+                    .Collect()
+                    .Select(x => x.OrderBy(f => f.Id).FirstOrDefault() ?? new FactType(0)));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/SubnetUpdateTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/SubnetUpdateTest.cs
@@ -5,83 +5,82 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class SubnetUpdateTest : BaseRuleTestFixture
 {
-    public class SubnetUpdateTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_InsertThenUpdate_OnlyNecessaryEvaluations()
     {
-        [Fact]
-        public void Fire_InsertThenUpdate_OnlyNecessaryEvaluations()
+        //Arrange
+        var fact11 = new FactType1();
+        var fact12 = new FactType1();
+        var fact21 = new FactType2();
+        var fact22 = new FactType2();
+
+        Session.InsertAll(new[] {fact11, fact12});
+        Session.InsertAll(new[] {fact21, fact22});
+
+        int evaluations = 0;
+        Session.Events.LhsExpressionEvaluatedEvent += (sender, args) => evaluations++;
+
+        //Act
+        Session.UpdateAll(new []{fact11, fact12});
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(2, evaluations);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+    }
+
+    public class FactType2
+    {
+    }
+
+    public class TestRule : Rule
+    {
+        public Action<IContext> Action = ctx => { };
+
+        public override void Define()
         {
-            //Arrange
-            var fact11 = new FactType1();
-            var fact12 = new FactType1();
-            var fact21 = new FactType2();
-            var fact22 = new FactType2();
+            FactType1 fact = null;
+            IEnumerable<FactType2> collection = null;
 
-            Session.InsertAll(new[] {fact11, fact12});
-            Session.InsertAll(new[] {fact21, fact22});
-
-            int evaluations = 0;
-            Session.Events.LhsExpressionEvaluatedEvent += (sender, args) => evaluations++;
-
-            //Act
-            Session.UpdateAll(new []{fact11, fact12});
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(2, evaluations);
+            When()
+                .Match(() => fact)
+                .Query(() => collection, x => x
+                    .Match<FactType2>()
+                    .Select(f => TransformFact(f))
+                    .Collect()
+                    .Select(c => TransformCollection(c))
+                    .Select(c => TransformWithJoin(c, fact))
+                );
+            Then()
+                .Do(ctx => Action(ctx));
         }
 
-        protected override void SetUpRules()
+        private static FactType2 TransformFact(FactType2 fact)
         {
-            SetUpRule<TestRule>();
+            return fact;
         }
 
-        public class FactType1
+        private IEnumerable<FactType2> TransformCollection(IEnumerable<FactType2> facts)
         {
+            return facts;
         }
 
-        public class FactType2
+        private IEnumerable<FactType2> TransformWithJoin(IEnumerable<FactType2> facts, FactType1 fact)
         {
-        }
-
-        public class TestRule : Rule
-        {
-            public Action<IContext> Action = ctx => { };
-
-            public override void Define()
-            {
-                FactType1 fact = null;
-                IEnumerable<FactType2> collection = null;
-
-                When()
-                    .Match(() => fact)
-                    .Query(() => collection, x => x
-                        .Match<FactType2>()
-                        .Select(f => TransformFact(f))
-                        .Collect()
-                        .Select(c => TransformCollection(c))
-                        .Select(c => TransformWithJoin(c, fact))
-                    );
-                Then()
-                    .Do(ctx => Action(ctx));
-            }
-
-            private static FactType2 TransformFact(FactType2 fact)
-            {
-                return fact;
-            }
-
-            private IEnumerable<FactType2> TransformCollection(IEnumerable<FactType2> facts)
-            {
-                return facts;
-            }
-
-            private IEnumerable<FactType2> TransformWithJoin(IEnumerable<FactType2> facts, FactType1 fact)
-            {
-                return facts;
-            }
+            return facts;
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TestAssets/BaseRuleTestFixture.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TestAssets/BaseRuleTestFixture.cs
@@ -6,186 +6,185 @@ using NRules.Fluent;
 using NRules.Fluent.Dsl;
 using NRules.RuleModel;
 
-namespace NRules.IntegrationTests.TestAssets
+namespace NRules.IntegrationTests.TestAssets;
+
+public abstract class BaseRuleTestFixture
 {
-    public abstract class BaseRuleTestFixture
+    protected readonly ISession Session;
+    protected readonly RuleRepository Repository;
+
+    private readonly Dictionary<string, List<AgendaEventArgs>> _firedRulesMap;
+    private readonly Dictionary<Type, IRuleMetadata> _ruleMap;
+
+    protected BaseRuleTestFixture()
     {
-        protected readonly ISession Session;
-        protected readonly RuleRepository Repository;
+        _firedRulesMap = new Dictionary<string, List<AgendaEventArgs>>();
+        _ruleMap = new Dictionary<Type, IRuleMetadata>();
 
-        private readonly Dictionary<string, List<AgendaEventArgs>> _firedRulesMap;
-        private readonly Dictionary<Type, IRuleMetadata> _ruleMap;
+        Repository = new RuleRepository {Activator = new InstanceActivator()};
 
-        protected BaseRuleTestFixture()
+        SetUpRules();
+
+        ISessionFactory factory = Compile();
+        Session = factory.CreateSession();
+        Session.Events.RuleFiredEvent += (sender, args) => _firedRulesMap[args.Rule.Name].Add(args);
+    }
+
+    protected virtual ISessionFactory Compile()
+    {
+        var factory = Repository.Compile();
+        return factory;
+    }
+
+    protected abstract void SetUpRules();
+
+    protected void SetUpRule<T>() where T : Rule, new()
+    {
+        var metadata = new RuleMetadata(typeof (T));
+        _ruleMap[typeof (T)] = metadata;
+        _firedRulesMap[metadata.Name] = new List<AgendaEventArgs>();
+        Repository.Load(x => x
+            .PrivateTypes()
+            .NestedTypes()
+            .From(typeof (T)));
+    }
+
+    protected T GetRuleInstance<T>() where T : Rule
+    {
+        return (T)Repository.Activator.Activate(typeof(T)).Single();
+    }
+
+    protected IEnumerable<T> GetFiredFacts<T>()
+    {
+        var ruleFiring = GetLastRuleFiring();
+        return GetFacts<T>(ruleFiring, allowEmpty: true).Select(f => (T) f.Value);
+    }
+
+    protected T GetFiredFact<T>()
+    {
+        var ruleFiring = GetLastRuleFiring();
+        return (T)GetFacts<T>(ruleFiring).First().Value;
+    }
+
+    protected T GetFiredFact<T>(int instanceNumber)
+    {
+        var ruleFiring = GetRuleFiring(instanceNumber);
+        return (T)GetFacts<T>(ruleFiring).First().Value;
+    }
+
+    protected void AssertFiredOnce()
+    {
+        AssertFiredTimes(1);
+    }
+
+    protected void AssertFiredTwice()
+    {
+        AssertFiredTimes(2);
+    }
+
+    protected void AssertFiredTimes(int expected)
+    {
+        var ruleMetadata = GetRule();
+        var actual = GetRuleFirings(ruleMetadata).Count;
+        AssertRuleFiredTimes(ruleMetadata.Name, expected, actual);
+    }
+
+    protected void AssertDidNotFire()
+    {
+        AssertFiredTimes(0);
+    }
+
+    protected void AssertFiredOnce<T>()
+    {
+        AssertFiredTimes<T>(1);
+    }
+
+    protected void AssertFiredTwice<T>()
+    {
+        AssertFiredTimes<T>(2);
+    }
+
+    protected void AssertFiredTimes<T>(int expected)
+    {
+        var ruleMetadata = GetRule<T>();
+        var actual = GetRuleFirings(ruleMetadata).Count;
+        AssertRuleFiredTimes(ruleMetadata.Name, expected, actual);
+    }
+    
+    protected void AssertDidNotFire<T>()
+    {
+        AssertFiredTimes<T>(0);
+    }
+    
+    private static void AssertRuleFiredTimes(string ruleName, int expected, int actual)
+    {
+        if (expected != actual)
+            throw new RuleFiredAssertionException(expected, actual, ruleName);
+    }
+
+    private IRuleMetadata GetRule<T>()
+    {
+        if (!_ruleMap.TryGetValue(typeof(T), out var ruleMetadata))
+            throw new ArgumentException($"Rule {typeof(T).FullName} not found");
+        return ruleMetadata;
+    }
+    
+    private IRuleMetadata GetRule()
+    {
+        if (_ruleMap.Count == 0)
+            throw new ArgumentException("Expected single rule test, but found no rules registered");
+        if (_ruleMap.Count > 1)
+            throw new ArgumentException("Expected single rule test, but found multiple rules registered");
+
+        return _ruleMap.Single().Value;
+    }
+
+    private IReadOnlyCollection<AgendaEventArgs> GetRuleFirings(IRuleMetadata ruleMetadata)
+    {
+        if (!_firedRulesMap.TryGetValue(ruleMetadata.Name, out var firings))
+            throw new ArgumentException($"Expected rule {ruleMetadata.Name} to fire");
+        return firings;
+    }
+
+    private AgendaEventArgs GetLastRuleFiring()
+    {
+        var ruleMetadata = GetRule();
+        var ruleFirings = GetRuleFirings(ruleMetadata);
+        var lastFiring = ruleFirings.LastOrDefault();
+        if (lastFiring == null)
+            throw new InvalidOperationException($"Unable to retrieve last firing of the rule {ruleMetadata.Name}");
+        return lastFiring;
+    }
+
+    private AgendaEventArgs GetRuleFiring(int firingIndex)
+    {
+        var ruleMetadata = GetRule();
+        var ruleFirings = GetRuleFirings(ruleMetadata);
+        if (ruleFirings.Count < firingIndex + 1)
+            throw new InvalidOperationException($"Unable to retrieve firing of the rule {ruleMetadata.Name} at index {firingIndex}");
+        return ruleFirings.ElementAt(firingIndex);
+    }
+
+    private static IFactMatch[] GetFacts<T>(AgendaEventArgs ruleFiring, bool allowEmpty = false)
+    {
+        var factMatches = ruleFiring.Facts.Where(f => typeof(T).IsAssignableFrom(f.Declaration.Type)).ToArray();
+        if (factMatches.Length == 0 && !allowEmpty)
+            throw new InvalidOperationException($"Did not find any facts of type {typeof(T)} in the rule match");
+        return factMatches;
+    }
+
+    private class InstanceActivator : IRuleActivator
+    {
+        private readonly Dictionary<Type, Rule> _rules = new();
+
+        public IEnumerable<Rule> Activate(Type type)
         {
-            _firedRulesMap = new Dictionary<string, List<AgendaEventArgs>>();
-            _ruleMap = new Dictionary<Type, IRuleMetadata>();
-
-            Repository = new RuleRepository {Activator = new InstanceActivator()};
-
-            SetUpRules();
-
-            ISessionFactory factory = Compile();
-            Session = factory.CreateSession();
-            Session.Events.RuleFiredEvent += (sender, args) => _firedRulesMap[args.Rule.Name].Add(args);
-        }
-
-        protected virtual ISessionFactory Compile()
-        {
-            var factory = Repository.Compile();
-            return factory;
-        }
-
-        protected abstract void SetUpRules();
-
-        protected void SetUpRule<T>() where T : Rule, new()
-        {
-            var metadata = new RuleMetadata(typeof (T));
-            _ruleMap[typeof (T)] = metadata;
-            _firedRulesMap[metadata.Name] = new List<AgendaEventArgs>();
-            Repository.Load(x => x
-                .PrivateTypes()
-                .NestedTypes()
-                .From(typeof (T)));
-        }
-
-        protected T GetRuleInstance<T>() where T : Rule
-        {
-            return (T)Repository.Activator.Activate(typeof(T)).Single();
-        }
-
-        protected IEnumerable<T> GetFiredFacts<T>()
-        {
-            var ruleFiring = GetLastRuleFiring();
-            return GetFacts<T>(ruleFiring, allowEmpty: true).Select(f => (T) f.Value);
-        }
-
-        protected T GetFiredFact<T>()
-        {
-            var ruleFiring = GetLastRuleFiring();
-            return (T)GetFacts<T>(ruleFiring).First().Value;
-        }
-
-        protected T GetFiredFact<T>(int instanceNumber)
-        {
-            var ruleFiring = GetRuleFiring(instanceNumber);
-            return (T)GetFacts<T>(ruleFiring).First().Value;
-        }
-
-        protected void AssertFiredOnce()
-        {
-            AssertFiredTimes(1);
-        }
-
-        protected void AssertFiredTwice()
-        {
-            AssertFiredTimes(2);
-        }
-
-        protected void AssertFiredTimes(int expected)
-        {
-            var ruleMetadata = GetRule();
-            var actual = GetRuleFirings(ruleMetadata).Count;
-            AssertRuleFiredTimes(ruleMetadata.Name, expected, actual);
-        }
-
-        protected void AssertDidNotFire()
-        {
-            AssertFiredTimes(0);
-        }
-
-        protected void AssertFiredOnce<T>()
-        {
-            AssertFiredTimes<T>(1);
-        }
-
-        protected void AssertFiredTwice<T>()
-        {
-            AssertFiredTimes<T>(2);
-        }
-
-        protected void AssertFiredTimes<T>(int expected)
-        {
-            var ruleMetadata = GetRule<T>();
-            var actual = GetRuleFirings(ruleMetadata).Count;
-            AssertRuleFiredTimes(ruleMetadata.Name, expected, actual);
-        }
-        
-        protected void AssertDidNotFire<T>()
-        {
-            AssertFiredTimes<T>(0);
-        }
-        
-        private static void AssertRuleFiredTimes(string ruleName, int expected, int actual)
-        {
-            if (expected != actual)
-                throw new RuleFiredAssertionException(expected, actual, ruleName);
-        }
-
-        private IRuleMetadata GetRule<T>()
-        {
-            if (!_ruleMap.TryGetValue(typeof(T), out var ruleMetadata))
-                throw new ArgumentException($"Rule {typeof(T).FullName} not found");
-            return ruleMetadata;
-        }
-        
-        private IRuleMetadata GetRule()
-        {
-            if (_ruleMap.Count == 0)
-                throw new ArgumentException("Expected single rule test, but found no rules registered");
-            if (_ruleMap.Count > 1)
-                throw new ArgumentException("Expected single rule test, but found multiple rules registered");
-
-            return _ruleMap.Single().Value;
-        }
-
-        private IReadOnlyCollection<AgendaEventArgs> GetRuleFirings(IRuleMetadata ruleMetadata)
-        {
-            if (!_firedRulesMap.TryGetValue(ruleMetadata.Name, out var firings))
-                throw new ArgumentException($"Expected rule {ruleMetadata.Name} to fire");
-            return firings;
-        }
-
-        private AgendaEventArgs GetLastRuleFiring()
-        {
-            var ruleMetadata = GetRule();
-            var ruleFirings = GetRuleFirings(ruleMetadata);
-            var lastFiring = ruleFirings.LastOrDefault();
-            if (lastFiring == null)
-                throw new InvalidOperationException($"Unable to retrieve last firing of the rule {ruleMetadata.Name}");
-            return lastFiring;
-        }
-
-        private AgendaEventArgs GetRuleFiring(int firingIndex)
-        {
-            var ruleMetadata = GetRule();
-            var ruleFirings = GetRuleFirings(ruleMetadata);
-            if (ruleFirings.Count < firingIndex + 1)
-                throw new InvalidOperationException($"Unable to retrieve firing of the rule {ruleMetadata.Name} at index {firingIndex}");
-            return ruleFirings.ElementAt(firingIndex);
-        }
-
-        private static IFactMatch[] GetFacts<T>(AgendaEventArgs ruleFiring, bool allowEmpty = false)
-        {
-            var factMatches = ruleFiring.Facts.Where(f => typeof(T).IsAssignableFrom(f.Declaration.Type)).ToArray();
-            if (factMatches.Length == 0 && !allowEmpty)
-                throw new InvalidOperationException($"Did not find any facts of type {typeof(T)} in the rule match");
-            return factMatches;
-        }
-
-        private class InstanceActivator : IRuleActivator
-        {
-            private readonly Dictionary<Type, Rule> _rules = new();
-
-            public IEnumerable<Rule> Activate(Type type)
+            if (!_rules.TryGetValue(type, out var rule))
             {
-                if (!_rules.TryGetValue(type, out var rule))
-                {
-                    rule = (Rule) Activator.CreateInstance(type);
-                    _rules[type] = rule;
-                }
-                yield return rule;
+                rule = (Rule) Activator.CreateInstance(type);
+                _rules[type] = rule;
             }
+            yield return rule;
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TestAssets/ContextExtensions.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TestAssets/ContextExtensions.cs
@@ -1,11 +1,10 @@
 ﻿using NRules.RuleModel;
 
-namespace NRules.IntegrationTests.TestAssets
+namespace NRules.IntegrationTests.TestAssets;
+
+public static class ContextExtensions
 {
-    public static class ContextExtensions
+    public static void NoOp(this IContext context)
     {
-        public static void NoOp(this IContext context)
-        {
-        }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TestAssets/RuleFiredAssertionException.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TestAssets/RuleFiredAssertionException.cs
@@ -1,12 +1,11 @@
 ﻿using Xunit.Sdk;
 
-namespace NRules.IntegrationTests.TestAssets
+namespace NRules.IntegrationTests.TestAssets;
+
+public class RuleFiredAssertionException : AssertActualExpectedException
 {
-    public class RuleFiredAssertionException : AssertActualExpectedException
+    public RuleFiredAssertionException(object expected, object actual, string ruleName) 
+        : base(expected, actual, $"Rule {ruleName}", "Expected fired times", "Actual fired times")
     {
-        public RuleFiredAssertionException(object expected, object actual, string ruleName) 
-            : base(expected, actual, $"Rule {ruleName}", "Expected fired times", "Actual fired times")
-        {
-        }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/ThreeFactGroupByCollectMatchRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/ThreeFactGroupByCollectMatchRuleTest.cs
@@ -4,126 +4,125 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class ThreeFactGroupByCollectMatchRuleTest : BaseRuleTestFixture
 {
-    public class ThreeFactGroupByCollectMatchRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_AllPatternsMatch_FiresOnce()
     {
-        [Fact]
-        public void Fire_AllPatternsMatch_FiresOnce()
+        //Arrange
+        var fact1 = new FactType1{Key = "key1", Join = "join1"};
+        var fact2 = new FactType2{Join = "join1"};
+        var fact3 = new FactType3{Join = "join1"};
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+    
+    [Fact]
+    public void Fire_AllPatternsMatchThenFirstFactRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1{Key = "key1", Join = "join1"};
+        var fact2 = new FactType2{Join = "join1"};
+        var fact3 = new FactType3{Join = "join1"};
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        //Act
+        Session.Retract(fact1);
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+    
+    [Fact]
+    public void Fire_AllPatternsMatchThenSecondFactRetracted_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1{Key = "key1", Join = "join1"};
+        var fact2 = new FactType2{Join = "join1"};
+        var fact3 = new FactType3{Join = "join1"};
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        //Act
+        Session.Retract(fact2);
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_AllPatternsMatchThenThirdFactRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1{Key = "key1", Join = "join1"};
+        var fact2 = new FactType2{Join = "join1"};
+        var fact3 = new FactType3{Join = "join1"};
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        //Act
+        Session.Retract(fact3);
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string Key { get; set; }
+        public string Join { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string Join { get; set; }
+    }
+
+    public class FactType3
+    {
+        public string Join { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1{Key = "key1", Join = "join1"};
-            var fact2 = new FactType2{Join = "join1"};
-            var fact3 = new FactType3{Join = "join1"};
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
+            IGrouping<string, FactType1> group = default;
+            IEnumerable<FactType2> facts2 = default;
+            FactType3 fact3 = default;
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-        
-        [Fact]
-        public void Fire_AllPatternsMatchThenFirstFactRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1{Key = "key1", Join = "join1"};
-            var fact2 = new FactType2{Join = "join1"};
-            var fact3 = new FactType3{Join = "join1"};
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            //Act
-            Session.Retract(fact1);
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-        
-        [Fact]
-        public void Fire_AllPatternsMatchThenSecondFactRetracted_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1{Key = "key1", Join = "join1"};
-            var fact2 = new FactType2{Join = "join1"};
-            var fact3 = new FactType3{Join = "join1"};
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            //Act
-            Session.Retract(fact2);
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_AllPatternsMatchThenThirdFactRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1{Key = "key1", Join = "join1"};
-            var fact2 = new FactType2{Join = "join1"};
-            var fact3 = new FactType3{Join = "join1"};
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            //Act
-            Session.Retract(fact3);
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string Key { get; set; }
-            public string Join { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string Join { get; set; }
-        }
-
-        public class FactType3
-        {
-            public string Join { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                IGrouping<string, FactType1> group = default;
-                IEnumerable<FactType2> facts2 = default;
-                FactType3 fact3 = default;
-
-                When()
-                    .Query(() => group, x => x
-                        .Match<FactType1>()
-                        .GroupBy(f => f.Key))
-                    .Query(() => facts2, q => q
-                        .Match<FactType2>(f => f.Join == group.First().Join)
-                        .Collect())
-                    .Match<FactType3>(() => fact3, f => f.Join == group.First().Join);
-                
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Query(() => group, x => x
+                    .Match<FactType1>()
+                    .GroupBy(f => f.Key))
+                .Query(() => facts2, q => q
+                    .Match<FactType2>(f => f.Join == group.First().Join)
+                    .Collect())
+                .Match<FactType3>(() => fact3, f => f.Join == group.First().Join);
+            
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/ThreeFactNestedOrGroupRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/ThreeFactNestedOrGroupRuleTest.cs
@@ -2,95 +2,94 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class ThreeFactNestedOrGroupRuleTest : BaseRuleTestFixture
 {
-    public class ThreeFactNestedOrGroupRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchingOuterFact_FiresOnce()
     {
-        [Fact]
-        public void Fire_MatchingOuterFact_FiresOnce()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingInnerFact_FiresOnce()
+    {
+        //Arrange
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2"};
+
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingInnerAndOuterFacts_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2"};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType3
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+            FactType1 fact1 = null;
+            FactType2 fact2 = null;
+            FactType3 fact3 = null;
 
-            Session.Insert(fact1);
+            When()
+                .Or(x => x
+                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                    .Or(xx => xx
+                        .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"))
+                        .Match<FactType3>(() => fact3, f => f.TestProperty.StartsWith("Valid"))));
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingInnerFact_FiresOnce()
-        {
-            //Arrange
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2"};
-
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingInnerAndOuterFacts_FiresTwice()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2"};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType3
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-                FactType2 fact2 = null;
-                FactType3 fact3 = null;
-
-                When()
-                    .Or(x => x
-                        .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                        .Or(xx => xx
-                            .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"))
-                            .Match<FactType3>(() => fact3, f => f.TestProperty.StartsWith("Valid"))));
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/ThreeFactOrGroupRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/ThreeFactOrGroupRuleTest.cs
@@ -5,265 +5,264 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class ThreeFactOrGroupRuleTest : BaseRuleTestFixture
 {
-    public class ThreeFactOrGroupRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchingMainFactAndNoneOfOrGroup_DoesNotFire()
     {
-        [Fact]
-        public void Fire_MatchingMainFactAndNoneOfOrGroup_DoesNotFire()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingMainFactAndFirstPartOfOrGroup_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsFirstPart_FactsInContext()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        IFactMatch[] matches = null;
+        GetRuleInstance<TestRule>().Action = ctx =>
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+            matches = ctx.Match.Facts.ToArray();
+        };
 
-            Session.Insert(fact1);
+        //Act
+        Session.Fire();
 
-            //Act
-            Session.Fire();
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(3, matches.Length);
+        Assert.Equal("fact1", matches[0].Declaration.Name);
+        Assert.Same(fact1, matches[0].Value);
+        Assert.Equal("fact2", matches[1].Declaration.Name);
+        Assert.Same(fact2, matches[1].Value);
+        Assert.Equal("fact3", matches[2].Declaration.Name);
+        Assert.Null(matches[2].Value);
+    }
 
-            //Assert
-            AssertDidNotFire();
-        }
+    [Fact]
+    public void Fire_MatchingFactsSecondPart_FactsInContext()
+    {
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType2 { TestProperty = "Invalid Value 2", JoinProperty = fact1.TestProperty };
+        var fact3 = new FactType3 { TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty };
 
-        [Fact]
-        public void Fire_MatchingMainFactAndFirstPartOfOrGroup_FiresOnce()
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        IFactMatch[] matches = null;
+        GetRuleInstance<TestRule>().Action = ctx =>
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+            matches = ctx.Match.Facts.ToArray();
+        };
 
-            Session.Insert(fact1);
-            Session.Insert(fact2);
+        //Act
+        Session.Fire();
 
-            //Act
-            Session.Fire();
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(3, matches.Length);
+        Assert.Equal("fact1", matches[0].Declaration.Name);
+        Assert.Same(fact1, matches[0].Value);
+        Assert.Equal("fact2", matches[1].Declaration.Name);
+        Assert.Same(fact2, matches[1].Value);
+        Assert.Equal("fact3", matches[2].Declaration.Name);
+        Assert.Same(fact3, matches[2].Value);
+    }
 
-            //Assert
-            AssertFiredOnce();
-        }
+    [Fact]
+    public void Fire_MatchingMainFactAndSecondPartOfOrGroup_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 { TestProperty = "Invalid Value 2", JoinProperty = fact1.TestProperty };
+        var fact3 = new FactType3 { TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty };
 
-        [Fact]
-        public void Fire_MatchingFactsFirstPart_FactsInContext()
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingMainFactAndBothPartsOfOrGroup_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Invalid Value 3", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType3 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+        Session.Insert(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void Fire_MatchingMainFactAndOnePartOfOrGroupAndMainFactRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        Session.Retract(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingMainFactAndOnePartOfOrGroupAndMainFactUpdatedToInvalid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact1.TestProperty = "Invalid Value";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingMainFactAndOnePartOfOrGroupAndGroupFactRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingMainFactAndOnePartOfOrGroupAndGroupFactUpdatedToInvalid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact2.TestProperty = "Invalid Value";
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class FactType3
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public Action<IContext> Action = ctx => { };
+
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+            FactType1 fact1 = null;
+            FactType2 fact2 = null;
+            FactType3 fact3 = null;
 
-            Session.Insert(fact1);
-            Session.Insert(fact2);
+            When()
+                .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                .Or(x => x
+                    .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty)
+                    .And(xx => xx
+                        .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Invalid"), f => f.JoinProperty == fact1.TestProperty)
+                        .Match<FactType3>(() => fact3, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty)));
 
-            IFactMatch[] matches = null;
-            GetRuleInstance<TestRule>().Action = ctx =>
-            {
-                matches = ctx.Match.Facts.ToArray();
-            };
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(3, matches.Length);
-            Assert.Equal("fact1", matches[0].Declaration.Name);
-            Assert.Same(fact1, matches[0].Value);
-            Assert.Equal("fact2", matches[1].Declaration.Name);
-            Assert.Same(fact2, matches[1].Value);
-            Assert.Equal("fact3", matches[2].Declaration.Name);
-            Assert.Null(matches[2].Value);
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsSecondPart_FactsInContext()
-        {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
-            var fact2 = new FactType2 { TestProperty = "Invalid Value 2", JoinProperty = fact1.TestProperty };
-            var fact3 = new FactType3 { TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty };
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            IFactMatch[] matches = null;
-            GetRuleInstance<TestRule>().Action = ctx =>
-            {
-                matches = ctx.Match.Facts.ToArray();
-            };
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(3, matches.Length);
-            Assert.Equal("fact1", matches[0].Declaration.Name);
-            Assert.Same(fact1, matches[0].Value);
-            Assert.Equal("fact2", matches[1].Declaration.Name);
-            Assert.Same(fact2, matches[1].Value);
-            Assert.Equal("fact3", matches[2].Declaration.Name);
-            Assert.Same(fact3, matches[2].Value);
-        }
-
-        [Fact]
-        public void Fire_MatchingMainFactAndSecondPartOfOrGroup_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 { TestProperty = "Invalid Value 2", JoinProperty = fact1.TestProperty };
-            var fact3 = new FactType3 { TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty };
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingMainFactAndBothPartsOfOrGroup_FiresTwice()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Invalid Value 3", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType3 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-            Session.Insert(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        [Fact]
-        public void Fire_MatchingMainFactAndOnePartOfOrGroupAndMainFactRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            Session.Retract(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingMainFactAndOnePartOfOrGroupAndMainFactUpdatedToInvalid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact1.TestProperty = "Invalid Value";
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingMainFactAndOnePartOfOrGroupAndGroupFactRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            Session.Retract(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingMainFactAndOnePartOfOrGroupAndGroupFactUpdatedToInvalid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact2.TestProperty = "Invalid Value";
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class FactType3
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public Action<IContext> Action = ctx => { };
-
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-                FactType2 fact2 = null;
-                FactType3 fact3 = null;
-
-                When()
-                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                    .Or(x => x
-                        .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty)
-                        .And(xx => xx
-                            .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Invalid"), f => f.JoinProperty == fact1.TestProperty)
-                            .Match<FactType3>(() => fact3, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty)));
-
-                Then()
-                    .Do(ctx => Action(ctx));
-            }
+            Then()
+                .Do(ctx => Action(ctx));
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/ThreeFactTwoExistsRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/ThreeFactTwoExistsRuleTest.cs
@@ -2,288 +2,287 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class ThreeFactTwoExistsRuleTest : BaseRuleTestFixture
 {
-    public class ThreeFactTwoExistsRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchingFacts_FiresOnce()
     {
-        [Fact]
-        public void Fire_MatchingFacts_FiresOnce()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+    
+    [Fact]
+    public void Fire_NoMatchingFactsBothKind_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_NoMatchingFactsFirstKind_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+    
+    [Fact]
+    public void Fire_NoMatchingFactsSecondKind_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsInsertedThenRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+        Session.Retract(fact2);
+        Session.Retract(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsTwoInsertedThenFirstRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsTwoInsertedThenSecondRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+        Session.Retract(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_InvalidFactsInsertedThenUpdated_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Invalid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Invalid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        fact2.TestProperty = "Valid Value 2";
+        Session.Update(fact2);
+
+        fact3.TestProperty = "Valid Value 3";
+        Session.Update(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsInsertedThenUpdated_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        fact2.TestProperty = "Invalid Value 2";
+        Session.Update(fact2);
+
+        fact3.TestProperty = "Invalid Value 3";
+        Session.Update(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsTwoInsertedThenFirstUpdated_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        fact2.TestProperty = "Invalid Value 2";
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsTwoInsertedThenSecondUpdated_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        fact3.TestProperty = "Invalid Value 3";
+        Session.Update(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsInsertedThenSomeRetractedRetracted_StillFires()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType3 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
+
+        var facts = new object[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+        Session.Retract(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class FactType3
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+            FactType1 fact1 = null;
 
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-        
-        [Fact]
-        public void Fire_NoMatchingFactsBothKind_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_NoMatchingFactsFirstKind_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-        
-        [Fact]
-        public void Fire_NoMatchingFactsSecondKind_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsInsertedThenRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-            Session.Retract(fact2);
-            Session.Retract(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsTwoInsertedThenFirstRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-            Session.Retract(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsTwoInsertedThenSecondRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-            Session.Retract(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_InvalidFactsInsertedThenUpdated_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Invalid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Invalid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            fact2.TestProperty = "Valid Value 2";
-            Session.Update(fact2);
-
-            fact3.TestProperty = "Valid Value 3";
-            Session.Update(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsInsertedThenUpdated_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            fact2.TestProperty = "Invalid Value 2";
-            Session.Update(fact2);
-
-            fact3.TestProperty = "Invalid Value 3";
-            Session.Update(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsTwoInsertedThenFirstUpdated_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            fact2.TestProperty = "Invalid Value 2";
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsTwoInsertedThenSecondUpdated_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            fact3.TestProperty = "Invalid Value 3";
-            Session.Update(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsInsertedThenSomeRetractedRetracted_StillFires()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType3 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
-
-            var facts = new object[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
-            Session.Retract(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class FactType3
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-
-                When()
-                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                    .Exists<FactType2>(f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty)
-                    .Exists<FactType3>(f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty);
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                .Exists<FactType2>(f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty)
+                .Exists<FactType3>(f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty);
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/ThreeFactTwoNotRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/ThreeFactTwoNotRuleTest.cs
@@ -2,320 +2,319 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class ThreeFactTwoNotRuleTest : BaseRuleTestFixture
 {
-    public class ThreeFactTwoNotRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_NotMatchingNotPatternFacts_FiresOnce()
     {
-        [Fact]
-        public void Fire_NotMatchingNotPatternFacts_FiresOnce()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+    
+    [Fact]
+    public void Fire_MatchingNotPatternFactsBothKind_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+    
+    [Fact]
+    public void Fire_MatchingNotPatternFactsFirst_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingNotPatternFactsSecondKind_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingNotPatternFactsInsertedThenRetracted_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+        Session.RetractAll(new object[] {fact2, fact3});
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingNotPatternFactsTwoInsertedThenFirstRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingNotPatternFactsTwoInsertedThenSecondRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+        Session.Retract(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_InvalidNotPatternFactsInsertedThenUpdated_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Invalid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Invalid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        fact2.TestProperty = "Valid Value 2";
+        Session.Update(fact2);
+
+        fact3.TestProperty = "Valid Value 3";
+        Session.Update(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingNotPatternFactsInsertedThenUpdated_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        fact2.TestProperty = "Invalid Value 2";
+        Session.Update(fact2);
+
+        fact3.TestProperty = "Invalid Value 3";
+        Session.Update(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingNotPatternFactsTwoInsertedThenFirstUpdated_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        fact2.TestProperty = "Invalid Value 2";
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingNotPatternFactsTwoInsertedThenSecondUpdated_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        fact3.TestProperty = "Invalid Value 3";
+        Session.Update(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingNotPatternFactsInsertedThenRetractSomeOfThemButNotAll_StillDoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
+
+        var fact5 = new FactType3 {TestProperty = "Valid Value 5", JoinProperty = fact1.TestProperty};
+        var fact6 = new FactType3 {TestProperty = "Valid Value 6", JoinProperty = fact1.TestProperty};
+
+        var allFacts = new object[] {fact1, fact2, fact3, fact4, fact5, fact6};
+        Session.InsertAll(allFacts);
+        Session.RetractAll(new object[] {fact3, fact4, fact5});
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingNotPatternFactsInsertedTheUpdatesSomeOfThemButNotAll_StillDoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
+
+        var fact5 = new FactType3 {TestProperty = "Valid Value 5", JoinProperty = fact1.TestProperty};
+        var fact6 = new FactType3 {TestProperty = "Valid Value 6", JoinProperty = fact1.TestProperty};
+
+        var allFacts = new object[] {fact1, fact2, fact3, fact4, fact5, fact6};
+        Session.InsertAll(allFacts);
+
+        fact3.JoinProperty = "FakeJoinProp";
+        fact4.JoinProperty = "FakeJoinProp";
+        fact5.JoinProperty = "FakeJoinProp";
+        var facts = new object[] {fact3, fact4, fact5};
+        Session.UpdateAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class FactType3
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-        
-        [Fact]
-        public void Fire_MatchingNotPatternFactsBothKind_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-        
-        [Fact]
-        public void Fire_MatchingNotPatternFactsFirst_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingNotPatternFactsSecondKind_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingNotPatternFactsInsertedThenRetracted_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-            Session.RetractAll(new object[] {fact2, fact3});
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingNotPatternFactsTwoInsertedThenFirstRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-            Session.Retract(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingNotPatternFactsTwoInsertedThenSecondRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-            Session.Retract(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_InvalidNotPatternFactsInsertedThenUpdated_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Invalid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Invalid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            fact2.TestProperty = "Valid Value 2";
-            Session.Update(fact2);
-
-            fact3.TestProperty = "Valid Value 3";
-            Session.Update(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingNotPatternFactsInsertedThenUpdated_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            fact2.TestProperty = "Invalid Value 2";
-            Session.Update(fact2);
-
-            fact3.TestProperty = "Invalid Value 3";
-            Session.Update(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingNotPatternFactsTwoInsertedThenFirstUpdated_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            fact2.TestProperty = "Invalid Value 2";
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingNotPatternFactsTwoInsertedThenSecondUpdated_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType3 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            fact3.TestProperty = "Invalid Value 3";
-            Session.Update(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingNotPatternFactsInsertedThenRetractSomeOfThemButNotAll_StillDoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
-
-            var fact5 = new FactType3 {TestProperty = "Valid Value 5", JoinProperty = fact1.TestProperty};
-            var fact6 = new FactType3 {TestProperty = "Valid Value 6", JoinProperty = fact1.TestProperty};
-
-            var allFacts = new object[] {fact1, fact2, fact3, fact4, fact5, fact6};
-            Session.InsertAll(allFacts);
-            Session.RetractAll(new object[] {fact3, fact4, fact5});
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingNotPatternFactsInsertedTheUpdatesSomeOfThemButNotAll_StillDoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
-
-            var fact5 = new FactType3 {TestProperty = "Valid Value 5", JoinProperty = fact1.TestProperty};
-            var fact6 = new FactType3 {TestProperty = "Valid Value 6", JoinProperty = fact1.TestProperty};
-
-            var allFacts = new object[] {fact1, fact2, fact3, fact4, fact5, fact6};
-            Session.InsertAll(allFacts);
-
-            fact3.JoinProperty = "FakeJoinProp";
-            fact4.JoinProperty = "FakeJoinProp";
-            fact5.JoinProperty = "FakeJoinProp";
-            var facts = new object[] {fact3, fact4, fact5};
-            Session.UpdateAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class FactType3
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-
-                When()
-                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                    .Not<FactType2>(f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty)
-                    .Not<FactType3>(f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty);
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            FactType1 fact1 = null;
+
+            When()
+                .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                .Not<FactType2>(f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty)
+                .Not<FactType3>(f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty);
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TwoFactCalculateRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TwoFactCalculateRuleTest.cs
@@ -2,237 +2,236 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class TwoFactCalculateRuleTest : BaseRuleTestFixture
 {
-    public class TwoFactCalculateRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKind_FiresOnce()
     {
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKind_FiresOnce()
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Valid Value 1|Valid Value 2", GetFiredFact<CalculatedFact3>().Value);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKindNullFact_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1", ShouldProduceNull3 = true };
+        var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Null(GetFiredFact<CalculatedFact3>());
+        Assert.NotNull(GetFiredFact<CalculatedFact4>());
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKindNullFactFilteredOut_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1", ShouldProduceNull4 = true };
+        var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKindSecondFactUpdated_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact2.TestProperty = "Valid Value 22";
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Valid Value 1|Valid Value 22", GetFiredFact<CalculatedFact3>().Value);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKindFireThenSecondFactUpdated_FiresTwice()
+    {
+        //Arrange - 1
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredOnce();
+        Assert.Equal("Valid Value 1|Valid Value 2", GetFiredFact<CalculatedFact3>(0).Value);
+
+        //Arrange - 2
+        fact2.TestProperty = "Valid Value 22";
+        Session.Update(fact2);
+
+        //Act - 2
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTwice();
+        Assert.Equal("Valid Value 1|Valid Value 22", GetFiredFact<CalculatedFact3>(1).Value);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKindSecondFactUpdatedToInvalidateBindingCondition_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact2.Counter = 1;
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKindSecondFactRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingSetsOfFacts_FiresTwiceCalculatesPerSet()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 11" };
+        var fact21 = new FactType2 { TestProperty = "Valid Value 21", JoinProperty = "Valid Value 11" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 12" };
+        var fact22 = new FactType2 { TestProperty = "Valid Value 22", JoinProperty = "Valid Value 12" };
+        Session.InsertAll(new []{fact11, fact12});
+        Session.InsertAll(new []{fact21, fact22});
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal("Valid Value 11|Valid Value 21", GetFiredFact<CalculatedFact3>(0).Value);
+        Assert.Equal("Valid Value 12|Valid Value 22", GetFiredFact<CalculatedFact3>(1).Value);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+        public int Counter { get; set; }
+        public bool ShouldProduceNull3 { get; set; }
+        public bool ShouldProduceNull4 { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public int Counter { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class CalculatedFact3
+    {
+        public CalculatedFact3(FactType1 fact1, FactType2 fact2)
         {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
-            var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Valid Value 1|Valid Value 2", GetFiredFact<CalculatedFact3>().Value);
+            Value = $"{fact1.TestProperty}|{fact2.TestProperty}";
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKindNullFact_FiresOnce()
+        public string Value { get; }
+    }
+
+    public class CalculatedFact4
+    {
+        public CalculatedFact4(FactType1 fact1, FactType2 fact2)
         {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1", ShouldProduceNull3 = true };
-            var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Null(GetFiredFact<CalculatedFact3>());
-            Assert.NotNull(GetFiredFact<CalculatedFact4>());
+            Value = fact1.Counter + fact2.Counter;
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKindNullFactFilteredOut_DoesNotFire()
+        public long Value { get; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1", ShouldProduceNull4 = true };
-            var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact1);
-            Session.Insert(fact2);
+            FactType1 fact1 = null;
+            FactType2 fact2 = null;
+            CalculatedFact3 fact3 = null;
+            CalculatedFact4 fact4 = null;
 
-            //Act
-            Session.Fire();
+            When()
+                .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty)
+                .Let(() => fact3, () => CreateFact3(fact1, fact2))
+                .Let(() => fact4, () => CreateFact4(fact1, fact2))
+                .Having(() => fact4 != null && fact4.Value == 0);
 
-            //Assert
-            AssertDidNotFire();
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKindSecondFactUpdated_FiresOnce()
+        private static CalculatedFact3 CreateFact3(FactType1 fact1, FactType2 fact2)
         {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
-            var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact2.TestProperty = "Valid Value 22";
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Valid Value 1|Valid Value 22", GetFiredFact<CalculatedFact3>().Value);
+            if (fact1.ShouldProduceNull3) return null;
+            return new CalculatedFact3(fact1, fact2);
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKindFireThenSecondFactUpdated_FiresTwice()
+        private static CalculatedFact4 CreateFact4(FactType1 fact1, FactType2 fact2)
         {
-            //Arrange - 1
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
-            var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredOnce();
-            Assert.Equal("Valid Value 1|Valid Value 2", GetFiredFact<CalculatedFact3>(0).Value);
-
-            //Arrange - 2
-            fact2.TestProperty = "Valid Value 22";
-            Session.Update(fact2);
-
-            //Act - 2
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTwice();
-            Assert.Equal("Valid Value 1|Valid Value 22", GetFiredFact<CalculatedFact3>(1).Value);
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKindSecondFactUpdatedToInvalidateBindingCondition_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
-            var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact2.Counter = 1;
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKindSecondFactRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
-            var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1" };
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            Session.Retract(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingSetsOfFacts_FiresTwiceCalculatesPerSet()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 11" };
-            var fact21 = new FactType2 { TestProperty = "Valid Value 21", JoinProperty = "Valid Value 11" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 12" };
-            var fact22 = new FactType2 { TestProperty = "Valid Value 22", JoinProperty = "Valid Value 12" };
-            Session.InsertAll(new []{fact11, fact12});
-            Session.InsertAll(new []{fact21, fact22});
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal("Valid Value 11|Valid Value 21", GetFiredFact<CalculatedFact3>(0).Value);
-            Assert.Equal("Valid Value 12|Valid Value 22", GetFiredFact<CalculatedFact3>(1).Value);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-            public int Counter { get; set; }
-            public bool ShouldProduceNull3 { get; set; }
-            public bool ShouldProduceNull4 { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public int Counter { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class CalculatedFact3
-        {
-            public CalculatedFact3(FactType1 fact1, FactType2 fact2)
-            {
-                Value = $"{fact1.TestProperty}|{fact2.TestProperty}";
-            }
-
-            public string Value { get; }
-        }
-
-        public class CalculatedFact4
-        {
-            public CalculatedFact4(FactType1 fact1, FactType2 fact2)
-            {
-                Value = fact1.Counter + fact2.Counter;
-            }
-
-            public long Value { get; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-                FactType2 fact2 = null;
-                CalculatedFact3 fact3 = null;
-                CalculatedFact4 fact4 = null;
-
-                When()
-                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                    .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty)
-                    .Let(() => fact3, () => CreateFact3(fact1, fact2))
-                    .Let(() => fact4, () => CreateFact4(fact1, fact2))
-                    .Having(() => fact4 != null && fact4.Value == 0);
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-
-            private static CalculatedFact3 CreateFact3(FactType1 fact1, FactType2 fact2)
-            {
-                if (fact1.ShouldProduceNull3) return null;
-                return new CalculatedFact3(fact1, fact2);
-            }
-
-            private static CalculatedFact4 CreateFact4(FactType1 fact1, FactType2 fact2)
-            {
-                if (fact1.ShouldProduceNull4) return null;
-                return new CalculatedFact4(fact1, fact2);
-            }
+            if (fact1.ShouldProduceNull4) return null;
+            return new CalculatedFact4(fact1, fact2);
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TwoFactFilterRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TwoFactFilterRuleTest.cs
@@ -2,198 +2,197 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class TwoFactFilterRuleTest : BaseRuleTestFixture
 {
-    public class TwoFactFilterRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchingFacts_Fires()
     {
-        [Fact]
-        public void Fire_MatchingFacts_Fires()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = true};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = true};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsInsertAndFireThenUpdateKey1ChangedAndFire_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = true};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = true};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        fact2.TestProperty = "Valid Value 22";
+        Session.Update(fact2);
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsInsertAndFireThenUpdateKey1TwiceNoEffectiveChangeAndFire_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = true};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = true};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        fact2.TestProperty = "Valid Value 22";
+        Session.Update(fact2);
+        fact2.TestProperty = "Valid Value 2";
+        Session.Update(fact2);
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsInsertAndFireThenUpdateKey2ChangedAndFire_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = true};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = true};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        fact1.TestProperty = "Valid Value 11";
+        Session.Update(fact1);
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsInsertAndFireThenUpdateKeyDidNotChangeAndFire_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = true};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = true};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        Session.Update(fact2);
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsOnePredicateDoesNotAllow_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = false};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = true};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsSecondPredicateDoesNotAllow_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = true};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = false};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsBothPredicatesDoNotAllow_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = false};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = false};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+        public bool Allow { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public bool Allow { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = true};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = true};
+            FactType1 fact1 = null;
+            FactType2 fact2 = null;
 
-            Session.Insert(fact1);
-            Session.Insert(fact2);
+            When()
+                .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"));
 
-            //Act
-            Session.Fire();
+            Filter()
+                .OnChange(() => fact1.TestProperty, () => fact2.TestProperty)
+                .Where(() => fact1.Allow, () => fact2.Allow);
 
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsInsertAndFireThenUpdateKey1ChangedAndFire_FiresTwice()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = true};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = true};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            fact2.TestProperty = "Valid Value 22";
-            Session.Update(fact2);
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsInsertAndFireThenUpdateKey1TwiceNoEffectiveChangeAndFire_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = true};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = true};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            fact2.TestProperty = "Valid Value 22";
-            Session.Update(fact2);
-            fact2.TestProperty = "Valid Value 2";
-            Session.Update(fact2);
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsInsertAndFireThenUpdateKey2ChangedAndFire_FiresTwice()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = true};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = true};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            fact1.TestProperty = "Valid Value 11";
-            Session.Update(fact1);
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsInsertAndFireThenUpdateKeyDidNotChangeAndFire_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = true};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = true};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            Session.Update(fact2);
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsOnePredicateDoesNotAllow_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = false};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = true};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsSecondPredicateDoesNotAllow_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = true};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = false};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsBothPredicatesDoNotAllow_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", Allow = false};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", Allow = false};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-            public bool Allow { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public bool Allow { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-                FactType2 fact2 = null;
-
-                When()
-                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                    .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"));
-
-                Filter()
-                    .OnChange(() => fact1.TestProperty, () => fact2.TestProperty)
-                    .Where(() => fact1.Allow, () => fact2.Allow);
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneCollectionRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneCollectionRuleTest.cs
@@ -6,374 +6,373 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class TwoFactOneCollectionRuleTest : BaseRuleTestFixture
 {
-    public class TwoFactOneCollectionRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFactOfOneKindAndTwoOfAnother_FiresOnceWithTwoFactsInCollection()
     {
-        [Fact]
-        public void Fire_OneMatchingFactOfOneKindAndTwoOfAnother_FiresOnceWithTwoFactsInCollection()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = null};
+        var fact4 = new FactType2 {TestProperty = "Invalid Value 4", JoinProperty = fact1.TestProperty};
+        var fact5 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4, fact5};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<IEnumerable<FactType2>>().Count());
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfOneKindAndNoneOfAnother_FiresOnceWithEmptyCollection()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<IEnumerable<FactType2>>());
+    }
+
+    [Fact]
+    public void Fire_OneMatchingSetOfFacts_FactsInContext()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        IFactMatch[] matches = null;
+        GetRuleInstance<TestRule>().Action = ctx =>
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = null};
-            var fact4 = new FactType2 {TestProperty = "Invalid Value 4", JoinProperty = fact1.TestProperty};
-            var fact5 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact1.TestProperty};
+            matches = ctx.Match.Facts.ToArray();
+        };
+        
+        //Act
+        Session.Fire();
 
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4, fact5};
-            Session.InsertAll(facts);
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, matches.Length);
+        Assert.Equal("fact", matches[0].Declaration.Name);
+        Assert.Same(fact1, matches[0].Value);
+        Assert.Equal("collection", matches[1].Declaration.Name);
+        Assert.Equal(new[] { fact2 }, (IEnumerable<FactType2>)matches[1].Value);
+    }
 
-            //Act
-            Session.Fire();
+    [Fact]
+    public void Fire_OneMatchingFactOfOneKindAndTwoOfAnotherThenFireThenAnotherMatchingFactThenFire_FiresOnceWithTwoFactsInCollectionThenFiresAgainWithThreeFacts()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact21 = new FactType2 {TestProperty = "Valid Value 21", JoinProperty = fact1.TestProperty};
+        var fact22 = new FactType2 {TestProperty = "Valid Value 22", JoinProperty = fact1.TestProperty};
+        var fact23 = new FactType2 {TestProperty = "Valid Value 23", JoinProperty = fact1.TestProperty};
 
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<IEnumerable<FactType2>>().Count());
-        }
+        Session.Insert(fact1);
+        Session.Insert(fact21);
+        Session.Insert(fact22);
 
-        [Fact]
-        public void Fire_OneMatchingFactOfOneKindAndNoneOfAnother_FiresOnceWithEmptyCollection()
+        //Act
+        Session.Fire();
+        var actualCount1 = GetFiredFact<IEnumerable<FactType2>>().Count();
+        Session.Insert(fact23);
+        Session.Fire();
+        var actualCount2 = GetFiredFact<IEnumerable<FactType2>>().Count();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(2, actualCount1);
+        Assert.Equal(3, actualCount2);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfOneKindAndTwoOfAnotherThenAnotherMatchingFactThenFire_FiresOnceWithThreeFactsInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact21 = new FactType2 {TestProperty = "Valid Value 21", JoinProperty = fact1.TestProperty};
+        var fact22 = new FactType2 {TestProperty = "Valid Value 22", JoinProperty = fact1.TestProperty};
+        var fact23 = new FactType2 {TestProperty = "Valid Value 23", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact21, fact22, fact23};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+        var actualCount = GetFiredFact<IEnumerable<FactType2>>().Count();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(3, actualCount);
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsValidAndTwoOfAnotherKindAreAssertedThenOneRetracted_FiresOnceWithOneFactInCollection()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3};
+        Session.InsertAll(facts);
+
+        Session.Retract(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Single(GetFiredFact<IEnumerable<FactType2>>());
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsValidAndTwoOfAnotherKindAreAssertedThenRetracted_FiresOnceWithEmptyCollection()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3};
+        Session.InsertAll(facts);
+
+        Session.Retract(fact2);
+        Session.Retract(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Empty(GetFiredFact<IEnumerable<FactType2>>());
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsInvalidAndTwoOfAnotherKindAreValid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Invalid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Invalid Value 3", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsAssertedThenRetractedAndTwoOfAnotherKindAreValid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Invalid Value 3", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        Session.Retract(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsAssertedThenUpdatedToInvalidAndTwoOfAnotherKindAreValid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Invalid Value 3", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact1.TestProperty = "Invalid Value 1";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoFactsOfOneKindAndAggregatedFactsMatchingOneOfTheFacts_FiresOnceWithTwoFactsAndOnceWithEmptyCollection()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2"};
+        var fact21 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact11.TestProperty};
+        var fact22 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact11.TestProperty};
+
+        Session.Insert(fact11);
+        Session.Insert(fact12);
+        Session.Insert(fact21);
+        Session.Insert(fact22);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(2, GetFiredFact<IEnumerable<FactType2>>(0).Count());
+        Assert.Empty(GetFiredFact<IEnumerable<FactType2>>(1));
+    }
+
+    [Fact]
+    public void Fire_TwoFactsOfOneKindAndAggregatedFactsMatchingBothOfTheFacts_FiresTwiceWithCorrectCounts()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2"};
+        var fact21 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact11.TestProperty};
+        var fact22 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact11.TestProperty};
+        var fact23 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact12.TestProperty};
+
+        Session.Insert(fact11);
+        Session.Insert(fact12);
+        var facts = new[] {fact21, fact22, fact23};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal(2, GetFiredFact<IEnumerable<FactType2>>(0).Count());
+        Assert.Single(GetFiredFact<IEnumerable<FactType2>>(1));
+    }
+
+    [Fact]
+    public void Fire_TwoMatchedSetsThenOneFactOfFirstKindUpdated_FiresTwiceThenFiresOnce()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2"};
+        var fact21 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact11.TestProperty};
+        var fact22 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact11.TestProperty};
+        var fact23 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact12.TestProperty};
+
+        Session.Insert(fact11);
+        Session.Insert(fact12);
+        var facts = new[] {fact21, fact22, fact23};
+        Session.InsertAll(facts);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredTwice();
+
+        //Act - 2
+        Session.Update(fact11);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTimes(3);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchedSetsThenOneFactOfSecondKindUpdated_FiresTwiceThenFiresOnce()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2"};
+        var fact21 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact11.TestProperty};
+        var fact22 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact11.TestProperty};
+        var fact23 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact12.TestProperty};
+
+        Session.Insert(fact11);
+        Session.Insert(fact12);
+        var facts = new[] {fact21, fact22, fact23};
+        Session.InsertAll(facts);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredTwice();
+
+        //Act - 2
+        Session.Update(fact21);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTimes(3);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public Action<IContext> Action = ctx => { };
+
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<IEnumerable<FactType2>>());
-        }
-
-        [Fact]
-        public void Fire_OneMatchingSetOfFacts_FactsInContext()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            IFactMatch[] matches = null;
-            GetRuleInstance<TestRule>().Action = ctx =>
-            {
-                matches = ctx.Match.Facts.ToArray();
-            };
-            
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, matches.Length);
-            Assert.Equal("fact", matches[0].Declaration.Name);
-            Assert.Same(fact1, matches[0].Value);
-            Assert.Equal("collection", matches[1].Declaration.Name);
-            Assert.Equal(new[] { fact2 }, (IEnumerable<FactType2>)matches[1].Value);
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactOfOneKindAndTwoOfAnotherThenFireThenAnotherMatchingFactThenFire_FiresOnceWithTwoFactsInCollectionThenFiresAgainWithThreeFacts()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact21 = new FactType2 {TestProperty = "Valid Value 21", JoinProperty = fact1.TestProperty};
-            var fact22 = new FactType2 {TestProperty = "Valid Value 22", JoinProperty = fact1.TestProperty};
-            var fact23 = new FactType2 {TestProperty = "Valid Value 23", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact21);
-            Session.Insert(fact22);
-
-            //Act
-            Session.Fire();
-            var actualCount1 = GetFiredFact<IEnumerable<FactType2>>().Count();
-            Session.Insert(fact23);
-            Session.Fire();
-            var actualCount2 = GetFiredFact<IEnumerable<FactType2>>().Count();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(2, actualCount1);
-            Assert.Equal(3, actualCount2);
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactOfOneKindAndTwoOfAnotherThenAnotherMatchingFactThenFire_FiresOnceWithThreeFactsInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact21 = new FactType2 {TestProperty = "Valid Value 21", JoinProperty = fact1.TestProperty};
-            var fact22 = new FactType2 {TestProperty = "Valid Value 22", JoinProperty = fact1.TestProperty};
-            var fact23 = new FactType2 {TestProperty = "Valid Value 23", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact21, fact22, fact23};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-            var actualCount = GetFiredFact<IEnumerable<FactType2>>().Count();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(3, actualCount);
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsValidAndTwoOfAnotherKindAreAssertedThenOneRetracted_FiresOnceWithOneFactInCollection()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3};
-            Session.InsertAll(facts);
-
-            Session.Retract(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Single(GetFiredFact<IEnumerable<FactType2>>());
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsValidAndTwoOfAnotherKindAreAssertedThenRetracted_FiresOnceWithEmptyCollection()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3};
-            Session.InsertAll(facts);
-
-            Session.Retract(fact2);
-            Session.Retract(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Empty(GetFiredFact<IEnumerable<FactType2>>());
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsInvalidAndTwoOfAnotherKindAreValid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Invalid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Invalid Value 3", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsAssertedThenRetractedAndTwoOfAnotherKindAreValid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Invalid Value 3", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            Session.Retract(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsAssertedThenUpdatedToInvalidAndTwoOfAnotherKindAreValid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Invalid Value 3", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact1.TestProperty = "Invalid Value 1";
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoFactsOfOneKindAndAggregatedFactsMatchingOneOfTheFacts_FiresOnceWithTwoFactsAndOnceWithEmptyCollection()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2"};
-            var fact21 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact11.TestProperty};
-            var fact22 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact11.TestProperty};
-
-            Session.Insert(fact11);
-            Session.Insert(fact12);
-            Session.Insert(fact21);
-            Session.Insert(fact22);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(2, GetFiredFact<IEnumerable<FactType2>>(0).Count());
-            Assert.Empty(GetFiredFact<IEnumerable<FactType2>>(1));
-        }
-
-        [Fact]
-        public void Fire_TwoFactsOfOneKindAndAggregatedFactsMatchingBothOfTheFacts_FiresTwiceWithCorrectCounts()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2"};
-            var fact21 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact11.TestProperty};
-            var fact22 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact11.TestProperty};
-            var fact23 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact12.TestProperty};
-
-            Session.Insert(fact11);
-            Session.Insert(fact12);
-            var facts = new[] {fact21, fact22, fact23};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal(2, GetFiredFact<IEnumerable<FactType2>>(0).Count());
-            Assert.Single(GetFiredFact<IEnumerable<FactType2>>(1));
-        }
-
-        [Fact]
-        public void Fire_TwoMatchedSetsThenOneFactOfFirstKindUpdated_FiresTwiceThenFiresOnce()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2"};
-            var fact21 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact11.TestProperty};
-            var fact22 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact11.TestProperty};
-            var fact23 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact12.TestProperty};
-
-            Session.Insert(fact11);
-            Session.Insert(fact12);
-            var facts = new[] {fact21, fact22, fact23};
-            Session.InsertAll(facts);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredTwice();
-
-            //Act - 2
-            Session.Update(fact11);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTimes(3);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchedSetsThenOneFactOfSecondKindUpdated_FiresTwiceThenFiresOnce()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2"};
-            var fact21 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact11.TestProperty};
-            var fact22 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact11.TestProperty};
-            var fact23 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact12.TestProperty};
-
-            Session.Insert(fact11);
-            Session.Insert(fact12);
-            var facts = new[] {fact21, fact22, fact23};
-            Session.InsertAll(facts);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredTwice();
-
-            //Act - 2
-            Session.Update(fact21);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTimes(3);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public Action<IContext> Action = ctx => { };
-
-            public override void Define()
-            {
-                FactType1 fact = null;
-                IEnumerable<FactType2> collection = null;
-
-                When()
-                    .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
-                    .Query(() => collection, x => x
-                        .Match<FactType2>(
-                            f => f.TestProperty.StartsWith("Valid"),
-                            f => f.JoinProperty == fact.TestProperty)
-                        .Collect());
-                Then()
-                    .Do(ctx => Action(ctx));
-            }
+            FactType1 fact = null;
+            IEnumerable<FactType2> collection = null;
+
+            When()
+                .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
+                .Query(() => collection, x => x
+                    .Match<FactType2>(
+                        f => f.TestProperty.StartsWith("Valid"),
+                        f => f.JoinProperty == fact.TestProperty)
+                    .Collect());
+            Then()
+                .Do(ctx => Action(ctx));
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneExistsCheckRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneExistsCheckRuleTest.cs
@@ -5,329 +5,328 @@ using NRules.IntegrationTests.TestAssets;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class TwoFactOneExistsCheckRuleTest : BaseRuleTestFixture
 {
-    public class TwoFactOneExistsCheckRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchingFacts_FiresOnce()
     {
-        [Fact]
-        public void Fire_MatchingFacts_FiresOnce()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsInReverseOrder_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact2);
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFacts_FactsInContext()
+    {
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty };
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        IFactMatch[] matches = null;
+        GetRuleInstance<TestRule>().Action = ctx =>
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+            matches = ctx.Match.Facts.ToArray();
+        };
 
-            Session.Insert(fact1);
-            Session.Insert(fact2);
+        //Act
+        Session.Fire();
 
-            //Act
-            Session.Fire();
+        //Assert
+        AssertFiredOnce();
+        Assert.Single(matches);
+        Assert.Equal("fact", matches[0].Declaration.Name);
+        Assert.Same(fact1, matches[0].Value);
+    }
 
-            //Assert
-            AssertFiredOnce();
-        }
+    [Fact]
+    public void Fire_MatchingFactsMultipleOfTypeTwo_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
 
-        [Fact]
-        public void Fire_MatchingFactsInReverseOrder_FiresOnce()
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsTwoOfTypeOneMultipleOfTypeTwo_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType1 {TestProperty = "Valid Value 2"};
+        var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact2.TestProperty};
+        var fact5 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact2.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        var facts = new[] {fact3, fact4, fact5};
+        Session.InsertAll(facts);
+
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void Fire_FactOneValidFactTwoAssertedAndRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactOneAssertedAndRetractedFactTwoValid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Retract(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactOneAssertedAndUpdatedFactTwoValid_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_FactOneValidFactTwoAssertedAndUpdatedToInvalid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2"};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact2.TestProperty = "Invalid Value 2";
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactTwoDoesNotExist_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsAndOneFactExists_FiresOnce()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2"};
+        var fact21 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact11.TestProperty};
+
+        var facts = new[] {fact11, fact12};
+        Session.InsertAll(facts);
+        Session.Insert(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingSetsFactOfSecondKindUpdated_DoesNotRefire()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value"};
+        var fact12 = new FactType1 {TestProperty = "Valid Value"};
+        var fact21 = new FactType2 {TestProperty = "Valid Value", JoinProperty = "Valid Value"};
+
+        var facts = new[] {fact11, fact12};
+        Session.InsertAll(facts);
+        Session.Insert(fact21);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredTwice();
+
+        //Act - 2
+        Session.Update(fact21);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingSetsFactOfSecondKindRetractedThenInserted_FiresTwiceThenFiresTwice()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value"};
+        var fact12 = new FactType1 {TestProperty = "Valid Value"};
+        var fact21 = new FactType2 {TestProperty = "Valid Value", JoinProperty = "Valid Value"};
+
+        var facts = new[] {fact11, fact12};
+        Session.InsertAll(facts);
+        Session.Insert(fact21);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredTwice();
+
+        //Act - 2
+        Session.Retract(fact21);
+        Session.Insert(fact21);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTimes(4);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingSetsFactOfFirstKindUpdated_FiresTwiceThenFiresOnce()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value"};
+        var fact12 = new FactType1 {TestProperty = "Valid Value"};
+        var fact21 = new FactType2 {TestProperty = "Valid Value", JoinProperty = "Valid Value"};
+
+        var facts = new[] {fact11, fact12};
+        Session.InsertAll(facts);
+        Session.Insert(fact21);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredTwice();
+
+        //Act - 2
+        Session.Update(fact11);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTimes(3);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public Action<IContext> Action = ctx => { };
+
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact2);
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFacts_FactsInContext()
-        {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value 1" };
-            var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty };
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            IFactMatch[] matches = null;
-            GetRuleInstance<TestRule>().Action = ctx =>
-            {
-                matches = ctx.Match.Facts.ToArray();
-            };
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Single(matches);
-            Assert.Equal("fact", matches[0].Declaration.Name);
-            Assert.Same(fact1, matches[0].Value);
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsMultipleOfTypeTwo_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsTwoOfTypeOneMultipleOfTypeTwo_FiresTwice()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType1 {TestProperty = "Valid Value 2"};
-            var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact2.TestProperty};
-            var fact5 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact2.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            var facts = new[] {fact3, fact4, fact5};
-            Session.InsertAll(facts);
-
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        [Fact]
-        public void Fire_FactOneValidFactTwoAssertedAndRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Retract(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FactOneAssertedAndRetractedFactTwoValid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Retract(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FactOneAssertedAndUpdatedFactTwoValid_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_FactOneValidFactTwoAssertedAndUpdatedToInvalid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2"};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact2.TestProperty = "Invalid Value 2";
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FactTwoDoesNotExist_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsAndOneFactExists_FiresOnce()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2"};
-            var fact21 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact11.TestProperty};
-
-            var facts = new[] {fact11, fact12};
-            Session.InsertAll(facts);
-            Session.Insert(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingSetsFactOfSecondKindUpdated_DoesNotRefire()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value"};
-            var fact12 = new FactType1 {TestProperty = "Valid Value"};
-            var fact21 = new FactType2 {TestProperty = "Valid Value", JoinProperty = "Valid Value"};
-
-            var facts = new[] {fact11, fact12};
-            Session.InsertAll(facts);
-            Session.Insert(fact21);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredTwice();
-
-            //Act - 2
-            Session.Update(fact21);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTwice();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingSetsFactOfSecondKindRetractedThenInserted_FiresTwiceThenFiresTwice()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value"};
-            var fact12 = new FactType1 {TestProperty = "Valid Value"};
-            var fact21 = new FactType2 {TestProperty = "Valid Value", JoinProperty = "Valid Value"};
-
-            var facts = new[] {fact11, fact12};
-            Session.InsertAll(facts);
-            Session.Insert(fact21);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredTwice();
-
-            //Act - 2
-            Session.Retract(fact21);
-            Session.Insert(fact21);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTimes(4);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingSetsFactOfFirstKindUpdated_FiresTwiceThenFiresOnce()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value"};
-            var fact12 = new FactType1 {TestProperty = "Valid Value"};
-            var fact21 = new FactType2 {TestProperty = "Valid Value", JoinProperty = "Valid Value"};
-
-            var facts = new[] {fact11, fact12};
-            Session.InsertAll(facts);
-            Session.Insert(fact21);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredTwice();
-
-            //Act - 2
-            Session.Update(fact11);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTimes(3);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public Action<IContext> Action = ctx => { };
-
-            public override void Define()
-            {
-                FactType1 fact = null;
-
-                When()
-                    .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
-                    .Exists<FactType2>(f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact.TestProperty);
-                Then()
-                    .Do(ctx => Action(ctx));
-            }
+            FactType1 fact = null;
+
+            When()
+                .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
+                .Exists<FactType2>(f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact.TestProperty);
+            Then()
+                .Do(ctx => Action(ctx));
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneForAllCheckRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneForAllCheckRuleTest.cs
@@ -2,199 +2,198 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class TwoFactOneForAllCheckRuleTest : BaseRuleTestFixture
 {
-    public class TwoFactOneForAllCheckRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchingFactOfTypeOneNothigOfTypeTwo_FiresOnce()
     {
-        [Fact]
-        public void Fire_MatchingFactOfTypeOneNothigOfTypeTwo_FiresOnce()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFacts_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactOfTypeOneMultipleOfTypeTwo_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsOfTypeOneMultipleOfTypeTwo_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType1 {TestProperty = "Valid Value 2"};
+        var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact2.TestProperty};
+
+        var facts = new[] {fact1, fact2};
+        Session.InsertAll(facts);
+        var facts2 = new[] {fact3, fact4};
+        Session.InsertAll(facts2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsOfTypeOneOnlyOneOfTypeTwo_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType1 {TestProperty = "Valid Value 2"};
+        var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
+        var fact5 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact2.TestProperty};
+        var fact6 = new FactType2 {TestProperty = "Invalid Value 6", JoinProperty = fact2.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        var facts = new[] {fact3, fact4, fact5, fact6};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactOfTypeOneNotAllMatchingOfTypeTwo_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Invalid Value 4", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsInvalidFactOfTypeTwoInsertedRetracted_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Invalid Value 4", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        Session.Retract(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsInvalidFactOfTypeTwoInsertedUpdatedToValid_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Invalid Value 4", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact3.TestProperty = "Valid Value 4";
+        Session.Update(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+            FactType1 fact = null;
 
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFacts_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactOfTypeOneMultipleOfTypeTwo_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsOfTypeOneMultipleOfTypeTwo_FiresTwice()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType1 {TestProperty = "Valid Value 2"};
-            var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact2.TestProperty};
-
-            var facts = new[] {fact1, fact2};
-            Session.InsertAll(facts);
-            var facts2 = new[] {fact3, fact4};
-            Session.InsertAll(facts2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsOfTypeOneOnlyOneOfTypeTwo_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType1 {TestProperty = "Valid Value 2"};
-            var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact1.TestProperty};
-            var fact5 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact2.TestProperty};
-            var fact6 = new FactType2 {TestProperty = "Invalid Value 6", JoinProperty = fact2.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            var facts = new[] {fact3, fact4, fact5, fact6};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactOfTypeOneNotAllMatchingOfTypeTwo_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Invalid Value 4", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsInvalidFactOfTypeTwoInsertedRetracted_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Invalid Value 4", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            Session.Retract(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsInvalidFactOfTypeTwoInsertedUpdatedToValid_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Invalid Value 4", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value 5", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact3.TestProperty = "Valid Value 4";
-            Session.Update(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact = null;
-
-                When()
-                    .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
-                    .All<FactType2>(f => f.JoinProperty == fact.TestProperty,
-                        f => f.TestProperty.StartsWith("Valid"));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
+                .All<FactType2>(f => f.JoinProperty == fact.TestProperty,
+                    f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneGroupByRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneGroupByRuleTest.cs
@@ -3,410 +3,409 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class TwoFactOneGroupByRuleTest : BaseRuleTestFixture
 {
-    public class TwoFactOneGroupByRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFactOfOneKindAndTwoOfAnother_FiresTwiceWithOneFactInEachGroup()
     {
-        [Fact]
-        public void Fire_OneMatchingFactOfOneKindAndTwoOfAnother_FiresTwiceWithOneFactInEachGroup()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
+        var fact4 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 22" };
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(0));
+        Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(1));
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfOneKindAndNoneOfAnother_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value" };
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfOneKindAndTwoOfAnotherInsertedInOppositeOrder_FiresTwiceWithOneFactInEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
+        var fact4 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 22" };
+
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(0));
+        Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(1));
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfOneKindAndTwoOfAnotherThenFireThenAnotherMatchingFactForSecondGroupThenFire_FiresTwiceWithOneFactInEachGroupThenFiresAgainWithTwoFactsInOneGroup()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
+        var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
+        var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
+
+        Session.Insert(fact1);
+        Session.Insert(fact21);
+        Session.Insert(fact22);
+
+        //Act
+        Session.Fire();
+        var actualCount11 = GetFiredFact<IGrouping<string, FactType2>>(0).Count();
+        var actualCount12 = GetFiredFact<IGrouping<string, FactType2>>(1).Count();
+
+        Session.Insert(fact23);
+        Session.Fire();
+        var actualCount2 = GetFiredFact<IGrouping<string, FactType2>>(2).Count();
+
+        //Assert
+        AssertFiredTimes(3);
+        Assert.Equal(1, actualCount11);
+        Assert.Equal(1, actualCount12);
+        Assert.Equal(2, actualCount2);
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsValidAndTwoOfAnotherKindAreAssertedThenOneRetracted_FiresOnceWithOneFactInGroup()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        Session.Retract(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Single(GetFiredFact<IGrouping<string, FactType2>>());
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsValidAndTwoOfAnotherKindAreAssertedThenRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        Session.Retract(fact2);
+        Session.Retract(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsInvalidAndTwoOfAnotherKindAreValid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Invalid Value 1" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21" };
+        var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsAssertedThenRetractedAndTwoOfAnotherKindAreValid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21" };
+        var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        Session.Retract(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsAssertedThenUpdatedToInvalidAndTwoOfAnotherKindAreValid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21" };
+        var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact1.TestProperty = "Invalid Value 1";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsInvalidThenUpdatedToValidAndTwoOfAnotherKindAreValid_FiresTwiceWithOneFactInEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Invalid Value 1" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21" };
+        var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact1.TestProperty = "Valid Value 1";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(0));
+        Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(1));
+    }
+    
+    [Fact]
+    public void Fire_BulkInsertForMultipleTypes_FiresFourTimesWithCorrectCounts()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1" };
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2" };
+        var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
+        var fact24 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
+
+        var facts = new object[] {fact11, fact12, fact21, fact22, fact23, fact24};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTimes(4);
+        var firedFacts2 = new[]
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
-            var fact4 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 22" };
+            GetFiredFact<IGrouping<string, FactType2>>(0),
+            GetFiredFact<IGrouping<string, FactType2>>(1),
+            GetFiredFact<IGrouping<string, FactType2>>(2),
+            GetFiredFact<IGrouping<string, FactType2>>(3)
+        };
+        var validAmountsPerGroup = firedFacts2.Count(x => x.Count() == 2) == 4;
+        Assert.True(validAmountsPerGroup);
+    }
 
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
+    [Fact]
+    public void Fire_TwoFactsOfOneKindAndAggregatedFactsMatchingBothOfTheFactsInsertInReverse_FiresFourTimesWithCorrectCounts()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1" };
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2" };
+        var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
+        var fact24 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
 
-            //Act
-            Session.Fire();
+        var facts = new[] {fact24, fact23, fact22, fact21};
+        Session.InsertAll(facts);
+        var facts2 = new[] {fact12, fact11};
+        Session.InsertAll(facts2);
 
-            //Assert
-            AssertFiredTwice();
-            Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(0));
-            Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(1));
-        }
+        //Act
+        Session.Fire();
 
-        [Fact]
-        public void Fire_OneMatchingFactOfOneKindAndNoneOfAnother_DoesNotFire()
+        //Assert
+        AssertFiredTimes(4);
+        var firedFacts2 = new[]
         {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value" };
+            GetFiredFact<IGrouping<string, FactType2>>(0),
+            GetFiredFact<IGrouping<string, FactType2>>(1),
+            GetFiredFact<IGrouping<string, FactType2>>(2),
+            GetFiredFact<IGrouping<string, FactType2>>(3)
+        };
+        var validAmountsPerGroup = firedFacts2.Count(x => x.Count() == 2) == 4;
+        Assert.True(validAmountsPerGroup);
+    }
 
-            Session.Insert(fact1);
+    [Fact]
+    public void Fire_TwoMatchingCombinationsThenOneFactOfFirstKindUpdated_FiresTwiceBeforeUpdateAndOnceAfter()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1" };
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2" };
+        var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
 
-            //Act
-            Session.Fire();
+        Session.Insert(fact11);
+        Session.Insert(fact12);
+        Session.Insert(fact21);
+        Session.Insert(fact22);
 
-            //Assert
-            AssertDidNotFire();
-        }
+        //Act - 1
+        Session.Fire();
 
-        [Fact]
-        public void Fire_OneMatchingFactOfOneKindAndTwoOfAnotherInsertedInOppositeOrder_FiresTwiceWithOneFactInEachGroup()
+        //Assert - 1
+        AssertFiredTimes(2);
+
+        //Act - 2
+        Session.Update(fact11);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTimes(3);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingCombinationsThenOneFactOfSecondKindUpdated_FiresTwiceBeforeUpdateAndTwiceAfter()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1" };
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2" };
+        var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+        var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
+
+        Session.Insert(fact11);
+        Session.Insert(fact12);
+        Session.Insert(fact21);
+        Session.Insert(fact22);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredTimes(2);
+
+        //Act - 2
+        Session.Update(fact21);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTimes(4);
+    }
+    
+    [Fact]
+    public void Fire_OneFactOfOneKindAndAggregatedFactsMatchThenAggregatedFactUpdatedWithDifferentGroupKey_FiresTwiceFactsInCorrectGroups()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        var fact21 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 1" };
+        var fact22 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 1" };
+        var fact23 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 2" };
+
+        Session.Insert(fact11);
+        Session.Insert(fact21);
+        Session.Insert(fact22);
+        Session.Insert(fact23);
+
+        fact22.GroupKey = "Group 2";
+        Session.Update(fact22);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal("Group 1", GetFiredFact<IGrouping<string, FactType2>>(0).Key);
+        Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(0));
+        Assert.Equal("Group 2", GetFiredFact<IGrouping<string, FactType2>>(1).Key);
+        Assert.Equal(2, GetFiredFact<IGrouping<string, FactType2>>(1).Count());
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string GroupKey { get; set; }
+        public string TestProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
-            var fact4 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 22" };
-
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(0));
-            Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(1));
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactOfOneKindAndTwoOfAnotherThenFireThenAnotherMatchingFactForSecondGroupThenFire_FiresTwiceWithOneFactInEachGroupThenFiresAgainWithTwoFactsInOneGroup()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
-            var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
-            var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
-
-            Session.Insert(fact1);
-            Session.Insert(fact21);
-            Session.Insert(fact22);
-
-            //Act
-            Session.Fire();
-            var actualCount11 = GetFiredFact<IGrouping<string, FactType2>>(0).Count();
-            var actualCount12 = GetFiredFact<IGrouping<string, FactType2>>(1).Count();
-
-            Session.Insert(fact23);
-            Session.Fire();
-            var actualCount2 = GetFiredFact<IGrouping<string, FactType2>>(2).Count();
-
-            //Assert
-            AssertFiredTimes(3);
-            Assert.Equal(1, actualCount11);
-            Assert.Equal(1, actualCount12);
-            Assert.Equal(2, actualCount2);
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsValidAndTwoOfAnotherKindAreAssertedThenOneRetracted_FiresOnceWithOneFactInGroup()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            Session.Retract(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Single(GetFiredFact<IGrouping<string, FactType2>>());
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsValidAndTwoOfAnotherKindAreAssertedThenRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            Session.Retract(fact2);
-            Session.Retract(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsInvalidAndTwoOfAnotherKindAreValid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Invalid Value 1" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21" };
-            var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsAssertedThenRetractedAndTwoOfAnotherKindAreValid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21" };
-            var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            Session.Retract(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsAssertedThenUpdatedToInvalidAndTwoOfAnotherKindAreValid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21" };
-            var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact1.TestProperty = "Invalid Value 1";
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsInvalidThenUpdatedToValidAndTwoOfAnotherKindAreValid_FiresTwiceWithOneFactInEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Invalid Value 1" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21" };
-            var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact1.TestProperty = "Valid Value 1";
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(0));
-            Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(1));
-        }
-        
-        [Fact]
-        public void Fire_BulkInsertForMultipleTypes_FiresFourTimesWithCorrectCounts()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1" };
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2" };
-            var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
-            var fact24 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
-
-            var facts = new object[] {fact11, fact12, fact21, fact22, fact23, fact24};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTimes(4);
-            var firedFacts2 = new[]
-            {
-                GetFiredFact<IGrouping<string, FactType2>>(0),
-                GetFiredFact<IGrouping<string, FactType2>>(1),
-                GetFiredFact<IGrouping<string, FactType2>>(2),
-                GetFiredFact<IGrouping<string, FactType2>>(3)
-            };
-            var validAmountsPerGroup = firedFacts2.Count(x => x.Count() == 2) == 4;
-            Assert.True(validAmountsPerGroup);
-        }
-
-        [Fact]
-        public void Fire_TwoFactsOfOneKindAndAggregatedFactsMatchingBothOfTheFactsInsertInReverse_FiresFourTimesWithCorrectCounts()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1" };
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2" };
-            var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
-            var fact24 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22" };
-
-            var facts = new[] {fact24, fact23, fact22, fact21};
-            Session.InsertAll(facts);
-            var facts2 = new[] {fact12, fact11};
-            Session.InsertAll(facts2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTimes(4);
-            var firedFacts2 = new[]
-            {
-                GetFiredFact<IGrouping<string, FactType2>>(0),
-                GetFiredFact<IGrouping<string, FactType2>>(1),
-                GetFiredFact<IGrouping<string, FactType2>>(2),
-                GetFiredFact<IGrouping<string, FactType2>>(3)
-            };
-            var validAmountsPerGroup = firedFacts2.Count(x => x.Count() == 2) == 4;
-            Assert.True(validAmountsPerGroup);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingCombinationsThenOneFactOfFirstKindUpdated_FiresTwiceBeforeUpdateAndOnceAfter()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1" };
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2" };
-            var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-
-            Session.Insert(fact11);
-            Session.Insert(fact12);
-            Session.Insert(fact21);
-            Session.Insert(fact22);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredTimes(2);
-
-            //Act - 2
-            Session.Update(fact11);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTimes(3);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingCombinationsThenOneFactOfSecondKindUpdated_FiresTwiceBeforeUpdateAndTwiceAfter()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1" };
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2" };
-            var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-            var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21" };
-
-            Session.Insert(fact11);
-            Session.Insert(fact12);
-            Session.Insert(fact21);
-            Session.Insert(fact22);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredTimes(2);
-
-            //Act - 2
-            Session.Update(fact21);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTimes(4);
-        }
-        
-        [Fact]
-        public void Fire_OneFactOfOneKindAndAggregatedFactsMatchThenAggregatedFactUpdatedWithDifferentGroupKey_FiresTwiceFactsInCorrectGroups()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            var fact21 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 1" };
-            var fact22 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 1" };
-            var fact23 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 2" };
-
-            Session.Insert(fact11);
-            Session.Insert(fact21);
-            Session.Insert(fact22);
-            Session.Insert(fact23);
-
-            fact22.GroupKey = "Group 2";
-            Session.Update(fact22);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal("Group 1", GetFiredFact<IGrouping<string, FactType2>>(0).Key);
-            Assert.Single(GetFiredFact<IGrouping<string, FactType2>>(0));
-            Assert.Equal("Group 2", GetFiredFact<IGrouping<string, FactType2>>(1).Key);
-            Assert.Equal(2, GetFiredFact<IGrouping<string, FactType2>>(1).Count());
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string GroupKey { get; set; }
-            public string TestProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact = null;
-                IGrouping<string, FactType2> group = null;
-
-                When()
-                    .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
-                    .Query(() => group, x => x
-                        .Match<FactType2>(
-                            f => f.TestProperty.StartsWith("Valid"))
-                        .GroupBy(f => f.GroupKey));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            FactType1 fact = null;
+            IGrouping<string, FactType2> group = null;
+
+            When()
+                .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
+                .Query(() => group, x => x
+                    .Match<FactType2>(
+                        f => f.TestProperty.StartsWith("Valid"))
+                    .GroupBy(f => f.GroupKey));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneJoinedGroupByRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneJoinedGroupByRuleTest.cs
@@ -3,516 +3,515 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class TwoFactOneJoinedGroupByRuleTest : BaseRuleTestFixture
 {
-    public class TwoFactOneJoinedGroupByRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFactOfOneKindAndTwoOfAnother_FiresTwiceWithOneFactInEachGroup()
     {
-        [Fact]
-        public void Fire_OneMatchingFactOfOneKindAndTwoOfAnother_FiresTwiceWithOneFactInEachGroup()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = null};
+        var fact4 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
+        var fact5 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 23", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4, fact5};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(0));
+        Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(1));
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfOneKindAndNoneOfAnother_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 { TestProperty = "Valid Value", GroupKey = "Group 11" };
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfOneKindAndTwoOfAnotherInsertedInOppositeOrder_FiresTwiceWithOneFactInEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = null};
+        var fact4 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
+        var fact5 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 23", JoinProperty = fact1.TestProperty};
+
+        var facts = new[] {fact2, fact3, fact4, fact5};
+        Session.InsertAll(facts);
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(0));
+        Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(1));
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfOneKindAndTwoOfAnotherThenFireThenAnotherMatchingFactForSecondGroupThenFire_FiresTwiceWithOneFactInEachGroupThenFiresAgainWithTwoFactsInOneGroup()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
+        var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
+        var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
+        var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact21);
+        Session.Insert(fact22);
+
+        //Act
+        Session.Fire();
+        var actualCount11 = GetFiredFact<IGrouping<string, GroupElement>>(0).Count();
+        var actualCount12 = GetFiredFact<IGrouping<string, GroupElement>>(1).Count();
+
+        Session.Insert(fact23);
+        Session.Fire();
+        var actualCount2 = GetFiredFact<IGrouping<string, GroupElement>>(2).Count();
+
+        //Assert
+        AssertFiredTimes(3);
+        Assert.Equal(1, actualCount11);
+        Assert.Equal(1, actualCount12);
+        Assert.Equal(2, actualCount2);
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsValidAndTwoOfAnotherKindAreAssertedThenOneRetracted_FiresOnceWithOneFactInGroup()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        Session.Retract(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>());
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsValidAndTwoOfAnotherKindAreAssertedThenRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        Session.Retract(fact2);
+        Session.Retract(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsInvalidAndTwoOfAnotherKindAreValid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Invalid Value 1", GroupKey = "Group 11" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsAssertedThenRetractedAndTwoOfAnotherKindAreValid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        Session.Retract(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsAssertedThenUpdatedToInvalidAndTwoOfAnotherKindAreValid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
+        var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact1.TestProperty = "Invalid Value 1";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactOfOneKindIsInvalidThenUpdatedToValidAndTwoOfAnotherKindAreValid_FiresTwiceWithOneFactInEachGroup()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Invalid Value 1", GroupKey = "Group 11" };
+        var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = "Valid Value 1"};
+        var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21", JoinProperty = "Valid Value 1"};
+        var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+        var facts = new[] {fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        fact1.TestProperty = "Valid Value 1";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(0));
+        Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(1));
+    }
+
+    [Fact]
+    public void Fire_TwoFactsOfOneKindAndAggregatedFactsMatchingOneOfTheFacts_FiresOnceWithTwoFactsInGroups()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 1" };
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2", GroupKey = "Group 1" };
+        var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 1", JoinProperty = fact11.TestProperty};
+        var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 1", JoinProperty = fact11.TestProperty};
+
+        Session.Insert(fact11);
+        Session.Insert(fact12);
+        Session.Insert(fact21);
+        Session.Insert(fact22);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal(2, GetFiredFact<IGrouping<string, GroupElement>>().Count());
+    }
+
+    [Fact]
+    public void Fire_TwoFactsOfOneKindAndAggregatedFactsMatchingBothOfTheFacts_FiresThreeTimesWithCorrectCounts()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2", GroupKey = "Group 12" };
+        var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
+        var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
+        var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact11.TestProperty};
+        var fact24 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact12.TestProperty};
+
+        Session.Insert(fact11);
+        Session.Insert(fact12);
+        var facts = new[] {fact21, fact22, fact23, fact24};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTimes(3);
+        var firedFacts2 = new[]
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = null};
-            var fact4 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
-            var fact5 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 23", JoinProperty = fact1.TestProperty};
+            GetFiredFact<IGrouping<string, GroupElement>>(0),
+            GetFiredFact<IGrouping<string, GroupElement>>(1),
+            GetFiredFact<IGrouping<string, GroupElement>>(2)
+        };
+        var firedFacts1 = new[] {GetFiredFact<FactType1>(0), GetFiredFact<FactType1>(1), GetFiredFact<FactType1>(2)};
+        var validAmountsPerGroup = firedFacts2.Count(x => x.Count() == 1) == 2 &&
+                                   firedFacts2.Count(x => x.Count() == 2) == 1;
+        var valid1 = firedFacts1.Count(x => Equals(fact11, x)) == 2;
+        var valid2 = firedFacts1.Count(x => Equals(fact12, x)) == 1;
+        Assert.True(validAmountsPerGroup && valid1 && valid2);
+    }
 
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4, fact5};
-            Session.InsertAll(facts);
+    [Fact]
+    public void Fire_BulkInsertForMultipleTypes_FiresThreeTimesWithCorrectCounts()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11"};
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2", GroupKey = "Group 12" };
+        var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
+        var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
+        var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact11.TestProperty};
+        var fact24 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact12.TestProperty};
 
-            //Act
-            Session.Fire();
+        var facts = new object[] {fact11, fact12, fact21, fact22, fact23, fact24};
+        Session.InsertAll(facts);
 
-            //Assert
-            AssertFiredTwice();
-            Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(0));
-            Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(1));
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTimes(3);
+        var firedFacts2 = new[]
+        {
+            GetFiredFact<IGrouping<string, GroupElement>>(0),
+            GetFiredFact<IGrouping<string, GroupElement>>(1),
+            GetFiredFact<IGrouping<string, GroupElement>>(2)
+        };
+        var firedFacts1 = new[] {GetFiredFact<FactType1>(0), GetFiredFact<FactType1>(1), GetFiredFact<FactType1>(2)};
+        var validAmountsPerGroup = firedFacts2.Count(x => x.Count() == 1) == 2 &&
+                                   firedFacts2.Count(x => x.Count() == 2) == 1;
+        var valid1 = firedFacts1.Count(x => Equals(fact11, x)) == 2;
+        var valid2 = firedFacts1.Count(x => Equals(fact12, x)) == 1;
+        Assert.True(validAmountsPerGroup && valid1 && valid2);
+    }
+
+    [Fact]
+    public void Fire_TwoFactsOfOneKindAndAggregatedFactsMatchingBothOfTheFactsInsertInReverse_FiresThreeTimesWithCorrectCounts()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11"};
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2", GroupKey = "Group 11" };
+        var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
+        var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
+        var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact11.TestProperty};
+        var fact24 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact12.TestProperty};
+
+        var facts = new[] {fact24, fact23, fact22, fact21};
+        Session.InsertAll(facts);
+        var facts2 = new[] {fact12, fact11};
+        Session.InsertAll(facts2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTimes(3);
+        var firedFacts2 = new[]
+        {
+            GetFiredFact<IGrouping<string, GroupElement>>(0),
+            GetFiredFact<IGrouping<string, GroupElement>>(1),
+            GetFiredFact<IGrouping<string, GroupElement>>(2)
+        };
+        var firedFacts1 = new[] {GetFiredFact<FactType1>(0), GetFiredFact<FactType1>(1), GetFiredFact<FactType1>(2)};
+        var validAmountsPerGroup = firedFacts2.Count(x => x.Count() == 1) == 2 &&
+                                   firedFacts2.Count(x => x.Count() == 2) == 1;
+        var valid1 = firedFacts1.Count(x => Equals(fact11, x)) == 2;
+        var valid2 = firedFacts1.Count(x => Equals(fact12, x)) == 1;
+        Assert.True(validAmountsPerGroup && valid1 && valid2);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingCombinationsThenOneFactOfFirstKindUpdated_FiresTwiceBeforeUpdateAndOnceAfter()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11"};
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2", GroupKey = "Group 12" };
+        var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
+        var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact12.TestProperty};
+
+        Session.Insert(fact11);
+        Session.Insert(fact12);
+        Session.Insert(fact21);
+        Session.Insert(fact22);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredTimes(2);
+
+        //Act - 2
+        Session.Update(fact11);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTimes(3);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingCombinationsThenOneFactOfSecondKindUpdated_FiresTwiceBeforeUpdateAndOnceAfter()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11"};
+        var fact12 = new FactType1 {TestProperty = "Valid Value 2", GroupKey = "Group 12" };
+        var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
+        var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact12.TestProperty};
+
+        Session.Insert(fact11);
+        Session.Insert(fact12);
+        Session.Insert(fact21);
+        Session.Insert(fact22);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredTimes(2);
+
+        //Act - 2
+        Session.Update(fact21);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTimes(3);
+    }
+
+    [Fact]
+    public void Fire_OneFactOfOneKindAndAggregatedFactsMatchThenFactUpdatedWithDifferentGroupKey_FiresOnceFactsInNewGroup()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", GroupKey = "Group 1" };
+        var fact21 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 1", JoinProperty = fact11.TestProperty };
+        var fact22 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 1", JoinProperty = fact11.TestProperty };
+
+        Session.Insert(fact11);
+        Session.Insert(fact21);
+        Session.Insert(fact22);
+
+        fact11.GroupKey = "Group 2";
+        Session.Update(fact11);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Group 2|Group 1", GetFiredFact<IGrouping<string, GroupElement>>().Key);
+    }
+
+    [Fact]
+    public void Fire_OneFactOfOneKindAndAggregatedFactsMatchThenAggregatedFactUpdatedWithDifferentGroupKey_FiresTwiceFactsInCorrectGroups()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", GroupKey = "Group 1" };
+        var fact21 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 1", JoinProperty = fact11.TestProperty };
+        var fact22 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 1", JoinProperty = fact11.TestProperty };
+        var fact23 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 2", JoinProperty = fact11.TestProperty };
+
+        Session.Insert(fact11);
+        Session.Insert(fact21);
+        Session.Insert(fact22);
+        Session.Insert(fact23);
+
+        fact22.GroupKey = "Group 2";
+        Session.Update(fact22);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal("Group 1|Group 1", GetFiredFact<IGrouping<string, GroupElement>>(0).Key);
+        Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(0));
+        Assert.Equal("Group 1|Group 2", GetFiredFact<IGrouping<string, GroupElement>>(1).Key);
+        Assert.Equal(2, GetFiredFact<IGrouping<string, GroupElement>>(1).Count());
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string GroupKey { get; set; }
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string GroupKey { get; set; }
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class GroupElement
+    {
+        public GroupElement(FactType1 fact1, FactType2 fact2)
+        {
+            TestProperty = $"{fact1.TestProperty}|{fact2.TestProperty}";
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactOfOneKindAndNoneOfAnother_DoesNotFire()
+        public string TestProperty { get; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 { TestProperty = "Valid Value", GroupKey = "Group 11" };
+            FactType1 fact = null;
+            IGrouping<string, GroupElement> group = null;
 
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
+            When()
+                .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
+                .Query(() => group, x => x
+                    .Match<FactType2>(
+                        f => f.TestProperty.StartsWith("Valid"),
+                        f => f.JoinProperty == fact.TestProperty)
+                    .GroupBy(f => GetKey(fact, f), f => new GroupElement(fact, f)));
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactOfOneKindAndTwoOfAnotherInsertedInOppositeOrder_FiresTwiceWithOneFactInEachGroup()
+        private static string GetKey(FactType1 fact1, FactType2 fact2)
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = null};
-            var fact4 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
-            var fact5 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 23", JoinProperty = fact1.TestProperty};
-
-            var facts = new[] {fact2, fact3, fact4, fact5};
-            Session.InsertAll(facts);
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(0));
-            Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(1));
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactOfOneKindAndTwoOfAnotherThenFireThenAnotherMatchingFactForSecondGroupThenFire_FiresTwiceWithOneFactInEachGroupThenFiresAgainWithTwoFactsInOneGroup()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
-            var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
-            var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
-            var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact21);
-            Session.Insert(fact22);
-
-            //Act
-            Session.Fire();
-            var actualCount11 = GetFiredFact<IGrouping<string, GroupElement>>(0).Count();
-            var actualCount12 = GetFiredFact<IGrouping<string, GroupElement>>(1).Count();
-
-            Session.Insert(fact23);
-            Session.Fire();
-            var actualCount2 = GetFiredFact<IGrouping<string, GroupElement>>(2).Count();
-
-            //Assert
-            AssertFiredTimes(3);
-            Assert.Equal(1, actualCount11);
-            Assert.Equal(1, actualCount12);
-            Assert.Equal(2, actualCount2);
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsValidAndTwoOfAnotherKindAreAssertedThenOneRetracted_FiresOnceWithOneFactInGroup()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            Session.Retract(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>());
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsValidAndTwoOfAnotherKindAreAssertedThenRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            Session.Retract(fact2);
-            Session.Retract(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsInvalidAndTwoOfAnotherKindAreValid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Invalid Value 1", GroupKey = "Group 11" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsAssertedThenRetractedAndTwoOfAnotherKindAreValid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            Session.Retract(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsAssertedThenUpdatedToInvalidAndTwoOfAnotherKindAreValid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21", JoinProperty = fact1.TestProperty};
-            var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact1.TestProperty = "Invalid Value 1";
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FactOfOneKindIsInvalidThenUpdatedToValidAndTwoOfAnotherKindAreValid_FiresTwiceWithOneFactInEachGroup()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Invalid Value 1", GroupKey = "Group 11" };
-            var fact2 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = "Valid Value 1"};
-            var fact3 = new FactType2 {TestProperty = "Invalid Value", GroupKey = "Group 21", JoinProperty = "Valid Value 1"};
-            var fact4 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-            var facts = new[] {fact2, fact3, fact4};
-            Session.InsertAll(facts);
-
-            fact1.TestProperty = "Valid Value 1";
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(0));
-            Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(1));
-        }
-
-        [Fact]
-        public void Fire_TwoFactsOfOneKindAndAggregatedFactsMatchingOneOfTheFacts_FiresOnceWithTwoFactsInGroups()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 1" };
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2", GroupKey = "Group 1" };
-            var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 1", JoinProperty = fact11.TestProperty};
-            var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 1", JoinProperty = fact11.TestProperty};
-
-            Session.Insert(fact11);
-            Session.Insert(fact12);
-            Session.Insert(fact21);
-            Session.Insert(fact22);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal(2, GetFiredFact<IGrouping<string, GroupElement>>().Count());
-        }
-
-        [Fact]
-        public void Fire_TwoFactsOfOneKindAndAggregatedFactsMatchingBothOfTheFacts_FiresThreeTimesWithCorrectCounts()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11" };
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2", GroupKey = "Group 12" };
-            var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
-            var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
-            var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact11.TestProperty};
-            var fact24 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact12.TestProperty};
-
-            Session.Insert(fact11);
-            Session.Insert(fact12);
-            var facts = new[] {fact21, fact22, fact23, fact24};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTimes(3);
-            var firedFacts2 = new[]
-            {
-                GetFiredFact<IGrouping<string, GroupElement>>(0),
-                GetFiredFact<IGrouping<string, GroupElement>>(1),
-                GetFiredFact<IGrouping<string, GroupElement>>(2)
-            };
-            var firedFacts1 = new[] {GetFiredFact<FactType1>(0), GetFiredFact<FactType1>(1), GetFiredFact<FactType1>(2)};
-            var validAmountsPerGroup = firedFacts2.Count(x => x.Count() == 1) == 2 &&
-                                       firedFacts2.Count(x => x.Count() == 2) == 1;
-            var valid1 = firedFacts1.Count(x => Equals(fact11, x)) == 2;
-            var valid2 = firedFacts1.Count(x => Equals(fact12, x)) == 1;
-            Assert.True(validAmountsPerGroup && valid1 && valid2);
-        }
-
-        [Fact]
-        public void Fire_BulkInsertForMultipleTypes_FiresThreeTimesWithCorrectCounts()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11"};
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2", GroupKey = "Group 12" };
-            var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
-            var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
-            var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact11.TestProperty};
-            var fact24 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact12.TestProperty};
-
-            var facts = new object[] {fact11, fact12, fact21, fact22, fact23, fact24};
-            Session.InsertAll(facts);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTimes(3);
-            var firedFacts2 = new[]
-            {
-                GetFiredFact<IGrouping<string, GroupElement>>(0),
-                GetFiredFact<IGrouping<string, GroupElement>>(1),
-                GetFiredFact<IGrouping<string, GroupElement>>(2)
-            };
-            var firedFacts1 = new[] {GetFiredFact<FactType1>(0), GetFiredFact<FactType1>(1), GetFiredFact<FactType1>(2)};
-            var validAmountsPerGroup = firedFacts2.Count(x => x.Count() == 1) == 2 &&
-                                       firedFacts2.Count(x => x.Count() == 2) == 1;
-            var valid1 = firedFacts1.Count(x => Equals(fact11, x)) == 2;
-            var valid2 = firedFacts1.Count(x => Equals(fact12, x)) == 1;
-            Assert.True(validAmountsPerGroup && valid1 && valid2);
-        }
-
-        [Fact]
-        public void Fire_TwoFactsOfOneKindAndAggregatedFactsMatchingBothOfTheFactsInsertInReverse_FiresThreeTimesWithCorrectCounts()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11"};
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2", GroupKey = "Group 11" };
-            var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
-            var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
-            var fact23 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 22", JoinProperty = fact11.TestProperty};
-            var fact24 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact12.TestProperty};
-
-            var facts = new[] {fact24, fact23, fact22, fact21};
-            Session.InsertAll(facts);
-            var facts2 = new[] {fact12, fact11};
-            Session.InsertAll(facts2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTimes(3);
-            var firedFacts2 = new[]
-            {
-                GetFiredFact<IGrouping<string, GroupElement>>(0),
-                GetFiredFact<IGrouping<string, GroupElement>>(1),
-                GetFiredFact<IGrouping<string, GroupElement>>(2)
-            };
-            var firedFacts1 = new[] {GetFiredFact<FactType1>(0), GetFiredFact<FactType1>(1), GetFiredFact<FactType1>(2)};
-            var validAmountsPerGroup = firedFacts2.Count(x => x.Count() == 1) == 2 &&
-                                       firedFacts2.Count(x => x.Count() == 2) == 1;
-            var valid1 = firedFacts1.Count(x => Equals(fact11, x)) == 2;
-            var valid2 = firedFacts1.Count(x => Equals(fact12, x)) == 1;
-            Assert.True(validAmountsPerGroup && valid1 && valid2);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingCombinationsThenOneFactOfFirstKindUpdated_FiresTwiceBeforeUpdateAndOnceAfter()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11"};
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2", GroupKey = "Group 12" };
-            var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
-            var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact12.TestProperty};
-
-            Session.Insert(fact11);
-            Session.Insert(fact12);
-            Session.Insert(fact21);
-            Session.Insert(fact22);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredTimes(2);
-
-            //Act - 2
-            Session.Update(fact11);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTimes(3);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingCombinationsThenOneFactOfSecondKindUpdated_FiresTwiceBeforeUpdateAndOnceAfter()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1", GroupKey = "Group 11"};
-            var fact12 = new FactType1 {TestProperty = "Valid Value 2", GroupKey = "Group 12" };
-            var fact21 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact11.TestProperty};
-            var fact22 = new FactType2 {TestProperty = "Valid Value", GroupKey = "Group 21", JoinProperty = fact12.TestProperty};
-
-            Session.Insert(fact11);
-            Session.Insert(fact12);
-            Session.Insert(fact21);
-            Session.Insert(fact22);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredTimes(2);
-
-            //Act - 2
-            Session.Update(fact21);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTimes(3);
-        }
-
-        [Fact]
-        public void Fire_OneFactOfOneKindAndAggregatedFactsMatchThenFactUpdatedWithDifferentGroupKey_FiresOnceFactsInNewGroup()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", GroupKey = "Group 1" };
-            var fact21 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 1", JoinProperty = fact11.TestProperty };
-            var fact22 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 1", JoinProperty = fact11.TestProperty };
-
-            Session.Insert(fact11);
-            Session.Insert(fact21);
-            Session.Insert(fact22);
-
-            fact11.GroupKey = "Group 2";
-            Session.Update(fact11);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Group 2|Group 1", GetFiredFact<IGrouping<string, GroupElement>>().Key);
-        }
-
-        [Fact]
-        public void Fire_OneFactOfOneKindAndAggregatedFactsMatchThenAggregatedFactUpdatedWithDifferentGroupKey_FiresTwiceFactsInCorrectGroups()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", GroupKey = "Group 1" };
-            var fact21 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 1", JoinProperty = fact11.TestProperty };
-            var fact22 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 1", JoinProperty = fact11.TestProperty };
-            var fact23 = new FactType2 { TestProperty = "Valid Value", GroupKey = "Group 2", JoinProperty = fact11.TestProperty };
-
-            Session.Insert(fact11);
-            Session.Insert(fact21);
-            Session.Insert(fact22);
-            Session.Insert(fact23);
-
-            fact22.GroupKey = "Group 2";
-            Session.Update(fact22);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal("Group 1|Group 1", GetFiredFact<IGrouping<string, GroupElement>>(0).Key);
-            Assert.Single(GetFiredFact<IGrouping<string, GroupElement>>(0));
-            Assert.Equal("Group 1|Group 2", GetFiredFact<IGrouping<string, GroupElement>>(1).Key);
-            Assert.Equal(2, GetFiredFact<IGrouping<string, GroupElement>>(1).Count());
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string GroupKey { get; set; }
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string GroupKey { get; set; }
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class GroupElement
-        {
-            public GroupElement(FactType1 fact1, FactType2 fact2)
-            {
-                TestProperty = $"{fact1.TestProperty}|{fact2.TestProperty}";
-            }
-
-            public string TestProperty { get; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact = null;
-                IGrouping<string, GroupElement> group = null;
-
-                When()
-                    .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
-                    .Query(() => group, x => x
-                        .Match<FactType2>(
-                            f => f.TestProperty.StartsWith("Valid"),
-                            f => f.JoinProperty == fact.TestProperty)
-                        .GroupBy(f => GetKey(fact, f), f => new GroupElement(fact, f)));
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-
-            private static string GetKey(FactType1 fact1, FactType2 fact2)
-            {
-                return $"{fact1.GroupKey}|{fact2.GroupKey}";
-            }
+            return $"{fact1.GroupKey}|{fact2.GroupKey}";
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneNotRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneNotRuleTest.cs
@@ -2,244 +2,243 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class TwoFactOneNotRuleTest : BaseRuleTestFixture
 {
-    public class TwoFactOneNotRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchingNotPatternFacts_DoesNotFire()
     {
-        [Fact]
-        public void Fire_MatchingNotPatternFacts_DoesNotFire()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+    
+    [Fact]
+    public void Fire_InsertedThenRetractedFactMatchingNotPatternFacts_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Retract(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+    
+    [Fact]
+    public void Fire_MatchingNotPatternFactAssertedThenRetracted_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+    
+    [Fact]
+    public void Fire_MatchingNotPatternFactAssertedThenUpdatedToInvalid_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact2.TestProperty = "Invalid Value 2";
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactInsertedThenRetractedAndNoFactsMatchingNotPattern_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+        Session.Retract(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+    
+    [Fact]
+    public void Fire_MatchingFactAndNoFactsMatchingNotPattern_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactInsertedThenUpdatedAndNoFactsMatchingNotPattern_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsAndNoFactsMatchingNotPattern_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType1 {TestProperty = "Valid Value 2"};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsAndOneFactMatchingNotPattern_FiresOnce()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 2" };
+        var fact21 = new FactType2 { TestProperty = "Valid Value 3", JoinProperty = fact11.TestProperty};
+
+        Session.Insert(fact11);
+        Session.Insert(fact12);
+        Session.Insert(fact21);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingSetsFactOfSecondKindInsertedThenRetracted_FiresTwiceThenFiresTwice()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value" };
+        var fact21 = new FactType2 { TestProperty = "Valid Value", JoinProperty = "Valid Value" };
+
+        var facts = new[] { fact11, fact12 };
+        Session.InsertAll(facts);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredTwice();
+
+        //Act - 2
+        Session.Insert(fact21);
+        Session.Retract(fact21);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTimes(4);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingSetsFactOfFirstKindUpdated_FiresTwiceThenFiresOnce()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value" };
+
+        var facts = new[] { fact11, fact12 };
+        Session.InsertAll(facts);
+
+        //Act - 1
+        Session.Fire();
+
+        //Assert - 1
+        AssertFiredTwice();
+
+        //Act - 2
+        Session.Update(fact11);
+        Session.Fire();
+
+        //Assert - 2
+        AssertFiredTimes(3);
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+            FactType1 fact = null;
 
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-        
-        [Fact]
-        public void Fire_InsertedThenRetractedFactMatchingNotPatternFacts_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Retract(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-        
-        [Fact]
-        public void Fire_MatchingNotPatternFactAssertedThenRetracted_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Retract(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-        
-        [Fact]
-        public void Fire_MatchingNotPatternFactAssertedThenUpdatedToInvalid_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact2.TestProperty = "Invalid Value 2";
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactInsertedThenRetractedAndNoFactsMatchingNotPattern_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-            Session.Retract(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-        
-        [Fact]
-        public void Fire_MatchingFactAndNoFactsMatchingNotPattern_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactInsertedThenUpdatedAndNoFactsMatchingNotPattern_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsAndNoFactsMatchingNotPattern_FiresTwice()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType1 {TestProperty = "Valid Value 2"};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsAndOneFactMatchingNotPattern_FiresOnce()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 2" };
-            var fact21 = new FactType2 { TestProperty = "Valid Value 3", JoinProperty = fact11.TestProperty};
-
-            Session.Insert(fact11);
-            Session.Insert(fact12);
-            Session.Insert(fact21);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingSetsFactOfSecondKindInsertedThenRetracted_FiresTwiceThenFiresTwice()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value" };
-            var fact21 = new FactType2 { TestProperty = "Valid Value", JoinProperty = "Valid Value" };
-
-            var facts = new[] { fact11, fact12 };
-            Session.InsertAll(facts);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredTwice();
-
-            //Act - 2
-            Session.Insert(fact21);
-            Session.Retract(fact21);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTimes(4);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingSetsFactOfFirstKindUpdated_FiresTwiceThenFiresOnce()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value" };
-
-            var facts = new[] { fact11, fact12 };
-            Session.InsertAll(facts);
-
-            //Act - 1
-            Session.Fire();
-
-            //Assert - 1
-            AssertFiredTwice();
-
-            //Act - 2
-            Session.Update(fact11);
-            Session.Fire();
-
-            //Assert - 2
-            AssertFiredTimes(3);
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact = null;
-
-                When()
-                    .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
-                    .Not<FactType2>(f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact.TestProperty);
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType1>(() => fact, f => f.TestProperty.StartsWith("Valid"))
+                .Not<FactType2>(f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact.TestProperty);
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneSelectRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TwoFactOneSelectRuleTest.cs
@@ -3,300 +3,299 @@ using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class TwoFactOneSelectRuleTest : BaseRuleTestFixture
 {
-    public class TwoFactOneSelectRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKind_FiresOnce()
     {
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKind_FiresOnce()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal($"{fact1.TestProperty}|{fact2.TestProperty}", GetFiredFact<FactProjection>().Value);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKindFirstFactUpdated_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact1.TestProperty = "Valid Value 11";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal($"{fact1.TestProperty}|{fact2.TestProperty}", GetFiredFact<FactProjection>().Value);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKindSecondFactUpdated_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact2.TestProperty = "Valid Value 22";
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal($"{fact1.TestProperty}|{fact2.TestProperty}", GetFiredFact<FactProjection>().Value);
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKindFirstFactUpdatedInvalidJoin_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact1.JoinProperty = "Value 2";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKindSecondFactUpdatedInvalidJoin_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact2.JoinProperty = "Value 2";
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKindFirstFactRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        Session.Retract(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactOfEachKindSecondFactRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoPairsOfMatchingFacts_FiresTwice()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 11", JoinProperty = "Value 1"};
+        var fact12 = new FactType1 {TestProperty = "Valid Value 12", JoinProperty = "Value 2"};
+        var fact21 = new FactType2 {TestProperty = "Valid Value 21", JoinProperty = "Value 1"};
+        var fact22 = new FactType2 {TestProperty = "Valid Value 22", JoinProperty = "Value 2"};
+        Session.InsertAll(new[] {fact11, fact12});
+        Session.InsertAll(new[] {fact21, fact22});
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal($"{fact11.TestProperty}|{fact21.TestProperty}", GetFiredFact<FactProjection>(0).Value);
+        Assert.Equal($"{fact12.TestProperty}|{fact22.TestProperty}", GetFiredFact<FactProjection>(1).Value);
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsOfOneKindOneFactOfSecondKindDuplicateProjectionsFirstSetUpdatedToInvalid_DoesNotFire()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Value 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Value 1" };
+        var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Value 1" };
+        Session.InsertAll(new object[] {fact11, fact12});
+        Session.Insert(fact2);
+
+        fact11.TestProperty = "Invalid Value 1";
+        Session.Update(fact11);
+        fact12.TestProperty = "Invalid Value 1";
+        Session.Update(fact12);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsOfOneKindOneFactOfSecondKindDuplicateProjectionsFirstSetRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Value 1" };
+        var fact12 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Value 1" };
+        var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Value 1" };
+        Session.InsertAll(new object[] {fact11, fact12});
+        Session.Insert(fact2);
+
+        Session.Retract(fact11);
+        Session.Retract(fact12);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactOfFirstKind_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactOfSecondKind_DoesNotFire()
+    {
+        //Arrange
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2"};
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class FactProjection : IEquatable<FactProjection>
+    {
+        public FactProjection(FactType1 fact1, FactType2 fact2)
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal($"{fact1.TestProperty}|{fact2.TestProperty}", GetFiredFact<FactProjection>().Value);
+            Value = $"{fact1.TestProperty}|{fact2.TestProperty}";
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKindFirstFactUpdated_FiresOnce()
+        public string Value { get; }
+
+        public bool Equals(FactProjection other)
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact1.TestProperty = "Valid Value 11";
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal($"{fact1.TestProperty}|{fact2.TestProperty}", GetFiredFact<FactProjection>().Value);
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(Value, other.Value);
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKindSecondFactUpdated_FiresOnce()
+        public override bool Equals(object obj)
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact2.TestProperty = "Valid Value 22";
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal($"{fact1.TestProperty}|{fact2.TestProperty}", GetFiredFact<FactProjection>().Value);
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((FactProjection)obj);
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKindFirstFactUpdatedInvalidJoin_DoesNotFire()
+        public override int GetHashCode()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
-            Session.Insert(fact1);
-            Session.Insert(fact2);
+            return (Value != null ? Value.GetHashCode() : 0);
+        }
+    }
 
-            fact1.JoinProperty = "Value 2";
-            Session.Update(fact1);
+    public class TestRule : Rule
+    {
+        public override void Define()
+        {
+            FactType1 fact1 = null;
+            FactProjection projection = null;
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
+            When()
+                .Match(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                .Query(() => projection, q => q
+                    .Match<FactType2>(f => f.JoinProperty == fact1.JoinProperty)
+                    .Select(f => new FactProjection(fact1, f))
+                    .Where(p => IsValid(p))
+                    );
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
 
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKindSecondFactUpdatedInvalidJoin_DoesNotFire()
+        private static bool IsValid(FactProjection p)
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact2.JoinProperty = "Value 2";
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKindFirstFactRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            Session.Retract(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactOfEachKindSecondFactRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Value 1"};
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            Session.Retract(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoPairsOfMatchingFacts_FiresTwice()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 11", JoinProperty = "Value 1"};
-            var fact12 = new FactType1 {TestProperty = "Valid Value 12", JoinProperty = "Value 2"};
-            var fact21 = new FactType2 {TestProperty = "Valid Value 21", JoinProperty = "Value 1"};
-            var fact22 = new FactType2 {TestProperty = "Valid Value 22", JoinProperty = "Value 2"};
-            Session.InsertAll(new[] {fact11, fact12});
-            Session.InsertAll(new[] {fact21, fact22});
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal($"{fact11.TestProperty}|{fact21.TestProperty}", GetFiredFact<FactProjection>(0).Value);
-            Assert.Equal($"{fact12.TestProperty}|{fact22.TestProperty}", GetFiredFact<FactProjection>(1).Value);
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsOfOneKindOneFactOfSecondKindDuplicateProjectionsFirstSetUpdatedToInvalid_DoesNotFire()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Value 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Value 1" };
-            var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Value 1" };
-            Session.InsertAll(new object[] {fact11, fact12});
-            Session.Insert(fact2);
-
-            fact11.TestProperty = "Invalid Value 1";
-            Session.Update(fact11);
-            fact12.TestProperty = "Invalid Value 1";
-            Session.Update(fact12);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsOfOneKindOneFactOfSecondKindDuplicateProjectionsFirstSetRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact11 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Value 1" };
-            var fact12 = new FactType1 { TestProperty = "Valid Value 1", JoinProperty = "Value 1" };
-            var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = "Value 1" };
-            Session.InsertAll(new object[] {fact11, fact12});
-            Session.Insert(fact2);
-
-            Session.Retract(fact11);
-            Session.Retract(fact12);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactOfFirstKind_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", JoinProperty = "Value 1"};
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactOfSecondKind_DoesNotFire()
-        {
-            //Arrange
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2"};
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class FactProjection : IEquatable<FactProjection>
-        {
-            public FactProjection(FactType1 fact1, FactType2 fact2)
-            {
-                Value = $"{fact1.TestProperty}|{fact2.TestProperty}";
-            }
-
-            public string Value { get; }
-
-            public bool Equals(FactProjection other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return string.Equals(Value, other.Value);
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((FactProjection)obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return (Value != null ? Value.GetHashCode() : 0);
-            }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-                FactProjection projection = null;
-
-                When()
-                    .Match(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                    .Query(() => projection, q => q
-                        .Match<FactType2>(f => f.JoinProperty == fact1.JoinProperty)
-                        .Select(f => new FactProjection(fact1, f))
-                        .Where(p => IsValid(p))
-                        );
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-
-            private static bool IsValid(FactProjection p)
-            {
-                return p.Value.StartsWith("Valid");
-            }
+            return p.Value.StartsWith("Valid");
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TwoFactOrGroupBindingRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TwoFactOrGroupBindingRuleTest.cs
@@ -2,100 +2,99 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class TwoFactOrGroupBindingRuleTest : BaseRuleTestFixture
 {
-    public class TwoFactOrGroupBindingRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_FactMatchingFirstPartOfOrGroup_FiresOnce()
     {
-        [Fact]
-        public void Fire_FactMatchingFirstPartOfOrGroup_FiresOnce()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", Value = "Fact1"};
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Fact1", GetFiredFact<string>());
+    }
+
+    [Fact]
+    public void Fire_FactsMatchingSecondPartOfOrGroup_FiresOnce()
+    {
+        //Arrange
+        var fact2 = new FactType2 { TestProperty = "Valid Value 2", Value = "Fact2"};
+
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+        Assert.Equal("Fact2", GetFiredFact<string>());
+    }
+
+    [Fact]
+    public void Fire_FactsMatchingBothPartsOfOrGroup_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1", Value = "Fact1"};
+        var fact2 = new FactType2 { TestProperty = "Valid Value 2", Value = "Fact2"};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+        Assert.Equal("Fact1", GetFiredFact<string>(0));
+        Assert.Equal("Fact2", GetFiredFact<string>(1));
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+        public string Value { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string Value { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", Value = "Fact1"};
+            FactType1 fact1 = null;
+            FactType2 fact2 = null;
+            string value = null;
 
-            Session.Insert(fact1);
+            When()
+                .Or(x => x
+                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                    .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid")))
+                .Let(() => value, () => GetValue(fact1, fact2));
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Fact1", GetFiredFact<string>());
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
 
-        [Fact]
-        public void Fire_FactsMatchingSecondPartOfOrGroup_FiresOnce()
+        private static string GetValue(FactType1 fact1, FactType2 fact2)
         {
-            //Arrange
-            var fact2 = new FactType2 { TestProperty = "Valid Value 2", Value = "Fact2"};
-
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-            Assert.Equal("Fact2", GetFiredFact<string>());
-        }
-
-        [Fact]
-        public void Fire_FactsMatchingBothPartsOfOrGroup_FiresTwice()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1", Value = "Fact1"};
-            var fact2 = new FactType2 { TestProperty = "Valid Value 2", Value = "Fact2"};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-            Assert.Equal("Fact1", GetFiredFact<string>(0));
-            Assert.Equal("Fact2", GetFiredFact<string>(1));
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-            public string Value { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string Value { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-                FactType2 fact2 = null;
-                string value = null;
-
-                When()
-                    .Or(x => x
-                        .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                        .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid")))
-                    .Let(() => value, () => GetValue(fact1, fact2));
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
-
-            private static string GetValue(FactType1 fact1, FactType2 fact2)
-            {
-                return fact1 != null ? fact1.Value : fact2.Value;
-            }
+            return fact1 != null ? fact1.Value : fact2.Value;
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TwoFactOrGroupRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TwoFactOrGroupRuleTest.cs
@@ -2,105 +2,104 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class TwoFactOrGroupRuleTest : BaseRuleTestFixture
 {
-    public class TwoFactOrGroupRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_NoMatchingFacts_DoesNotFire()
     {
-        [Fact]
-        public void Fire_NoMatchingFacts_DoesNotFire()
+        //Arrange
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FactMatchingFirstPartOfOrGroup_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_FactsMatchingSecondPartOfOrGroup_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Invalid Value 1"};
+        var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty };
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_FactsMatchingBothPartsOfOrGroup_FiresTwice()
+    {
+        //Arrange
+        var fact11 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact12 = new FactType1 {TestProperty = "Invalid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact12.TestProperty};
+
+        Session.Insert(fact11);
+        Session.Insert(fact12);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            //Act
-            Session.Fire();
+            FactType1 fact1 = null;
+            FactType2 fact2 = null;
 
-            //Assert
-            AssertDidNotFire();
-        }
+            When()
+                .Or(x => x
+                    .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                    .And(xx => xx
+                        .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Invalid"))
+                        .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty)));
 
-        [Fact]
-        public void Fire_FactMatchingFirstPartOfOrGroup_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_FactsMatchingSecondPartOfOrGroup_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Invalid Value 1"};
-            var fact2 = new FactType2 { TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty };
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_FactsMatchingBothPartsOfOrGroup_FiresTwice()
-        {
-            //Arrange
-            var fact11 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact12 = new FactType1 {TestProperty = "Invalid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact12.TestProperty};
-
-            Session.Insert(fact11);
-            Session.Insert(fact12);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType1 fact1 = null;
-                FactType2 fact2 = null;
-
-                When()
-                    .Or(x => x
-                        .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                        .And(xx => xx
-                            .Match<FactType1>(() => fact1, f => f.TestProperty.StartsWith("Invalid"))
-                            .Match<FactType2>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.JoinProperty == fact1.TestProperty)));
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TwoFactRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TwoFactRuleTest.cs
@@ -2,340 +2,339 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class TwoFactRuleTest : BaseRuleTestFixture
 {
-    public class TwoFactRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchingFactsInsertAndFireThenUpdateAndFire_FiresTwice()
     {
-        [Fact]
-        public void Fire_MatchingFactsInsertAndFireThenUpdateAndFire_FiresTwice()
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+        Session.Update(fact1);
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+    
+    [Fact]
+    public void Fire_MatchingFactsInsertThenUpdateThenFire_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+    
+    [Fact]
+    public void Fire_MatchingFacts_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_MatchingFactsReverseOrder_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact2);
+        Session.Insert(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingPairsOfFacts_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        var fact3 = new FactType1 {TestProperty = "Valid Value 3"};
+        var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact3.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+        Session.Insert(fact4);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsOfOneKindOneMatchingFactOfAnotherKind_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+        var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Insert(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredTwice();
+    }
+
+    [Fact]
+    public void Fire_FirstMatchingFactSecondInvalidFact_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Invalid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_FirstInvalidFactSecondMatchingFact_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Invalid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsUnsatisfiedJoin_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = null};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsFirstRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Retract(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsSecondRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsFirstUpdatedToInvalid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact1.TestProperty = "Invalid Value 1";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneInvalidFactAndSecondMatchingFactFirstUpdatedToValid_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Invalid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1"};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact1.TestProperty = "Valid Value 1";
+        Session.Update(fact1);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFactsSecondUpdatedToInvalid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact2.TestProperty = "Invalid Value 2";
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactSecondInvalidThenUpdatedToValid_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Invalid Value 2", JoinProperty = fact1.TestProperty};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact2.TestProperty = "Valid Value 2";
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactSecondInvalidThenUpdatedToValidJoin_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = null};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        fact2.JoinProperty = fact1.TestProperty;
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public FactType1 Fact1 { get; set; }
+        public FactType2 Fact2;
+
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-            Session.Update(fact1);
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-        
-        [Fact]
-        public void Fire_MatchingFactsInsertThenUpdateThenFire_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-        
-        [Fact]
-        public void Fire_MatchingFacts_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_MatchingFactsReverseOrder_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact2);
-            Session.Insert(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingPairsOfFacts_FiresTwice()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            var fact3 = new FactType1 {TestProperty = "Valid Value 3"};
-            var fact4 = new FactType2 {TestProperty = "Valid Value 4", JoinProperty = fact3.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-            Session.Insert(fact4);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsOfOneKindOneMatchingFactOfAnotherKind_FiresTwice()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-            var fact3 = new FactType2 {TestProperty = "Valid Value 3", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Insert(fact3);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredTwice();
-        }
-
-        [Fact]
-        public void Fire_FirstMatchingFactSecondInvalidFact_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Invalid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_FirstInvalidFactSecondMatchingFact_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Invalid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsUnsatisfiedJoin_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = null};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsFirstRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Retract(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsSecondRetracted_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-            Session.Retract(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsFirstUpdatedToInvalid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact1.TestProperty = "Invalid Value 1";
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_OneInvalidFactAndSecondMatchingFactFirstUpdatedToValid_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Invalid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = "Valid Value 1"};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact1.TestProperty = "Valid Value 1";
-            Session.Update(fact1);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_TwoMatchingFactsSecondUpdatedToInvalid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact2.TestProperty = "Invalid Value 2";
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactSecondInvalidThenUpdatedToValid_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Invalid Value 2", JoinProperty = fact1.TestProperty};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact2.TestProperty = "Valid Value 2";
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        [Fact]
-        public void Fire_OneMatchingFactSecondInvalidThenUpdatedToValidJoin_FiresOnce()
-        {
-            //Arrange
-            var fact1 = new FactType1 {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType2 {TestProperty = "Valid Value 2", JoinProperty = null};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            fact2.JoinProperty = fact1.TestProperty;
-            Session.Update(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public FactType1 Fact1 { get; set; }
-            public FactType2 Fact2;
-
-            public override void Define()
-            {
-                When()
-                    .Match<FactType1>(() => Fact1, f => f.TestProperty.StartsWith("Valid"))
-                    .Match<FactType2>(() => Fact2, f => f.TestProperty.StartsWith("Valid"))
-                    .Having(() => Fact2.JoinProperty == Fact1.TestProperty);
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            When()
+                .Match<FactType1>(() => Fact1, f => f.TestProperty.StartsWith("Valid"))
+                .Match<FactType2>(() => Fact2, f => f.TestProperty.StartsWith("Valid"))
+                .Having(() => Fact2.JoinProperty == Fact1.TestProperty);
+
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.IntegrationTests/TwoFactSameTypeRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/TwoFactSameTypeRuleTest.cs
@@ -2,71 +2,70 @@
 using NRules.IntegrationTests.TestAssets;
 using Xunit;
 
-namespace NRules.IntegrationTests
+namespace NRules.IntegrationTests;
+
+public class TwoFactSameTypeRuleTest : BaseRuleTestFixture
 {
-    public class TwoFactSameTypeRuleTest : BaseRuleTestFixture
+    [Fact]
+    public void Fire_MatchingFacts_FiresOnce()
     {
-        [Fact]
-        public void Fire_MatchingFacts_FiresOnce()
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2", Parent = fact1};
+        var fact3 = new FactType {TestProperty = "Invalid Value 3", Parent = fact1};
+        var fact4 = new FactType {TestProperty = "Valid Value 4", Parent = null};
+
+        var facts = new[] {fact1, fact2, fact3, fact4};
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertFiredOnce();
+    }
+    
+    [Fact]
+    public void Fire_FirstMatchingFactSecondInvalid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType {TestProperty = "Valid Value 1"};
+        var fact2 = new FactType {TestProperty = "Valid Value 2"};
+
+        Session.Insert(fact1);
+        Session.Insert(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        AssertDidNotFire();
+    }
+
+    protected override void SetUpRules()
+    {
+        SetUpRule<TestRule>();
+    }
+
+    public class FactType
+    {
+        public string TestProperty { get; set; }
+        public FactType Parent { get; set; }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
         {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2", Parent = fact1};
-            var fact3 = new FactType {TestProperty = "Invalid Value 3", Parent = fact1};
-            var fact4 = new FactType {TestProperty = "Valid Value 4", Parent = null};
+            FactType fact1 = null;
+            FactType fact2 = null;
 
-            var facts = new[] {fact1, fact2, fact3, fact4};
-            Session.InsertAll(facts);
+            When()
+                .Match<FactType>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
+                .Match<FactType>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.Parent == fact1);
 
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertFiredOnce();
-        }
-        
-        [Fact]
-        public void Fire_FirstMatchingFactSecondInvalid_DoesNotFire()
-        {
-            //Arrange
-            var fact1 = new FactType {TestProperty = "Valid Value 1"};
-            var fact2 = new FactType {TestProperty = "Valid Value 2"};
-
-            Session.Insert(fact1);
-            Session.Insert(fact2);
-
-            //Act
-            Session.Fire();
-
-            //Assert
-            AssertDidNotFire();
-        }
-
-        protected override void SetUpRules()
-        {
-            SetUpRule<TestRule>();
-        }
-
-        public class FactType
-        {
-            public string TestProperty { get; set; }
-            public FactType Parent { get; set; }
-        }
-
-        public class TestRule : Rule
-        {
-            public override void Define()
-            {
-                FactType fact1 = null;
-                FactType fact2 = null;
-
-                When()
-                    .Match<FactType>(() => fact1, f => f.TestProperty.StartsWith("Valid"))
-                    .Match<FactType>(() => fact2, f => f.TestProperty.StartsWith("Valid"), f => f.Parent == fact1);
-
-                Then()
-                    .Do(ctx => ctx.NoOp());
-            }
+            Then()
+                .Do(ctx => ctx.NoOp());
         }
     }
 }

--- a/src/NRules/Tests/NRules.Json.Tests/ExpressionSerializerTest.cs
+++ b/src/NRules/Tests/NRules.Json.Tests/ExpressionSerializerTest.cs
@@ -6,220 +6,219 @@ using NRules.Json.Tests.TestAssets;
 using NRules.Json.Tests.Utilities;
 using Xunit;
 
-namespace NRules.Json.Tests
+namespace NRules.Json.Tests;
+
+public class ExpressionSerializerTest
 {
-    public class ExpressionSerializerTest
+    private readonly JsonSerializerOptions _options;
+
+    public ExpressionSerializerTest()
     {
-        private readonly JsonSerializerOptions _options;
+        _options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+        RuleSerializer.Setup(_options);
+    }
 
-        public ExpressionSerializerTest()
-        {
-            _options = new JsonSerializerOptions
-            {
-                WriteIndented = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            };
-            RuleSerializer.Setup(_options);
-        }
+    [Fact]
+    public void Roundtrip_Constant_Equals()
+    {
+        Expression<Func<string>> expression = () => "Value";
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_Constant_Equals()
-        {
-            Expression<Func<string>> expression = () => "Value";
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_PropertyAccess_Equals()
+    {
+        Expression<Func<string, int>> expression = s => s.Length;
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_PropertyAccess_Equals()
-        {
-            Expression<Func<string, int>> expression = s => s.Length;
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_InstanceMethod_Equals()
+    {
+        Expression<Func<string, string>> expression = s => s.ToUpper();
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_InstanceMethod_Equals()
-        {
-            Expression<Func<string, string>> expression = s => s.ToUpper();
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_StaticMethod_Equals()
+    {
+        Expression<Func<string, string>> expression = s => string.Concat(s, s);
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_StaticMethod_Equals()
-        {
-            Expression<Func<string, string>> expression = s => string.Concat(s, s);
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_StaticMethodOnInterface_Equals()
+    {
+        Expression<Func<FactType1, bool>> expression = f => Calculations.CallOnInterface(f);
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_StaticMethodOnInterface_Equals()
-        {
-            Expression<Func<FactType1, bool>> expression = f => Calculations.CallOnInterface(f);
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_ExtensionMethod_Equals()
+    {
+        Expression<Func<string, string>> expression = s => s.Transform();
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_ExtensionMethod_Equals()
-        {
-            Expression<Func<string, string>> expression = s => s.Transform();
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_BinaryExpressionEqualsOperator_Equals()
+    {
+        Expression<Func<string, string, bool>> expression = (s1, s2) => s1 == s2;
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_BinaryExpressionEqualsOperator_Equals()
-        {
-            Expression<Func<string, string, bool>> expression = (s1, s2) => s1 == s2;
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_BinaryExpressionEqualsBuiltIn_Equals()
+    {
+        Expression<Func<int, int, bool>> expression = (i1, i2) => i1 == i2;
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_BinaryExpressionEqualsBuiltIn_Equals()
-        {
-            Expression<Func<int, int, bool>> expression = (i1, i2) => i1 == i2;
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_BinaryExpressionArithmeticOps_Equals()
+    {
+        Expression<Func<double, double, double, double, double>> expression = (d1, d2, d3, d4) 
+            => ((d1 + d2 - d3) * d4) / d2 % 3;
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_BinaryExpressionArithmeticOps_Equals()
-        {
-            Expression<Func<double, double, double, double, double>> expression = (d1, d2, d3, d4) 
-                => ((d1 + d2 - d3) * d4) / d2 % 3;
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_BinaryExpressionArrayIndex_Equals()
+    {
+        Expression<Func<int[], int>> expression = arr => arr[0];
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_BinaryExpressionArrayIndex_Equals()
-        {
-            Expression<Func<int[], int>> expression = arr => arr[0];
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_BinaryExpressionAndOr_Equals()
+    {
+        Expression<Func<bool, bool, bool, bool>> expression = (a, b, c) => (a || b) && c;
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_BinaryExpressionAndOr_Equals()
-        {
-            Expression<Func<bool, bool, bool, bool>> expression = (a, b, c) => (a || b) && c;
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_BinaryExpressionStringConcatenation_Equals()
+    {
+        Expression<Func<string, string, string>> expression = (s1, s2) => s1 + s2;
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_BinaryExpressionStringConcatenation_Equals()
-        {
-            Expression<Func<string, string, string>> expression = (s1, s2) => s1 + s2;
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_UnaryExpressionNot_Equals()
+    {
+        Expression<Func<bool, bool>> expression = a => !a;
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_UnaryExpressionNot_Equals()
-        {
-            Expression<Func<bool, bool>> expression = a => !a;
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_UnaryExpressionConvert_Equals()
+    {
+        Expression<Func<object, string>> expression = o => (string)o;
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_UnaryExpressionConvert_Equals()
-        {
-            Expression<Func<object, string>> expression = o => (string)o;
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_UnaryExpressionTypeAs_Equals()
+    {
+        Expression<Func<object, string>> expression = o => o as string;
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_UnaryExpressionTypeAs_Equals()
-        {
-            Expression<Func<object, string>> expression = o => o as string;
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_TypeBinaryExpressionTypeIs_Equals()
+    {
+        Expression<Func<object, bool>> expression = o => o is string;
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_TypeBinaryExpressionTypeIs_Equals()
-        {
-            Expression<Func<object, bool>> expression = o => o is string;
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_NewExpression_Equals()
+    {
+        Expression<Func<string, FactType3>> expression = s => new FactType3(s);
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_NewExpression_Equals()
-        {
-            Expression<Func<string, FactType3>> expression = s => new FactType3(s);
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_MemberInit_Equals()
+    {
+        Expression<Func<bool, string, FactType1>> expression = (b, s) => new FactType1
+            { BooleanProperty = b, StringProperty = s };
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_MemberInit_Equals()
-        {
-            Expression<Func<bool, string, FactType1>> expression = (b, s) => new FactType1
-                { BooleanProperty = b, StringProperty = s };
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_ListInit_Equals()
+    {
+        Expression<Func<string, string, List<string>>> expression = (s1, s2) => new List<string> { s1, s2 };
+        TestRoundtrip(expression);
+    }
+    
+    [Fact]
+    public void Roundtrip_NewArrayExpression_Equals()
+    {
+        Expression<Func<string, string[]>> expression = s => new[] {s};
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_ListInit_Equals()
-        {
-            Expression<Func<string, string, List<string>>> expression = (s1, s2) => new List<string> { s1, s2 };
-            TestRoundtrip(expression);
-        }
-        
-        [Fact]
-        public void Roundtrip_NewArrayExpression_Equals()
-        {
-            Expression<Func<string, string[]>> expression = s => new[] {s};
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_InvocationExpression_Equals()
+    {
+        Expression<Func<string, string>> expression = s => Calculations.Concat(s, "Value");
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_InvocationExpression_Equals()
-        {
-            Expression<Func<string, string>> expression = s => Calculations.Concat(s, "Value");
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_NestedLambda_Equals()
+    {
+        Expression<Func<string, string>> expression = s => Calculations.Transform(s, x => x);
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_NestedLambda_Equals()
-        {
-            Expression<Func<string, string>> expression = s => Calculations.Transform(s, x => x);
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_ConditionalExpression_Equals()
+    {
+        Expression<Func<int, int>> expression = i => i > 0 ? 1 : 0;
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_ConditionalExpression_Equals()
-        {
-            Expression<Func<int, int>> expression = i => i > 0 ? 1 : 0;
-            TestRoundtrip(expression);
-        }
+    [Fact]
+    public void Roundtrip_DefaultExpression_Equals()
+    {
+        var expression = Expression.Default(typeof(string));
+        TestRoundtrip(expression);
+    }
 
-        [Fact]
-        public void Roundtrip_DefaultExpression_Equals()
-        {
-            var expression = Expression.Default(typeof(string));
-            TestRoundtrip(expression);
-        }
-
-        [Fact]
-        public void Deserialize_WrongPropertyPosition_Throws()
-        {
-            var jsonString = @"{
+    [Fact]
+    public void Deserialize_WrongPropertyPosition_Throws()
+    {
+        var jsonString = @"{
   'nodeType': 'Constant',
   'value': 'My Value'
 }".Replace('\'', '\"');
-            var ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Expression>(jsonString, _options));
-            Assert.Contains("Expected property. Name=Type", ex.Message);
-        }
+        var ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Expression>(jsonString, _options));
+        Assert.Contains("Expected property. Name=Type", ex.Message);
+    }
 
-        [Fact]
-        public void Deserialize_WrongEnumValue_Throws()
-        {
-            var jsonString = @"{
+    [Fact]
+    public void Deserialize_WrongEnumValue_Throws()
+    {
+        var jsonString = @"{
   'nodeType': 'InvalidValue'
 }".Replace('\'', '\"');
-            var ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Expression>(jsonString, _options));
-            Assert.Contains("Unable to convert Enum value. Value=InvalidValue, EnumType=System.Linq.Expressions.ExpressionType", ex.Message);
-        }
+        var ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Expression>(jsonString, _options));
+        Assert.Contains("Unable to convert Enum value. Value=InvalidValue, EnumType=System.Linq.Expressions.ExpressionType", ex.Message);
+    }
 
-        private void TestRoundtrip<TExpression>(TExpression expression) where TExpression: Expression
-        {
-            var jsonString = JsonSerializer.Serialize(expression, _options);
-            //System.IO.File.WriteAllText(@"C:\temp\expression.json", jsonString);
-            var deserialized = JsonSerializer.Deserialize<TExpression>(jsonString, _options);
+    private void TestRoundtrip<TExpression>(TExpression expression) where TExpression: Expression
+    {
+        var jsonString = JsonSerializer.Serialize(expression, _options);
+        //System.IO.File.WriteAllText(@"C:\temp\expression.json", jsonString);
+        var deserialized = JsonSerializer.Deserialize<TExpression>(jsonString, _options);
 
-            Assert.True(ExpressionComparer.AreEqual(expression, deserialized));
-        }
+        Assert.True(ExpressionComparer.AreEqual(expression, deserialized));
     }
 }

--- a/src/NRules/Tests/NRules.Json.Tests/NRules.Json.Tests.csproj
+++ b/src/NRules/Tests/NRules.Json.Tests/NRules.Json.Tests.csproj
@@ -6,7 +6,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NRules/Tests/NRules.Json.Tests/RuleSerializerTest.cs
+++ b/src/NRules/Tests/NRules.Json.Tests/RuleSerializerTest.cs
@@ -8,224 +8,223 @@ using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 using Xunit;
 
-namespace NRules.Json.Tests
+namespace NRules.Json.Tests;
+
+public class RuleSerializerTest
 {
-    public class RuleSerializerTest
+    private readonly JsonSerializerOptions _options;
+
+    public RuleSerializerTest()
     {
-        private readonly JsonSerializerOptions _options;
-
-        public RuleSerializerTest()
+        _options = new JsonSerializerOptions
         {
-            _options = new JsonSerializerOptions
-            {
-                WriteIndented = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            };
-            RuleSerializer.Setup(_options);
-        }
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+        RuleSerializer.Setup(_options);
+    }
 
-        [Fact]
-        public void Roundtrip_SimpleMatchRuleWithMetadata_Equals()
-        {
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
-            builder.Description("My test rule");
-            builder.Priority(2);
-            builder.Repeatability(RuleRepeatability.NonRepeatable);
+    [Fact]
+    public void Roundtrip_SimpleMatchRuleWithMetadata_Equals()
+    {
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
+        builder.Description("My test rule");
+        builder.Priority(2);
+        builder.Repeatability(RuleRepeatability.NonRepeatable);
 
-            builder.Tag("Test");
-            builder.Tag("Debug");
+        builder.Tag("Test");
+        builder.Tag("Debug");
 
-            builder.Property("ClrType", typeof(RuleSerializerTest));
+        builder.Property("ClrType", typeof(RuleSerializerTest));
 
-            var fact1Pattern = builder.LeftHandSide().Pattern(typeof(FactType1), "fact1");
-            Expression<Func<FactType1, bool>> fact1Condition = fact1 => fact1.BooleanProperty;
-            fact1Pattern.Condition(fact1Condition);
+        var fact1Pattern = builder.LeftHandSide().Pattern(typeof(FactType1), "fact1");
+        Expression<Func<FactType1, bool>> fact1Condition = fact1 => fact1.BooleanProperty;
+        fact1Pattern.Condition(fact1Condition);
 
-            Expression<Action<IContext, FactType1>> action = (ctx, fact1) => Calculations.DoSomething(fact1);
-            builder.RightHandSide().Action(action);
-            var ruleDefinition = builder.Build();
+        Expression<Action<IContext, FactType1>> action = (ctx, fact1) => Calculations.DoSomething(fact1);
+        builder.RightHandSide().Action(action);
+        var ruleDefinition = builder.Build();
 
-            TestRoundtrip(ruleDefinition);
-        }
+        TestRoundtrip(ruleDefinition);
+    }
 
-        [Fact]
-        public void Roundtrip_RuleWithFilter_Equals()
-        {
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
+    [Fact]
+    public void Roundtrip_RuleWithFilter_Equals()
+    {
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
 
-            builder.LeftHandSide().Pattern(typeof(FactType1), "fact1");
+        builder.LeftHandSide().Pattern(typeof(FactType1), "fact1");
 
-            Expression<Func<FactType1, bool>> filter1 = (fact1) => fact1.BooleanProperty;
-            builder.Filters()
-                .Filter(FilterType.Predicate, filter1);
-            Expression<Func<FactType1, object>> filter2 = (fact1) => fact1.StringProperty;
-            builder.Filters()
-                .Filter(FilterType.KeyChange, filter2);
+        Expression<Func<FactType1, bool>> filter1 = (fact1) => fact1.BooleanProperty;
+        builder.Filters()
+            .Filter(FilterType.Predicate, filter1);
+        Expression<Func<FactType1, object>> filter2 = (fact1) => fact1.StringProperty;
+        builder.Filters()
+            .Filter(FilterType.KeyChange, filter2);
 
-            Expression<Action<IContext, FactType1>> action = (ctx, fact1) => Calculations.DoSomething(fact1);
-            builder.RightHandSide().Action(action);
-            var ruleDefinition = builder.Build();
+        Expression<Action<IContext, FactType1>> action = (ctx, fact1) => Calculations.DoSomething(fact1);
+        builder.RightHandSide().Action(action);
+        var ruleDefinition = builder.Build();
 
-            TestRoundtrip(ruleDefinition);
-        }
+        TestRoundtrip(ruleDefinition);
+    }
 
-        [Fact]
-        public void Roundtrip_RuleWithDependency_Equals()
-        {
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
+    [Fact]
+    public void Roundtrip_RuleWithDependency_Equals()
+    {
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
 
-            builder.Dependencies()
-                .Dependency(typeof(ITestService), "service");
+        builder.Dependencies()
+            .Dependency(typeof(ITestService), "service");
 
-            builder.LeftHandSide().Pattern(typeof(FactType1), "fact1");
+        builder.LeftHandSide().Pattern(typeof(FactType1), "fact1");
 
-            Expression<Action<IContext, FactType1, ITestService>> action = (ctx, fact1, service) => Calculations.DoSomething(fact1, service);
-            builder.RightHandSide().Action(action);
-            var ruleDefinition = builder.Build();
+        Expression<Action<IContext, FactType1, ITestService>> action = (ctx, fact1, service) => Calculations.DoSomething(fact1, service);
+        builder.RightHandSide().Action(action);
+        var ruleDefinition = builder.Build();
 
-            TestRoundtrip(ruleDefinition);
-        }
+        TestRoundtrip(ruleDefinition);
+    }
+    
+    [Fact]
+    public void Roundtrip_TwoFactJoinRule_Equals()
+    {
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
+
+        builder.LeftHandSide().Pattern(typeof(FactType1), "fact1");
+        var pattern2 = builder.LeftHandSide().Pattern(typeof(FactType2), "fact2");
+        Expression<Func<FactType1, FactType2, bool>> condition21 = (fact1, fact2) 
+            => fact2.JoinProperty == fact1;
+        pattern2.Condition(condition21);
+
+        Expression<Action<IContext, FactType1, FactType2>> action = (ctx, fact1, fact2) 
+            => Calculations.DoSomething(fact1, fact2);
+        builder.RightHandSide().Action(action);
+        var ruleDefinition = builder.Build();
+
+        TestRoundtrip(ruleDefinition);
+    }
+
+    [Fact]
+    public void Roundtrip_ExistsRule_Equals()
+    {
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
+
+        builder.LeftHandSide().Exists().Pattern(typeof(FactType1), "fact1");
+
+        Expression<Action<IContext>> action = ctx 
+            => Calculations.DoSomething();
+        builder.RightHandSide().Action(action);
+        var ruleDefinition = builder.Build();
+
+        TestRoundtrip(ruleDefinition);
+    }
+
+    [Fact]
+    public void Roundtrip_NotRule_Equals()
+    {
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
+
+        builder.LeftHandSide().Not().Pattern(typeof(FactType1), "fact1");
+
+        Expression<Action<IContext>> action = ctx 
+            => Calculations.DoSomething();
+        builder.RightHandSide().Action(action);
+        var ruleDefinition = builder.Build();
+
+        TestRoundtrip(ruleDefinition);
+    }
+    
+    [Fact]
+    public void Roundtrip_AggregateRule_Equals()
+    {
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
+
+        var factGroupPattern = builder.LeftHandSide().Pattern(typeof(IEnumerable<FactType1>), "factGroup");
         
-        [Fact]
-        public void Roundtrip_TwoFactJoinRule_Equals()
-        {
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
+        var aggregate = factGroupPattern.Aggregate();
+        Expression<Func<FactType1, string>> keySelector = fact1 => fact1.GroupKey;
+        Expression<Func<FactType1, FactType1>> elementSelector = fact1 => fact1;
+        aggregate.GroupBy(keySelector, elementSelector);
 
-            builder.LeftHandSide().Pattern(typeof(FactType1), "fact1");
-            var pattern2 = builder.LeftHandSide().Pattern(typeof(FactType2), "fact2");
-            Expression<Func<FactType1, FactType2, bool>> condition21 = (fact1, fact2) 
-                => fact2.JoinProperty == fact1;
-            pattern2.Condition(condition21);
+        var fact1Pattern = aggregate.Pattern(typeof(FactType1), "fact1");
+        Expression<Func<FactType1, bool>> fact1Condition = fact1 => fact1.BooleanProperty;
+        fact1Pattern.Condition(fact1Condition);
 
-            Expression<Action<IContext, FactType1, FactType2>> action = (ctx, fact1, fact2) 
-                => Calculations.DoSomething(fact1, fact2);
-            builder.RightHandSide().Action(action);
-            var ruleDefinition = builder.Build();
+        Expression<Action<IContext, IEnumerable<FactType1>>> action = (ctx, factGroup)
+            => Calculations.DoSomething(factGroup);
+        builder.RightHandSide().Action(action);
+        var ruleDefinition = builder.Build();
 
-            TestRoundtrip(ruleDefinition);
-        }
+        TestRoundtrip(ruleDefinition);
+    }
 
-        [Fact]
-        public void Roundtrip_ExistsRule_Equals()
-        {
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
+    [Fact]
+    public void Roundtrip_BindingRule_Equals()
+    {
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
 
-            builder.LeftHandSide().Exists().Pattern(typeof(FactType1), "fact1");
-
-            Expression<Action<IContext>> action = ctx 
-                => Calculations.DoSomething();
-            builder.RightHandSide().Action(action);
-            var ruleDefinition = builder.Build();
-
-            TestRoundtrip(ruleDefinition);
-        }
-
-        [Fact]
-        public void Roundtrip_NotRule_Equals()
-        {
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
-
-            builder.LeftHandSide().Not().Pattern(typeof(FactType1), "fact1");
-
-            Expression<Action<IContext>> action = ctx 
-                => Calculations.DoSomething();
-            builder.RightHandSide().Action(action);
-            var ruleDefinition = builder.Build();
-
-            TestRoundtrip(ruleDefinition);
-        }
+        builder.LeftHandSide().Pattern(typeof(FactType1), "fact1");
         
-        [Fact]
-        public void Roundtrip_AggregateRule_Equals()
-        {
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
+        var bindingPattern = builder.LeftHandSide().Pattern(typeof(int), "length");
+        
+        var binding = bindingPattern.Binding();
+        Expression<Func<FactType1, int>> expression = fact1 => fact1.StringProperty.Length;
+        binding.BindingExpression(expression);
 
-            var factGroupPattern = builder.LeftHandSide().Pattern(typeof(IEnumerable<FactType1>), "factGroup");
-            
-            var aggregate = factGroupPattern.Aggregate();
-            Expression<Func<FactType1, string>> keySelector = fact1 => fact1.GroupKey;
-            Expression<Func<FactType1, FactType1>> elementSelector = fact1 => fact1;
-            aggregate.GroupBy(keySelector, elementSelector);
+        Expression<Action<IContext, int>> action = (ctx, length)
+            => Calculations.DoSomething(length);
+        builder.RightHandSide().Action(action);
+        var ruleDefinition = builder.Build();
 
-            var fact1Pattern = aggregate.Pattern(typeof(FactType1), "fact1");
-            Expression<Func<FactType1, bool>> fact1Condition = fact1 => fact1.BooleanProperty;
-            fact1Pattern.Condition(fact1Condition);
+        TestRoundtrip(ruleDefinition);
+    }
 
-            Expression<Action<IContext, IEnumerable<FactType1>>> action = (ctx, factGroup)
-                => Calculations.DoSomething(factGroup);
-            builder.RightHandSide().Action(action);
-            var ruleDefinition = builder.Build();
+    [Fact]
+    public void Roundtrip_ForAllRule_Equals()
+    {
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
 
-            TestRoundtrip(ruleDefinition);
-        }
+        var forAll = builder.LeftHandSide().ForAll();
+        var basePattern = forAll.BasePattern(typeof(FactType1));
+        var baseParameter = Expression.Parameter(basePattern.Declaration.Type, basePattern.Declaration.Name);
+        var baseCondition = Expression.Lambda<Func<FactType1, bool>>(
+            Expression.Property(baseParameter, nameof(FactType1.BooleanProperty)),
+            baseParameter);
+        basePattern.Condition(baseCondition);
 
-        [Fact]
-        public void Roundtrip_BindingRule_Equals()
-        {
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
+        var pattern1 = forAll.Pattern(typeof(FactType1));
+        var parameter1 = Expression.Parameter(pattern1.Declaration.Type, pattern1.Declaration.Name);
+        var condition1 = Expression.Lambda<Func<FactType1, bool>>(
+            Expression.Call(
+                Expression.Property(parameter1, nameof(FactType1.StringProperty)),
+                nameof(string.StartsWith),
+                Type.EmptyTypes,
+                Expression.Constant("Valid")),
+            parameter1);
+        pattern1.Condition(condition1);
 
-            builder.LeftHandSide().Pattern(typeof(FactType1), "fact1");
-            
-            var bindingPattern = builder.LeftHandSide().Pattern(typeof(int), "length");
-            
-            var binding = bindingPattern.Binding();
-            Expression<Func<FactType1, int>> expression = fact1 => fact1.StringProperty.Length;
-            binding.BindingExpression(expression);
+        Expression<Action<IContext>> action = ctx => Calculations.DoSomething();
+        builder.RightHandSide().Action(action);
+        var ruleDefinition = builder.Build();
 
-            Expression<Action<IContext, int>> action = (ctx, length)
-                => Calculations.DoSomething(length);
-            builder.RightHandSide().Action(action);
-            var ruleDefinition = builder.Build();
+        TestRoundtrip(ruleDefinition);
+    }
 
-            TestRoundtrip(ruleDefinition);
-        }
-
-        [Fact]
-        public void Roundtrip_ForAllRule_Equals()
-        {
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
-
-            var forAll = builder.LeftHandSide().ForAll();
-            var basePattern = forAll.BasePattern(typeof(FactType1));
-            var baseParameter = Expression.Parameter(basePattern.Declaration.Type, basePattern.Declaration.Name);
-            var baseCondition = Expression.Lambda<Func<FactType1, bool>>(
-                Expression.Property(baseParameter, nameof(FactType1.BooleanProperty)),
-                baseParameter);
-            basePattern.Condition(baseCondition);
-
-            var pattern1 = forAll.Pattern(typeof(FactType1));
-            var parameter1 = Expression.Parameter(pattern1.Declaration.Type, pattern1.Declaration.Name);
-            var condition1 = Expression.Lambda<Func<FactType1, bool>>(
-                Expression.Call(
-                    Expression.Property(parameter1, nameof(FactType1.StringProperty)),
-                    nameof(string.StartsWith),
-                    Type.EmptyTypes,
-                    Expression.Constant("Valid")),
-                parameter1);
-            pattern1.Condition(condition1);
-
-            Expression<Action<IContext>> action = ctx => Calculations.DoSomething();
-            builder.RightHandSide().Action(action);
-            var ruleDefinition = builder.Build();
-
-            TestRoundtrip(ruleDefinition);
-        }
-
-        private void TestRoundtrip(IRuleDefinition original)
-        {
-            var jsonString = JsonSerializer.Serialize(original, _options);
-            //System.IO.File.WriteAllText(@"C:\temp\rule.json", jsonString);
-            var deserialized = JsonSerializer.Deserialize<IRuleDefinition>(jsonString, _options);
-            Assert.True(RuleDefinitionComparer.AreEqual(original, deserialized));
-        }
+    private void TestRoundtrip(IRuleDefinition original)
+    {
+        var jsonString = JsonSerializer.Serialize(original, _options);
+        //System.IO.File.WriteAllText(@"C:\temp\rule.json", jsonString);
+        var deserialized = JsonSerializer.Deserialize<IRuleDefinition>(jsonString, _options);
+        Assert.True(RuleDefinitionComparer.AreEqual(original, deserialized));
     }
 }

--- a/src/NRules/Tests/NRules.Json.Tests/TestAssets/Calculations.cs
+++ b/src/NRules/Tests/NRules.Json.Tests/TestAssets/Calculations.cs
@@ -1,51 +1,50 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace NRules.Json.Tests.TestAssets
+namespace NRules.Json.Tests.TestAssets;
+
+public delegate string TransformDelegate(string value1, string value2);
+
+public static class Calculations
 {
-    public delegate string TransformDelegate(string value1, string value2);
-
-    public static class Calculations
+    public static void DoSomething()
     {
-        public static void DoSomething()
-        {
-        }
-        
-        public static void DoSomething(FactType1 fact1)
-        {
-        }
-        
-        public static void DoSomething(FactType1 fact1, FactType2 fact2)
-        {
-        }
-
-        public static void DoSomething(FactType1 fact1, ITestService service)
-        {
-        }
-
-        public static void DoSomething(IEnumerable<FactType1> factGroup)
-        {
-        }
-
-        public static void DoSomething(int value)
-        {
-        }
-
-        public static string Transform(this string value)
-        {
-            return value;
-        }
-
-        public static string Transform(string s, Func<string, string> map)
-        {
-            return map(s);
-        }
-
-        public static bool CallOnInterface(IFactType1 fact1)
-        {
-            return fact1.BooleanProperty;
-        }
-
-        public static TransformDelegate Concat = string.Concat;
     }
+    
+    public static void DoSomething(FactType1 fact1)
+    {
+    }
+    
+    public static void DoSomething(FactType1 fact1, FactType2 fact2)
+    {
+    }
+
+    public static void DoSomething(FactType1 fact1, ITestService service)
+    {
+    }
+
+    public static void DoSomething(IEnumerable<FactType1> factGroup)
+    {
+    }
+
+    public static void DoSomething(int value)
+    {
+    }
+
+    public static string Transform(this string value)
+    {
+        return value;
+    }
+
+    public static string Transform(string s, Func<string, string> map)
+    {
+        return map(s);
+    }
+
+    public static bool CallOnInterface(IFactType1 fact1)
+    {
+        return fact1.BooleanProperty;
+    }
+
+    public static TransformDelegate Concat = string.Concat;
 }

--- a/src/NRules/Tests/NRules.Json.Tests/TestAssets/Facts.cs
+++ b/src/NRules/Tests/NRules.Json.Tests/TestAssets/Facts.cs
@@ -1,37 +1,36 @@
-﻿namespace NRules.Json.Tests.TestAssets
+﻿namespace NRules.Json.Tests.TestAssets;
+
+public interface IFactType1
 {
-    public interface IFactType1
-    {
-        public bool BooleanProperty { get; }
-        public string StringProperty { get; }
-        public string GroupKey { get; }
-    }
+    public bool BooleanProperty { get; }
+    public string StringProperty { get; }
+    public string GroupKey { get; }
+}
 
-    public class FactType1 : IFactType1
-    {
-        public bool BooleanProperty { get; set; }
-        public string StringProperty { get; set; }
-        public string GroupKey { get; set; }
-    }
-    
-    public class FactType2
-    {
-        public FactType1 JoinProperty { get; set; }
-    }
+public class FactType1 : IFactType1
+{
+    public bool BooleanProperty { get; set; }
+    public string StringProperty { get; set; }
+    public string GroupKey { get; set; }
+}
 
-    public class FactType3
-    {
-        public FactType3(string value) => StringProperty = value;
-     
-        public string StringProperty { get; }
-    }
+public class FactType2
+{
+    public FactType1 JoinProperty { get; set; }
+}
 
-    public class Container<T>
-    {
-    }
+public class FactType3
+{
+    public FactType3(string value) => StringProperty = value;
+ 
+    public string StringProperty { get; }
+}
 
-    public class Outer
-    {
-        public class Inner{}
-    }
+public class Container<T>
+{
+}
+
+public class Outer
+{
+    public class Inner{}
 }

--- a/src/NRules/Tests/NRules.Json.Tests/TestAssets/ITestService.cs
+++ b/src/NRules/Tests/NRules.Json.Tests/TestAssets/ITestService.cs
@@ -1,7 +1,6 @@
-﻿namespace NRules.Json.Tests.TestAssets
+﻿namespace NRules.Json.Tests.TestAssets;
+
+public interface ITestService
 {
-    public interface ITestService
-    {
-        public void Operation();
-    }
+    public void Operation();
 }

--- a/src/NRules/Tests/NRules.Json.Tests/TypeResolverTest.cs
+++ b/src/NRules/Tests/NRules.Json.Tests/TypeResolverTest.cs
@@ -3,189 +3,188 @@ using System.Collections.Generic;
 using NRules.Json.Tests.TestAssets;
 using Xunit;
 
-namespace NRules.Json.Tests
+namespace NRules.Json.Tests;
+
+public class TypeResolverTest
 {
-    public class TypeResolverTest
+    [Fact]
+    public void Roundtrip_SimpleSystemType_TypeNameWithoutAssemblyName()
     {
-        [Fact]
-        public void Roundtrip_SimpleSystemType_TypeNameWithoutAssemblyName()
-        {
-            TestRoundtrip(
-                typeof(string),
-                typeof(string).FullName);
-        }
+        TestRoundtrip(
+            typeof(string),
+            typeof(string).FullName);
+    }
 
-        [Fact]
-        public void Roundtrip_SimpleCustomType_TypeNameWithAssemblyName()
-        {
-            TestRoundtrip(
-                typeof(FactType1),
-                typeof(FactType1).AssemblyQualifiedName);
-        }
-        
-        [Fact]
-        public void Roundtrip_SimpleTypeWithAlias_Alias()
-        {
-            TestRoundtrip(new()
-                {
-                    { "string", typeof(string) }
-                },
-                typeof(string),
-                "string");
-        }
-        
-        [Fact]
-        public void Roundtrip_ArrayTypeWithAlias_Alias()
-        {
-            TestRoundtrip(new()
-                {
-                    { "string", typeof(string) }
-                },
-                typeof(string[]),
-                "string[]");
-        }
-        
-        [Fact]
-        public void Roundtrip_2DArrayTypeWithAlias_Alias()
-        {
-            TestRoundtrip(new()
-                {
-                    { "string", typeof(string) }
-                },
-                typeof(string[,]),
-                "string[,]");
-        }
-        
-        [Fact]
-        public void Roundtrip_JaggedArrayTypeWithAlias_Alias()
-        {
-            TestRoundtrip(new()
-                {
-                    { "string", typeof(string) }
-                },
-                typeof(string[][]),
-                "string[][]");
-        }
-
-        [Fact]
-        public void Roundtrip_GenericSystemTypeWithSystemTypeArgument_TypeNamesWithoutAssemblyNames()
-        {
-            TestRoundtrip(
-                typeof(List<string>),
-                $"{typeof(List<>).FullName}[[{typeof(string).FullName}]]");
-        }
-
-        [Fact]
-        public void Roundtrip_GenericSystemTypeWithAliasWithSystemTypeArgumentWithAlias_GenericAliasWithTypeArgumentAlias()
-        {
-            TestRoundtrip(new()
-                {
-                    { "list", typeof(List<>) },
-                    { "string", typeof(string) }
-                },
-                typeof(List<string>),
-                "list[[string]]");
-        }
-
-        [Fact]
-        public void Roundtrip_ConstructedGenericSystemTypeWithAlias_Alias()
-        {
-            TestRoundtrip(new()
-                {
-                    { "list_s", typeof(List<string>) }
-                },
-                typeof(List<string>),
-                "list_s");
-        }
-
-        [Fact]
-        public void Roundtrip_NestedGenericSystemTypeWithSystemTypeArgument_TypeNamesWithoutAssemblyNames()
-        {
-            TestRoundtrip(
-                typeof(Dictionary<int, List<string>>),
-                $"{typeof(Dictionary<,>).FullName}[[{typeof(int).FullName}],[{typeof(List<>).FullName}[[{typeof(string).FullName}]]]]");
-        }
-
-        [Fact]
-        public void Roundtrip_GenericSystemTypeWithCustomTypeArgument_GenericTypeNameWithoutAssemblyNameTypeArgumentWithAssemblyName()
-        {
-            TestRoundtrip(
-                typeof(List<FactType1>),
-                $"{typeof(List<>).FullName}[[{typeof(FactType1).AssemblyQualifiedName}]]");
-        }
-
-        [Fact]
-        public void Roundtrip_GenericCustomTypeWithSystemTypeArgument_GenericTypeNameWithAssemblyNameTypeArgumentWithoutAssemblyName()
-        {
-            TestRoundtrip(
-                typeof(Container<string>),
-                $"{typeof(Container<>).FullName}[[{typeof(string).FullName}]], {typeof(Container<>).Assembly.FullName}");
-        }
-
-        [Fact]
-        public void Roundtrip_GenericCustomTypeWithAliasWithSystemTypeArgument_GenericTypeAliasTypeArgumentWithoutAssemblyName()
-        {
-            TestRoundtrip(new()
-                {
-                    { "container", typeof(Container<>) }
-                },
-                typeof(Container<string>),
-                $"container[[{typeof(string).FullName}]]");
-        }
-
-        [Fact]
-        public void Roundtrip_CustomNestedClassType_OuterTypePlusInnerType()
-        {
-            TestRoundtrip(
-                typeof(Outer.Inner),
-                $"{typeof(Outer).FullName}+{nameof(Outer.Inner)}, {typeof(Container<>).Assembly.FullName}");
-        }
-
-        [Fact]
-        public void Roundtrip_CustomNestedClassTypeWithAlias_Alias()
-        {
-            TestRoundtrip(new()
-                {
-                    { "inner", typeof(Outer.Inner) }
-                },
-                typeof(Outer.Inner),
-                "inner");
-        }
-
-        [Fact]
-        public void GetTypeFromName_InvalidName_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act - Assert
-            var ex = Assert.Throws<ArgumentException>(() => target.GetTypeFromName("BadTypeName")); 
-            Assert.Contains("BadTypeName", ex.Message);
-        }
-
-        private void TestRoundtrip(Type originalType, string expectedTypeName)
-        {
-            TestRoundtrip(new (), originalType, expectedTypeName);
-        }
-
-        private void TestRoundtrip(Dictionary<string, Type> aliases, Type originalType, string expectedTypeName)
-        {
-            var typeResolver = CreateTarget();
-            foreach (var alias in aliases)
+    [Fact]
+    public void Roundtrip_SimpleCustomType_TypeNameWithAssemblyName()
+    {
+        TestRoundtrip(
+            typeof(FactType1),
+            typeof(FactType1).AssemblyQualifiedName);
+    }
+    
+    [Fact]
+    public void Roundtrip_SimpleTypeWithAlias_Alias()
+    {
+        TestRoundtrip(new()
             {
-                typeResolver.RegisterAlias(alias.Key, alias.Value);
-            }
+                { "string", typeof(string) }
+            },
+            typeof(string),
+            "string");
+    }
+    
+    [Fact]
+    public void Roundtrip_ArrayTypeWithAlias_Alias()
+    {
+        TestRoundtrip(new()
+            {
+                { "string", typeof(string) }
+            },
+            typeof(string[]),
+            "string[]");
+    }
+    
+    [Fact]
+    public void Roundtrip_2DArrayTypeWithAlias_Alias()
+    {
+        TestRoundtrip(new()
+            {
+                { "string", typeof(string) }
+            },
+            typeof(string[,]),
+            "string[,]");
+    }
+    
+    [Fact]
+    public void Roundtrip_JaggedArrayTypeWithAlias_Alias()
+    {
+        TestRoundtrip(new()
+            {
+                { "string", typeof(string) }
+            },
+            typeof(string[][]),
+            "string[][]");
+    }
 
-            var serializedTypeName = typeResolver.GetTypeName(originalType);
-            var deserializedType = typeResolver.GetTypeFromName(serializedTypeName);
+    [Fact]
+    public void Roundtrip_GenericSystemTypeWithSystemTypeArgument_TypeNamesWithoutAssemblyNames()
+    {
+        TestRoundtrip(
+            typeof(List<string>),
+            $"{typeof(List<>).FullName}[[{typeof(string).FullName}]]");
+    }
 
-            Assert.Equal(expectedTypeName, serializedTypeName);
-            Assert.Equal(originalType, deserializedType);
-        }
+    [Fact]
+    public void Roundtrip_GenericSystemTypeWithAliasWithSystemTypeArgumentWithAlias_GenericAliasWithTypeArgumentAlias()
+    {
+        TestRoundtrip(new()
+            {
+                { "list", typeof(List<>) },
+                { "string", typeof(string) }
+            },
+            typeof(List<string>),
+            "list[[string]]");
+    }
 
-        private static TypeResolver CreateTarget()
+    [Fact]
+    public void Roundtrip_ConstructedGenericSystemTypeWithAlias_Alias()
+    {
+        TestRoundtrip(new()
+            {
+                { "list_s", typeof(List<string>) }
+            },
+            typeof(List<string>),
+            "list_s");
+    }
+
+    [Fact]
+    public void Roundtrip_NestedGenericSystemTypeWithSystemTypeArgument_TypeNamesWithoutAssemblyNames()
+    {
+        TestRoundtrip(
+            typeof(Dictionary<int, List<string>>),
+            $"{typeof(Dictionary<,>).FullName}[[{typeof(int).FullName}],[{typeof(List<>).FullName}[[{typeof(string).FullName}]]]]");
+    }
+
+    [Fact]
+    public void Roundtrip_GenericSystemTypeWithCustomTypeArgument_GenericTypeNameWithoutAssemblyNameTypeArgumentWithAssemblyName()
+    {
+        TestRoundtrip(
+            typeof(List<FactType1>),
+            $"{typeof(List<>).FullName}[[{typeof(FactType1).AssemblyQualifiedName}]]");
+    }
+
+    [Fact]
+    public void Roundtrip_GenericCustomTypeWithSystemTypeArgument_GenericTypeNameWithAssemblyNameTypeArgumentWithoutAssemblyName()
+    {
+        TestRoundtrip(
+            typeof(Container<string>),
+            $"{typeof(Container<>).FullName}[[{typeof(string).FullName}]], {typeof(Container<>).Assembly.FullName}");
+    }
+
+    [Fact]
+    public void Roundtrip_GenericCustomTypeWithAliasWithSystemTypeArgument_GenericTypeAliasTypeArgumentWithoutAssemblyName()
+    {
+        TestRoundtrip(new()
+            {
+                { "container", typeof(Container<>) }
+            },
+            typeof(Container<string>),
+            $"container[[{typeof(string).FullName}]]");
+    }
+
+    [Fact]
+    public void Roundtrip_CustomNestedClassType_OuterTypePlusInnerType()
+    {
+        TestRoundtrip(
+            typeof(Outer.Inner),
+            $"{typeof(Outer).FullName}+{nameof(Outer.Inner)}, {typeof(Container<>).Assembly.FullName}");
+    }
+
+    [Fact]
+    public void Roundtrip_CustomNestedClassTypeWithAlias_Alias()
+    {
+        TestRoundtrip(new()
+            {
+                { "inner", typeof(Outer.Inner) }
+            },
+            typeof(Outer.Inner),
+            "inner");
+    }
+
+    [Fact]
+    public void GetTypeFromName_InvalidName_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act - Assert
+        var ex = Assert.Throws<ArgumentException>(() => target.GetTypeFromName("BadTypeName")); 
+        Assert.Contains("BadTypeName", ex.Message);
+    }
+
+    private void TestRoundtrip(Type originalType, string expectedTypeName)
+    {
+        TestRoundtrip(new (), originalType, expectedTypeName);
+    }
+
+    private void TestRoundtrip(Dictionary<string, Type> aliases, Type originalType, string expectedTypeName)
+    {
+        var typeResolver = CreateTarget();
+        foreach (var alias in aliases)
         {
-            return new TypeResolver();
+            typeResolver.RegisterAlias(alias.Key, alias.Value);
         }
+
+        var serializedTypeName = typeResolver.GetTypeName(originalType);
+        var deserializedType = typeResolver.GetTypeFromName(serializedTypeName);
+
+        Assert.Equal(expectedTypeName, serializedTypeName);
+        Assert.Equal(originalType, deserializedType);
+    }
+
+    private static TypeResolver CreateTarget()
+    {
+        return new TypeResolver();
     }
 }

--- a/src/NRules/Tests/NRules.Json.Tests/Utilities/ExpressionComparer.cs
+++ b/src/NRules/Tests/NRules.Json.Tests/Utilities/ExpressionComparer.cs
@@ -4,216 +4,215 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace NRules.Json.Tests.Utilities
+namespace NRules.Json.Tests.Utilities;
+
+public static class ExpressionComparer
 {
-    public static class ExpressionComparer
+    public static bool AreEqual(Expression x, Expression y)
     {
-        public static bool AreEqual(Expression x, Expression y)
-        {
-            return ExpressionEqual(x, y, null, null);
-        }
+        return ExpressionEqual(x, y, null, null);
+    }
 
-        private static bool ExpressionEqual(Expression x, Expression y, LambdaExpression rootX, LambdaExpression rootY)
-        {
-            if (ReferenceEquals(x, y)) return true;
-            if (x == null || y == null) return false;
-            if (x.NodeType != y.NodeType || x.Type != y.Type) return false;
+    private static bool ExpressionEqual(Expression x, Expression y, LambdaExpression rootX, LambdaExpression rootY)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x == null || y == null) return false;
+        if (x.NodeType != y.NodeType || x.Type != y.Type) return false;
 
-            switch (x)
+        switch (x)
+        {
+            case LambdaExpression lx:
             {
-                case LambdaExpression lx:
-                {
-                    var ly = (LambdaExpression)y;
-                    var paramsX = lx.Parameters;
-                    var paramsY = ly.Parameters;
-                    return CollectionsEqual(paramsX, paramsY, lx, ly) && ExpressionEqual(lx.Body, ly.Body, lx, ly);
-                }
-                case MemberExpression mex:
-                {
-                    var mey = (MemberExpression)y;
-                    return MemberExpressionsEqual(mex, mey, rootX, rootY);
-                }
-                case BinaryExpression bx:
-                {
-                    var by = (BinaryExpression)y;
-                    return bx.Method == @by.Method && ExpressionEqual(bx.Left, @by.Left, rootX, rootY) &&
-                           ExpressionEqual(bx.Right, @by.Right, rootX, rootY);
-                }
-                case UnaryExpression ux:
-                {
-                    var uy = (UnaryExpression)y;
-                    return ux.Method == uy.Method && ExpressionEqual(ux.Operand, uy.Operand, rootX, rootY);
-                }
-                case ParameterExpression px:
-                {
-                    var py = (ParameterExpression)y;
-                    return rootX.Parameters.IndexOf(px) == rootY.Parameters.IndexOf(py) &&
-                           px.Name == py.Name;
-                }
-                case MethodCallExpression cx:
-                {
-                    var cy = (MethodCallExpression)y;
-                    return cx.Method == cy.Method
-                           && ExpressionEqual(cx.Object, cy.Object, rootX, rootY)
-                           && CollectionsEqual(cx.Arguments, cy.Arguments, rootX, rootY);
-                }
-                case InvocationExpression ix:
-                {
-                    var iy = (InvocationExpression)y;
-                    return ExpressionEqual(ix.Expression, iy.Expression, rootX, rootY)
-                           && CollectionsEqual(ix.Arguments, iy.Arguments, rootX, rootY);
-                }
-                case NewExpression nx:
-                {
-                    var ny = (NewExpression)y;
-                    return nx.Constructor == ny.Constructor
-                           && CollectionsEqual(nx.Arguments, ny.Arguments, rootX, rootY);
-                }
-                case MemberInitExpression mix:
-                {
-                    var miy = (MemberInitExpression)y;
-                    return ExpressionEqual(mix.NewExpression, miy.NewExpression, rootX, rootY)
-                           && MemberBindingCollectionsEqual(mix.Bindings, miy.Bindings, rootX, rootY);
-                }
-                case ListInitExpression lix:
-                {
-                    var liy = (ListInitExpression)y;
-                    return ExpressionEqual(lix.NewExpression, liy.NewExpression, rootX, rootY)
-                           && ElementInitCollectionsEqual(lix.Initializers, liy.Initializers, rootX, rootY);
-                }
-                case ConstantExpression cx:
-                {
-                    var cy = (ConstantExpression)y;
-                    return Equals(cx.Value, cy.Value);
-                }
-                case TypeBinaryExpression tbx:
-                {
-                    var tby = (TypeBinaryExpression)y;
-                    return tbx.TypeOperand == tby.TypeOperand;
-                }
-                case ConditionalExpression cx:
-                {
-                    var cy = (ConditionalExpression)y;
-                    return ExpressionEqual(cx.Test, cy.Test, rootX, rootY)
-                           && ExpressionEqual(cx.IfTrue, cy.IfTrue, rootX, rootY)
-                           && ExpressionEqual(cx.IfFalse, cy.IfFalse, rootX, rootY);
-                }
-                case NewArrayExpression ax:
-                {
-                    var ay = (NewArrayExpression) y;
-                    return ax.Type == ay.Type && CollectionsEqual(ax.Expressions, ay.Expressions, rootX, rootY);
-                }
-                case DefaultExpression dx:
-                {
-                    var dy = (DefaultExpression) y;
-                    return dx.Type == dy.Type;
-                }
-                default:
-                    throw new NotImplementedException(x.ToString());
+                var ly = (LambdaExpression)y;
+                var paramsX = lx.Parameters;
+                var paramsY = ly.Parameters;
+                return CollectionsEqual(paramsX, paramsY, lx, ly) && ExpressionEqual(lx.Body, ly.Body, lx, ly);
             }
-        }
-
-        private static bool MemberBindingCollectionsEqual(IReadOnlyCollection<MemberBinding> x, IReadOnlyCollection<MemberBinding> y,
-            LambdaExpression rootX, LambdaExpression rootY)
-        {
-            return x.Count == y.Count
-                   && x.Zip(y, (first, second) => new {X = first, Y = second})
-                       .All(o => MemberBindingsEqual(o.X, o.Y, rootX, rootY));
-        }
-
-        private static bool ElementInitCollectionsEqual(IReadOnlyCollection<ElementInit> x, IReadOnlyCollection<ElementInit> y,
-            LambdaExpression rootX, LambdaExpression rootY)
-        {
-            return x.Count == y.Count
-                   && x.Zip(y, (first, second) => new {X = first, Y = second})
-                       .All(o => ElementInitsEqual(o.X, o.Y, rootX, rootY));
-        }
-
-        private static bool CollectionsEqual(IReadOnlyCollection<Expression> x, IReadOnlyCollection<Expression> y,
-            LambdaExpression rootX, LambdaExpression rootY)
-        {
-            return x.Count == y.Count
-                   && x.Zip(y, (first, second) => new {X = first, Y = second})
-                       .All(o => ExpressionEqual(o.X, o.Y, rootX, rootY));
-        }
-
-        private static bool ElementInitsEqual(ElementInit x, ElementInit y, LambdaExpression rootX,
-            LambdaExpression rootY)
-        {
-            return Equals(x.AddMethod, y.AddMethod)
-                   && CollectionsEqual(x.Arguments, y.Arguments, rootX, rootY);
-        }
-
-        private static bool MemberBindingsEqual(MemberBinding x, MemberBinding y, LambdaExpression rootX,
-            LambdaExpression rootY)
-        {
-            if (x.BindingType != y.BindingType)
-                return false;
-
-            switch (x.BindingType)
+            case MemberExpression mex:
             {
-                case MemberBindingType.Assignment:
-                    var max = (MemberAssignment)x;
-                    var may = (MemberAssignment)y;
-                    return ExpressionEqual(max.Expression, may.Expression, rootX, rootY);
-                case MemberBindingType.MemberBinding:
-                    var mmbx = (MemberMemberBinding)x;
-                    var mmby = (MemberMemberBinding)y;
-                    return MemberBindingCollectionsEqual(mmbx.Bindings, mmby.Bindings, rootX, rootY);
-                case MemberBindingType.ListBinding:
-                    var mlbx = (MemberListBinding)x;
-                    var mlby = (MemberListBinding)y;
-                    return ElementInitCollectionsEqual(mlbx.Initializers, mlby.Initializers, rootX, rootY);
-                default:
-                    throw new ArgumentOutOfRangeException($"Unsupported binding type. BindingType={x.BindingType}");
+                var mey = (MemberExpression)y;
+                return MemberExpressionsEqual(mex, mey, rootX, rootY);
             }
-        }
-
-        private static bool MemberExpressionsEqual(MemberExpression x, MemberExpression y, LambdaExpression rootX, LambdaExpression rootY)
-        {
-            if (x.Expression == null || y.Expression == null)
-                return Equals(x.Member, y.Member);
-
-            if (x.Expression.NodeType != y.Expression.NodeType)
-                return false;
-
-            switch (x.Expression.NodeType)
+            case BinaryExpression bx:
             {
-                case ExpressionType.Constant:
-                    var cx = GetValueOfConstantExpression(x);
-                    var cy = GetValueOfConstantExpression(y);
-                    return Equals(cx, cy);
-                case ExpressionType.Parameter:
-                case ExpressionType.MemberAccess:
-                case ExpressionType.Convert:
-                case ExpressionType.Add:
-                case ExpressionType.AddChecked:
-                case ExpressionType.Subtract:
-                case ExpressionType.SubtractChecked:
-                case ExpressionType.Multiply:
-                case ExpressionType.MultiplyChecked:
-                case ExpressionType.Divide:
-                case ExpressionType.Modulo:
-                case ExpressionType.Power:
-                case ExpressionType.Conditional:
-                    return Equals(x.Member, y.Member) && ExpressionEqual(x.Expression, y.Expression, rootX, rootY);
-                case ExpressionType.New:
-                case ExpressionType.Call:
-                    return ExpressionEqual(x.Expression, y.Expression, rootX, rootY);
-                default:
-                    throw new NotImplementedException(x.ToString());
+                var by = (BinaryExpression)y;
+                return bx.Method == @by.Method && ExpressionEqual(bx.Left, @by.Left, rootX, rootY) &&
+                       ExpressionEqual(bx.Right, @by.Right, rootX, rootY);
             }
-        }
-
-        private static object GetValueOfConstantExpression(MemberExpression mex)
-        {
-            var o = ((ConstantExpression)mex.Expression).Value;
-            return mex.Member switch
+            case UnaryExpression ux:
             {
-                FieldInfo fi => fi.GetValue(o),
-                PropertyInfo pi => pi.GetValue(o, null),
-                _ => throw new ArgumentException($"Unsupported member type. MemberType={mex.Member.GetType()}")
-            };
+                var uy = (UnaryExpression)y;
+                return ux.Method == uy.Method && ExpressionEqual(ux.Operand, uy.Operand, rootX, rootY);
+            }
+            case ParameterExpression px:
+            {
+                var py = (ParameterExpression)y;
+                return rootX.Parameters.IndexOf(px) == rootY.Parameters.IndexOf(py) &&
+                       px.Name == py.Name;
+            }
+            case MethodCallExpression cx:
+            {
+                var cy = (MethodCallExpression)y;
+                return cx.Method == cy.Method
+                       && ExpressionEqual(cx.Object, cy.Object, rootX, rootY)
+                       && CollectionsEqual(cx.Arguments, cy.Arguments, rootX, rootY);
+            }
+            case InvocationExpression ix:
+            {
+                var iy = (InvocationExpression)y;
+                return ExpressionEqual(ix.Expression, iy.Expression, rootX, rootY)
+                       && CollectionsEqual(ix.Arguments, iy.Arguments, rootX, rootY);
+            }
+            case NewExpression nx:
+            {
+                var ny = (NewExpression)y;
+                return nx.Constructor == ny.Constructor
+                       && CollectionsEqual(nx.Arguments, ny.Arguments, rootX, rootY);
+            }
+            case MemberInitExpression mix:
+            {
+                var miy = (MemberInitExpression)y;
+                return ExpressionEqual(mix.NewExpression, miy.NewExpression, rootX, rootY)
+                       && MemberBindingCollectionsEqual(mix.Bindings, miy.Bindings, rootX, rootY);
+            }
+            case ListInitExpression lix:
+            {
+                var liy = (ListInitExpression)y;
+                return ExpressionEqual(lix.NewExpression, liy.NewExpression, rootX, rootY)
+                       && ElementInitCollectionsEqual(lix.Initializers, liy.Initializers, rootX, rootY);
+            }
+            case ConstantExpression cx:
+            {
+                var cy = (ConstantExpression)y;
+                return Equals(cx.Value, cy.Value);
+            }
+            case TypeBinaryExpression tbx:
+            {
+                var tby = (TypeBinaryExpression)y;
+                return tbx.TypeOperand == tby.TypeOperand;
+            }
+            case ConditionalExpression cx:
+            {
+                var cy = (ConditionalExpression)y;
+                return ExpressionEqual(cx.Test, cy.Test, rootX, rootY)
+                       && ExpressionEqual(cx.IfTrue, cy.IfTrue, rootX, rootY)
+                       && ExpressionEqual(cx.IfFalse, cy.IfFalse, rootX, rootY);
+            }
+            case NewArrayExpression ax:
+            {
+                var ay = (NewArrayExpression) y;
+                return ax.Type == ay.Type && CollectionsEqual(ax.Expressions, ay.Expressions, rootX, rootY);
+            }
+            case DefaultExpression dx:
+            {
+                var dy = (DefaultExpression) y;
+                return dx.Type == dy.Type;
+            }
+            default:
+                throw new NotImplementedException(x.ToString());
         }
+    }
+
+    private static bool MemberBindingCollectionsEqual(IReadOnlyCollection<MemberBinding> x, IReadOnlyCollection<MemberBinding> y,
+        LambdaExpression rootX, LambdaExpression rootY)
+    {
+        return x.Count == y.Count
+               && x.Zip(y, (first, second) => new {X = first, Y = second})
+                   .All(o => MemberBindingsEqual(o.X, o.Y, rootX, rootY));
+    }
+
+    private static bool ElementInitCollectionsEqual(IReadOnlyCollection<ElementInit> x, IReadOnlyCollection<ElementInit> y,
+        LambdaExpression rootX, LambdaExpression rootY)
+    {
+        return x.Count == y.Count
+               && x.Zip(y, (first, second) => new {X = first, Y = second})
+                   .All(o => ElementInitsEqual(o.X, o.Y, rootX, rootY));
+    }
+
+    private static bool CollectionsEqual(IReadOnlyCollection<Expression> x, IReadOnlyCollection<Expression> y,
+        LambdaExpression rootX, LambdaExpression rootY)
+    {
+        return x.Count == y.Count
+               && x.Zip(y, (first, second) => new {X = first, Y = second})
+                   .All(o => ExpressionEqual(o.X, o.Y, rootX, rootY));
+    }
+
+    private static bool ElementInitsEqual(ElementInit x, ElementInit y, LambdaExpression rootX,
+        LambdaExpression rootY)
+    {
+        return Equals(x.AddMethod, y.AddMethod)
+               && CollectionsEqual(x.Arguments, y.Arguments, rootX, rootY);
+    }
+
+    private static bool MemberBindingsEqual(MemberBinding x, MemberBinding y, LambdaExpression rootX,
+        LambdaExpression rootY)
+    {
+        if (x.BindingType != y.BindingType)
+            return false;
+
+        switch (x.BindingType)
+        {
+            case MemberBindingType.Assignment:
+                var max = (MemberAssignment)x;
+                var may = (MemberAssignment)y;
+                return ExpressionEqual(max.Expression, may.Expression, rootX, rootY);
+            case MemberBindingType.MemberBinding:
+                var mmbx = (MemberMemberBinding)x;
+                var mmby = (MemberMemberBinding)y;
+                return MemberBindingCollectionsEqual(mmbx.Bindings, mmby.Bindings, rootX, rootY);
+            case MemberBindingType.ListBinding:
+                var mlbx = (MemberListBinding)x;
+                var mlby = (MemberListBinding)y;
+                return ElementInitCollectionsEqual(mlbx.Initializers, mlby.Initializers, rootX, rootY);
+            default:
+                throw new ArgumentOutOfRangeException($"Unsupported binding type. BindingType={x.BindingType}");
+        }
+    }
+
+    private static bool MemberExpressionsEqual(MemberExpression x, MemberExpression y, LambdaExpression rootX, LambdaExpression rootY)
+    {
+        if (x.Expression == null || y.Expression == null)
+            return Equals(x.Member, y.Member);
+
+        if (x.Expression.NodeType != y.Expression.NodeType)
+            return false;
+
+        switch (x.Expression.NodeType)
+        {
+            case ExpressionType.Constant:
+                var cx = GetValueOfConstantExpression(x);
+                var cy = GetValueOfConstantExpression(y);
+                return Equals(cx, cy);
+            case ExpressionType.Parameter:
+            case ExpressionType.MemberAccess:
+            case ExpressionType.Convert:
+            case ExpressionType.Add:
+            case ExpressionType.AddChecked:
+            case ExpressionType.Subtract:
+            case ExpressionType.SubtractChecked:
+            case ExpressionType.Multiply:
+            case ExpressionType.MultiplyChecked:
+            case ExpressionType.Divide:
+            case ExpressionType.Modulo:
+            case ExpressionType.Power:
+            case ExpressionType.Conditional:
+                return Equals(x.Member, y.Member) && ExpressionEqual(x.Expression, y.Expression, rootX, rootY);
+            case ExpressionType.New:
+            case ExpressionType.Call:
+                return ExpressionEqual(x.Expression, y.Expression, rootX, rootY);
+            default:
+                throw new NotImplementedException(x.ToString());
+        }
+    }
+
+    private static object GetValueOfConstantExpression(MemberExpression mex)
+    {
+        var o = ((ConstantExpression)mex.Expression).Value;
+        return mex.Member switch
+        {
+            FieldInfo fi => fi.GetValue(o),
+            PropertyInfo pi => pi.GetValue(o, null),
+            _ => throw new ArgumentException($"Unsupported member type. MemberType={mex.Member.GetType()}")
+        };
     }
 }

--- a/src/NRules/Tests/NRules.Json.Tests/Utilities/RuleDefinitionComparer.cs
+++ b/src/NRules/Tests/NRules.Json.Tests/Utilities/RuleDefinitionComparer.cs
@@ -3,152 +3,151 @@ using System.Collections.Generic;
 using System.Linq;
 using NRules.RuleModel;
 
-namespace NRules.Json.Tests.Utilities
+namespace NRules.Json.Tests.Utilities;
+
+public static class RuleDefinitionComparer
 {
-    public static class RuleDefinitionComparer
+    public static bool AreEqual(IRuleDefinition x, IRuleDefinition y)
     {
-        public static bool AreEqual(IRuleDefinition x, IRuleDefinition y)
+        if (ReferenceEquals(x, y)) return true;
+        if (x == null || y == null) return false;
+
+        if (x.Name != y.Name) return false;
+        if (x.Description != y.Description) return false;
+        if (x.Priority != y.Priority) return false;
+        if (x.Repeatability != y.Repeatability) return false;
+
+        if (!AreEqual(x.DependencyGroup, y.DependencyGroup)) return false;
+        if (!AreEqual(x.LeftHandSide, y.LeftHandSide)) return false;
+        if (!AreEqual(x.FilterGroup, y.FilterGroup)) return false;
+        if (!AreEqual(x.RightHandSide, y.RightHandSide)) return false;
+
+        return true;
+    }
+
+    private static bool AreEqual(RuleElement x, RuleElement y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x == null || y == null) return false;
+        if (x.ElementType != y.ElementType) return false;
+
+        switch (x.ElementType)
         {
-            if (ReferenceEquals(x, y)) return true;
-            if (x == null || y == null) return false;
-
-            if (x.Name != y.Name) return false;
-            if (x.Description != y.Description) return false;
-            if (x.Priority != y.Priority) return false;
-            if (x.Repeatability != y.Repeatability) return false;
-
-            if (!AreEqual(x.DependencyGroup, y.DependencyGroup)) return false;
-            if (!AreEqual(x.LeftHandSide, y.LeftHandSide)) return false;
-            if (!AreEqual(x.FilterGroup, y.FilterGroup)) return false;
-            if (!AreEqual(x.RightHandSide, y.RightHandSide)) return false;
-
-            return true;
-        }
-
-        private static bool AreEqual(RuleElement x, RuleElement y)
-        {
-            if (ReferenceEquals(x, y)) return true;
-            if (x == null || y == null) return false;
-            if (x.ElementType != y.ElementType) return false;
-
-            switch (x.ElementType)
+            case ElementType.Action:
             {
-                case ElementType.Action:
-                {
-                    var a = (ActionElement) x;
-                    var b = (ActionElement) y;
-                    return a.ActionTrigger == b.ActionTrigger &&
-                           ExpressionComparer.AreEqual(a.Expression, b.Expression);
-                }
-                case ElementType.ActionGroup:
-                {
-                    var a = (ActionGroupElement) x;
-                    var b = (ActionGroupElement) y;
-                    return AreEqual(a.Actions, b.Actions);
-                }
-                case ElementType.Aggregate:
-                {
-                    var a = (AggregateElement) x;
-                    var b = (AggregateElement) y;
-                    return a.Name == b.Name &&
-                           AreEqual(a.Expressions, b.Expressions) &&
-                           a.CustomFactoryType == b.CustomFactoryType &&
-                           AreEqual(a.Source, b.Source);
-                }
-                case ElementType.And:
-                case ElementType.Or:
-                {
-                    var a = (GroupElement) x;
-                    var b = (GroupElement) y;
-                    return AreEqual(a.ChildElements, b.ChildElements);
-                }
-                case ElementType.Binding:
-                {
-                    var a = (BindingElement) x;
-                    var b = (BindingElement) y;
-                    return ExpressionComparer.AreEqual(a.Expression, b.Expression);
-                }
-                case ElementType.Dependency:
-                {
-                    var a = (DependencyElement) x;
-                    var b = (DependencyElement) y;
-                    return a.ServiceType == b.ServiceType &&
-                           AreEqual(a.Declaration, b.Declaration);
-                }
-                case ElementType.DependencyGroup:
-                {
-                    var a = (DependencyGroupElement) x;
-                    var b = (DependencyGroupElement) y;
-                    return AreEqual(a.Dependencies, b.Dependencies);
-                }
-                case ElementType.Exists:
-                {
-                    var a = (ExistsElement) x;
-                    var b = (ExistsElement) y;
-                    return AreEqual(a.Source, b.Source);
-                }
-                case ElementType.Filter:
-                {
-                    var a = (FilterElement) x;
-                    var b = (FilterElement) y;
-                    return a.FilterType == b.FilterType &&
-                           ExpressionComparer.AreEqual(a.Expression, b.Expression);
-                }
-                case ElementType.FilterGroup:
-                {
-                    var a = (FilterGroupElement) x;
-                    var b = (FilterGroupElement) y;
-                    return AreEqual(a.Filters, b.Filters);
-                }
-                case ElementType.ForAll:
-                {
-                    var a = (ForAllElement) x;
-                    var b = (ForAllElement) y;
-                    return AreEqual(a.BasePattern, b.BasePattern) &&
-                           AreEqual(a.Patterns, b.Patterns);
-                }
-                case ElementType.Not:
-                {
-                    var a = (NotElement) x;
-                    var b = (NotElement) y;
-                    return AreEqual(a.Source, b.Source);
-                }
-                case ElementType.Pattern:
-                {
-                    var a = (PatternElement) x;
-                    var b = (PatternElement) y;
-                    return AreEqual(a.Expressions, b.Expressions) &&
-                           AreEqual(a.Declaration, b.Declaration) &&
-                           AreEqual(a.Source, b.Source);
-                }
-                case ElementType.NamedExpression:
-                {
-                    var a = (NamedExpressionElement) x;
-                    var b = (NamedExpressionElement) y;
-                    return a.Name == b.Name &&
-                           ExpressionComparer.AreEqual(a.Expression, b.Expression);
-                }
-                default:
-                    throw new ArgumentOutOfRangeException($"ElementType={x.ElementType}");
+                var a = (ActionElement) x;
+                var b = (ActionElement) y;
+                return a.ActionTrigger == b.ActionTrigger &&
+                       ExpressionComparer.AreEqual(a.Expression, b.Expression);
             }
+            case ElementType.ActionGroup:
+            {
+                var a = (ActionGroupElement) x;
+                var b = (ActionGroupElement) y;
+                return AreEqual(a.Actions, b.Actions);
+            }
+            case ElementType.Aggregate:
+            {
+                var a = (AggregateElement) x;
+                var b = (AggregateElement) y;
+                return a.Name == b.Name &&
+                       AreEqual(a.Expressions, b.Expressions) &&
+                       a.CustomFactoryType == b.CustomFactoryType &&
+                       AreEqual(a.Source, b.Source);
+            }
+            case ElementType.And:
+            case ElementType.Or:
+            {
+                var a = (GroupElement) x;
+                var b = (GroupElement) y;
+                return AreEqual(a.ChildElements, b.ChildElements);
+            }
+            case ElementType.Binding:
+            {
+                var a = (BindingElement) x;
+                var b = (BindingElement) y;
+                return ExpressionComparer.AreEqual(a.Expression, b.Expression);
+            }
+            case ElementType.Dependency:
+            {
+                var a = (DependencyElement) x;
+                var b = (DependencyElement) y;
+                return a.ServiceType == b.ServiceType &&
+                       AreEqual(a.Declaration, b.Declaration);
+            }
+            case ElementType.DependencyGroup:
+            {
+                var a = (DependencyGroupElement) x;
+                var b = (DependencyGroupElement) y;
+                return AreEqual(a.Dependencies, b.Dependencies);
+            }
+            case ElementType.Exists:
+            {
+                var a = (ExistsElement) x;
+                var b = (ExistsElement) y;
+                return AreEqual(a.Source, b.Source);
+            }
+            case ElementType.Filter:
+            {
+                var a = (FilterElement) x;
+                var b = (FilterElement) y;
+                return a.FilterType == b.FilterType &&
+                       ExpressionComparer.AreEqual(a.Expression, b.Expression);
+            }
+            case ElementType.FilterGroup:
+            {
+                var a = (FilterGroupElement) x;
+                var b = (FilterGroupElement) y;
+                return AreEqual(a.Filters, b.Filters);
+            }
+            case ElementType.ForAll:
+            {
+                var a = (ForAllElement) x;
+                var b = (ForAllElement) y;
+                return AreEqual(a.BasePattern, b.BasePattern) &&
+                       AreEqual(a.Patterns, b.Patterns);
+            }
+            case ElementType.Not:
+            {
+                var a = (NotElement) x;
+                var b = (NotElement) y;
+                return AreEqual(a.Source, b.Source);
+            }
+            case ElementType.Pattern:
+            {
+                var a = (PatternElement) x;
+                var b = (PatternElement) y;
+                return AreEqual(a.Expressions, b.Expressions) &&
+                       AreEqual(a.Declaration, b.Declaration) &&
+                       AreEqual(a.Source, b.Source);
+            }
+            case ElementType.NamedExpression:
+            {
+                var a = (NamedExpressionElement) x;
+                var b = (NamedExpressionElement) y;
+                return a.Name == b.Name &&
+                       ExpressionComparer.AreEqual(a.Expression, b.Expression);
+            }
+            default:
+                throw new ArgumentOutOfRangeException($"ElementType={x.ElementType}");
         }
+    }
 
-        private static bool AreEqual(IEnumerable<RuleElement> x, IEnumerable<RuleElement> y)
-        {
-            return x.Count() == y.Count()
-                   && x.Zip(y, (first, second) => new {X = first, Y = second})
-                       .All(o => AreEqual(o.X, o.Y));
-        }
+    private static bool AreEqual(IEnumerable<RuleElement> x, IEnumerable<RuleElement> y)
+    {
+        return x.Count() == y.Count()
+               && x.Zip(y, (first, second) => new {X = first, Y = second})
+                   .All(o => AreEqual(o.X, o.Y));
+    }
 
-        private static bool AreEqual(Declaration x, Declaration y)
-        {
-            if (ReferenceEquals(x, y)) return true;
-            if (x == null || y == null) return false;
+    private static bool AreEqual(Declaration x, Declaration y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x == null || y == null) return false;
 
-            if (x.Name != y.Name) return false;
-            if (x.Type != y.Type) return false;
+        if (x.Name != y.Name) return false;
+        if (x.Type != y.Type) return false;
 
-            return true;
-        }
+        return true;
     }
 }

--- a/src/NRules/Tests/NRules.Tests/AgendaTest.cs
+++ b/src/NRules/Tests/NRules.Tests/AgendaTest.cs
@@ -6,406 +6,405 @@ using NRules.RuleModel;
 using Xunit;
 using Tuple = NRules.Rete.Tuple;
 
-namespace NRules.Tests
+namespace NRules.Tests;
+
+public class AgendaTest
 {
-    public class AgendaTest
+    private readonly Mock<IExecutionContext> _context;
+    private readonly Mock<ISessionInternal> _session;
+
+    public AgendaTest()
     {
-        private readonly Mock<IExecutionContext> _context;
-        private readonly Mock<ISessionInternal> _session;
+        _context = new Mock<IExecutionContext>();
+        _session = new Mock<ISessionInternal>();
 
-        public AgendaTest()
+        _context.Setup(x => x.Session).Returns(_session.Object);
+    }
+
+    [Fact]
+    public void Agenda_Created_Empty()
+    {
+        // Arrange
+        // Act
+        var target = CreateTarget();
+
+        // Assert
+        Assert.True(target.IsEmpty);
+    }
+
+    [Fact]
+    public void Pop_AgendaEmpty_Throws()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act - Assert
+        Assert.Throws<InvalidOperationException>(() => target.Pop());
+    }
+
+    [Fact]
+    public void Peek_AgendaHasOneActivation_ReturnsActivationAgendaEmpty()
+    {
+        // Arrange
+        var rule = MockRule();
+        var activation = new Activation(rule, new Tuple(0));
+        var target = CreateTarget();
+
+        target.Add(activation);
+
+        // Act
+        var actualActivation = target.Pop();
+
+        // Assert
+        Assert.True(target.IsEmpty);
+        Assert.Same(activation, actualActivation);
+    }
+
+    [Fact]
+    public void Add_Called_ActivationInAgenda()
+    {
+        // Arrange
+        var rule = MockRule();
+        var factObject = new FactObject {Value = "Test"};
+        var tuple = CreateTuple(factObject);
+        var activation = new Activation(rule, tuple);
+        var target = CreateTarget();
+
+        // Act
+        target.Add(activation);
+
+        // Assert
+        Assert.False(target.IsEmpty);
+        var actualActivation = target.Pop();
+        Assert.Equal(rule, actualActivation.CompiledRule);
+        Assert.Equal(factObject, actualActivation.Tuple.RightFact.Object);
+        Assert.True(target.IsEmpty);
+    }
+
+    [Fact]
+    public void Add_AcceptingGlobalFilter_ActivationInAgenda()
+    {
+        // Arrange
+        var rule = MockRule();
+        var factObject = new FactObject {Value = "Test"};
+        var tuple = CreateTuple(factObject);
+        var activation = new Activation(rule, tuple);
+        var target = CreateTarget();
+        target.AddFilter(new AcceptingFilter());
+
+        // Act
+        target.Add(activation);
+
+        // Assert
+        Assert.False(target.IsEmpty);
+    }
+
+    [Fact]
+    public void Add_RejectingGlobalFilter_ActivationNotInAgenda()
+    {
+        // Arrange
+        var rule = MockRule();
+        var factObject = new FactObject {Value = "Test"};
+        var tuple = CreateTuple(factObject);
+        var activation = new Activation(rule, tuple);
+        var target = CreateTarget();
+        target.AddFilter(new RejectingFilter());
+
+        // Act
+        target.Add(activation);
+
+        // Assert
+        Assert.True(target.IsEmpty);
+    }
+
+    [Fact]
+    public void Add_AcceptingAndRejectingGlobalFilter_ActivationNotInAgenda()
+    {
+        // Arrange
+        var rule = MockRule();
+        var factObject = new FactObject {Value = "Test"};
+        var tuple = CreateTuple(factObject);
+        var activation = new Activation(rule, tuple);
+        var target = CreateTarget();
+        target.AddFilter(new AcceptingFilter());
+        target.AddFilter(new RejectingFilter());
+
+        // Act
+        target.Add(activation);
+
+        // Assert
+        Assert.True(target.IsEmpty);
+    }
+
+    [Fact]
+    public void Add_AcceptingRuleFilter_ActivationInAgenda()
+    {
+        // Arrange
+        var rule = MockRule();
+        var factObject = new FactObject {Value = "Test"};
+        var tuple = CreateTuple(factObject);
+        var activation = new Activation(rule, tuple);
+        var target = CreateTarget();
+        target.AddFilter(rule.Definition, new AcceptingFilter());
+
+        // Act
+        target.Add(activation);
+
+        // Assert
+        Assert.False(target.IsEmpty);
+    }
+
+    [Fact]
+    public void Add_RejectingRuleFilter_ActivationNotInAgenda()
+    {
+        // Arrange
+        var rule = MockRule();
+        var factObject = new FactObject {Value = "Test"};
+        var tuple = CreateTuple(factObject);
+        var activation = new Activation(rule, tuple);
+        var target = CreateTarget();
+        target.AddFilter(rule.Definition, new RejectingFilter());
+
+        // Act
+        target.Add(activation);
+
+        // Assert
+        Assert.True(target.IsEmpty);
+    }
+
+
+    [Fact]
+    public void Add_RejectingRuleFilterForDifferentRule_ActivationInAgenda()
+    {
+        // Arrange
+        var rule1 = MockRule();
+        var rule2 = MockRule();
+        var factObject = new FactObject { Value = "Test" };
+        var tuple = CreateTuple(factObject);
+        var activation = new Activation(rule1, tuple);
+        var target = CreateTarget();
+        target.AddFilter(rule2.Definition, new RejectingFilter());
+
+        // Act
+        target.Add(activation);
+
+        // Assert
+        Assert.False(target.IsEmpty);
+    }
+
+    [Fact]
+    public void Modify_ActivationAlreadyInQueue_ActivationUpdatedInQueue()
+    {
+        // Arrange
+        var rule = MockRule();
+        var factObject = new FactObject { Value = "Test" };
+        var tuple = CreateTuple(factObject);
+        var activation = new Activation(rule, tuple);
+        var target = CreateTarget();
+        target.Add(activation);
+
+        // Act
+        factObject.Value = "New Value";
+        target.Modify(activation);
+
+        // Assert
+        Assert.False(target.IsEmpty);
+        var actualActivation = target.Pop();
+        Assert.Equal(rule, actualActivation.CompiledRule);
+        Assert.Equal(factObject.Value, ((FactObject)actualActivation.Tuple.RightFact.Object).Value);
+        Assert.True(target.IsEmpty);
+    }
+
+    [Fact]
+    public void Modify_ActivationNotInQueue_ActivationReAddedToQueue()
+    {
+        // Arrange
+        var rule = MockRule();
+        var factObject = new FactObject { Value = "Test" };
+        var tuple = CreateTuple(factObject);
+        var activation = new Activation(rule, tuple);
+        var target = CreateTarget();
+        target.Add(activation);
+        target.Pop();
+
+        // Act
+        target.Modify(activation);
+
+        // Assert
+        Assert.False(target.IsEmpty);
+        var actualActivation = target.Pop();
+        Assert.Equal(rule, actualActivation.CompiledRule);
+        Assert.True(target.IsEmpty);
+    }
+
+    [Fact]
+    public void Modify_ActivationAlreadyInQueueRejectingFilter_ActivationRemovedFromQueue()
+    {
+        // Arrange
+        var rule = MockRule();
+        var factObject = new FactObject { Value = "Test" };
+        var tuple = CreateTuple(factObject);
+        var activation = new Activation(rule, tuple);
+        var target = CreateTarget();
+        target.Add(activation);
+
+        target.AddFilter(new RejectingFilter());
+
+        // Act
+        factObject.Value = "New Value";
+        target.Modify(activation);
+
+        // Assert
+        Assert.True(target.IsEmpty);
+    }
+
+    [Fact]
+    public void Modify_ActivationNotInQueue_ActivationNotReAddedToQueue()
+    {
+        // Arrange
+        var rule = MockRule();
+        var factObject = new FactObject { Value = "Test" };
+        var tuple = CreateTuple(factObject);
+        var activation = new Activation(rule, tuple);
+        var target = CreateTarget();
+        target.Add(activation);
+        target.Pop();
+
+        target.AddFilter(new RejectingFilter());
+
+        // Act
+        target.Modify(activation);
+
+        // Assert
+        Assert.True(target.IsEmpty);
+    }
+
+    [Fact]
+    public void Remove_CalledAfterAdd_AgendaEmpty()
+    {
+        // Arrange
+        var rule = MockRule();
+        var factObject = new FactObject { Value = "Test" };
+        var tuple = CreateTuple(factObject);
+        var activation = new Activation(rule, tuple);
+        var target = CreateTarget();
+        target.Add(activation);
+
+        _session.Setup(x => x.GetLinkedKeys(activation)).Returns(new object[0]);
+
+        // Act
+        target.Remove(activation);
+
+        // Assert
+        Assert.True(target.IsEmpty);
+    }
+
+    [Fact]
+    public void Add_CalledWithMultipleRules_RulesAreQueuedInOrder()
+    {
+        // Arrange
+        var rule1 = MockRule();
+        var rule2 = MockRule();
+        var activation1 = new Activation(rule1, new Tuple(0));
+        var activation2 = new Activation(rule2, new Tuple(0));
+        var target = CreateTarget();
+
+        // Act
+        target.Add(activation1);
+        target.Add(activation2);
+
+        // Assert
+        Assert.False(target.IsEmpty);
+        Assert.Equal(rule1, target.Pop().CompiledRule);
+        Assert.False(target.IsEmpty);
+        Assert.Equal(rule2, target.Pop().CompiledRule);
+    }
+
+    [Fact]
+    public void Peek_AgendaHasActivations_ReturnsActivationAgendaRemainsNonEmpty()
+    {
+        // Arrange
+        var rule = MockRule();
+        var activation = new Activation(rule, new Tuple(0));
+        var target = CreateTarget();
+
+        target.Add(activation);
+
+        // Act
+        var actualActivation = target.Peek();
+
+        // Assert
+        Assert.False(target.IsEmpty);
+        Assert.Same(activation, actualActivation);
+    }
+
+    [Fact]
+    public void Peek_AgendaEmpty_Throws()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act - Assert
+        Assert.Throws<InvalidOperationException>(() => target.Peek());
+    }
+
+    [Fact]
+    public void Clear_CalledAfterActivation_AgendaEmpty()
+    {
+        // Arrange
+        var rule = MockRule();
+        var activation = new Activation(rule, new Tuple(0));
+        var target = CreateTarget();
+
+        target.Add(activation);
+
+        // Act
+        target.Clear();
+
+        // Assert
+        Assert.True(target.IsEmpty);
+    }
+
+    private Agenda CreateTarget()
+    {
+        var agenda = new Agenda();
+        agenda.Initialize(_context.Object);
+        return agenda;
+    }
+
+    private static ICompiledRule MockRule()
+    {
+        var compiledRuleMock = new Mock<ICompiledRule>();
+        var ruleDefinitionMock = new Mock<IRuleDefinition>();
+        compiledRuleMock.Setup(x => x.Definition).Returns(ruleDefinitionMock.Object);
+        var actionTrigger = ActionTrigger.Activated | ActionTrigger.Reactivated | ActionTrigger.Deactivated;
+        compiledRuleMock.Setup(x => x.ActionTriggers).Returns(actionTrigger);
+        return compiledRuleMock.Object;
+    }
+
+    private static Tuple CreateTuple(object factObject)
+    {
+        return new Tuple(0, new Tuple(0), new Fact(factObject));
+    }
+
+    private class FactObject
+    {
+        public string Value { get; set; }
+    }
+
+    private class RejectingFilter : IAgendaFilter
+    {
+        public bool Accept(AgendaContext context, Activation activation)
         {
-            _context = new Mock<IExecutionContext>();
-            _session = new Mock<ISessionInternal>();
-
-            _context.Setup(x => x.Session).Returns(_session.Object);
+            return false;
         }
+    }
 
-        [Fact]
-        public void Agenda_Created_Empty()
+    private class AcceptingFilter : IAgendaFilter
+    {
+        public bool Accept(AgendaContext context, Activation activation)
         {
-            // Arrange
-            // Act
-            var target = CreateTarget();
-
-            // Assert
-            Assert.True(target.IsEmpty);
-        }
-
-        [Fact]
-        public void Pop_AgendaEmpty_Throws()
-        {
-            // Arrange
-            var target = CreateTarget();
-
-            // Act - Assert
-            Assert.Throws<InvalidOperationException>(() => target.Pop());
-        }
-
-        [Fact]
-        public void Peek_AgendaHasOneActivation_ReturnsActivationAgendaEmpty()
-        {
-            // Arrange
-            var rule = MockRule();
-            var activation = new Activation(rule, new Tuple(0));
-            var target = CreateTarget();
-
-            target.Add(activation);
-
-            // Act
-            var actualActivation = target.Pop();
-
-            // Assert
-            Assert.True(target.IsEmpty);
-            Assert.Same(activation, actualActivation);
-        }
-
-        [Fact]
-        public void Add_Called_ActivationInAgenda()
-        {
-            // Arrange
-            var rule = MockRule();
-            var factObject = new FactObject {Value = "Test"};
-            var tuple = CreateTuple(factObject);
-            var activation = new Activation(rule, tuple);
-            var target = CreateTarget();
-
-            // Act
-            target.Add(activation);
-
-            // Assert
-            Assert.False(target.IsEmpty);
-            var actualActivation = target.Pop();
-            Assert.Equal(rule, actualActivation.CompiledRule);
-            Assert.Equal(factObject, actualActivation.Tuple.RightFact.Object);
-            Assert.True(target.IsEmpty);
-        }
-
-        [Fact]
-        public void Add_AcceptingGlobalFilter_ActivationInAgenda()
-        {
-            // Arrange
-            var rule = MockRule();
-            var factObject = new FactObject {Value = "Test"};
-            var tuple = CreateTuple(factObject);
-            var activation = new Activation(rule, tuple);
-            var target = CreateTarget();
-            target.AddFilter(new AcceptingFilter());
-
-            // Act
-            target.Add(activation);
-
-            // Assert
-            Assert.False(target.IsEmpty);
-        }
-
-        [Fact]
-        public void Add_RejectingGlobalFilter_ActivationNotInAgenda()
-        {
-            // Arrange
-            var rule = MockRule();
-            var factObject = new FactObject {Value = "Test"};
-            var tuple = CreateTuple(factObject);
-            var activation = new Activation(rule, tuple);
-            var target = CreateTarget();
-            target.AddFilter(new RejectingFilter());
-
-            // Act
-            target.Add(activation);
-
-            // Assert
-            Assert.True(target.IsEmpty);
-        }
-
-        [Fact]
-        public void Add_AcceptingAndRejectingGlobalFilter_ActivationNotInAgenda()
-        {
-            // Arrange
-            var rule = MockRule();
-            var factObject = new FactObject {Value = "Test"};
-            var tuple = CreateTuple(factObject);
-            var activation = new Activation(rule, tuple);
-            var target = CreateTarget();
-            target.AddFilter(new AcceptingFilter());
-            target.AddFilter(new RejectingFilter());
-
-            // Act
-            target.Add(activation);
-
-            // Assert
-            Assert.True(target.IsEmpty);
-        }
-
-        [Fact]
-        public void Add_AcceptingRuleFilter_ActivationInAgenda()
-        {
-            // Arrange
-            var rule = MockRule();
-            var factObject = new FactObject {Value = "Test"};
-            var tuple = CreateTuple(factObject);
-            var activation = new Activation(rule, tuple);
-            var target = CreateTarget();
-            target.AddFilter(rule.Definition, new AcceptingFilter());
-
-            // Act
-            target.Add(activation);
-
-            // Assert
-            Assert.False(target.IsEmpty);
-        }
-
-        [Fact]
-        public void Add_RejectingRuleFilter_ActivationNotInAgenda()
-        {
-            // Arrange
-            var rule = MockRule();
-            var factObject = new FactObject {Value = "Test"};
-            var tuple = CreateTuple(factObject);
-            var activation = new Activation(rule, tuple);
-            var target = CreateTarget();
-            target.AddFilter(rule.Definition, new RejectingFilter());
-
-            // Act
-            target.Add(activation);
-
-            // Assert
-            Assert.True(target.IsEmpty);
-        }
-
-
-        [Fact]
-        public void Add_RejectingRuleFilterForDifferentRule_ActivationInAgenda()
-        {
-            // Arrange
-            var rule1 = MockRule();
-            var rule2 = MockRule();
-            var factObject = new FactObject { Value = "Test" };
-            var tuple = CreateTuple(factObject);
-            var activation = new Activation(rule1, tuple);
-            var target = CreateTarget();
-            target.AddFilter(rule2.Definition, new RejectingFilter());
-
-            // Act
-            target.Add(activation);
-
-            // Assert
-            Assert.False(target.IsEmpty);
-        }
-
-        [Fact]
-        public void Modify_ActivationAlreadyInQueue_ActivationUpdatedInQueue()
-        {
-            // Arrange
-            var rule = MockRule();
-            var factObject = new FactObject { Value = "Test" };
-            var tuple = CreateTuple(factObject);
-            var activation = new Activation(rule, tuple);
-            var target = CreateTarget();
-            target.Add(activation);
-
-            // Act
-            factObject.Value = "New Value";
-            target.Modify(activation);
-
-            // Assert
-            Assert.False(target.IsEmpty);
-            var actualActivation = target.Pop();
-            Assert.Equal(rule, actualActivation.CompiledRule);
-            Assert.Equal(factObject.Value, ((FactObject)actualActivation.Tuple.RightFact.Object).Value);
-            Assert.True(target.IsEmpty);
-        }
-
-        [Fact]
-        public void Modify_ActivationNotInQueue_ActivationReAddedToQueue()
-        {
-            // Arrange
-            var rule = MockRule();
-            var factObject = new FactObject { Value = "Test" };
-            var tuple = CreateTuple(factObject);
-            var activation = new Activation(rule, tuple);
-            var target = CreateTarget();
-            target.Add(activation);
-            target.Pop();
- 
-            // Act
-            target.Modify(activation);
-
-            // Assert
-            Assert.False(target.IsEmpty);
-            var actualActivation = target.Pop();
-            Assert.Equal(rule, actualActivation.CompiledRule);
-            Assert.True(target.IsEmpty);
-        }
-
-        [Fact]
-        public void Modify_ActivationAlreadyInQueueRejectingFilter_ActivationRemovedFromQueue()
-        {
-            // Arrange
-            var rule = MockRule();
-            var factObject = new FactObject { Value = "Test" };
-            var tuple = CreateTuple(factObject);
-            var activation = new Activation(rule, tuple);
-            var target = CreateTarget();
-            target.Add(activation);
-
-            target.AddFilter(new RejectingFilter());
-
-            // Act
-            factObject.Value = "New Value";
-            target.Modify(activation);
-
-            // Assert
-            Assert.True(target.IsEmpty);
-        }
-
-        [Fact]
-        public void Modify_ActivationNotInQueue_ActivationNotReAddedToQueue()
-        {
-            // Arrange
-            var rule = MockRule();
-            var factObject = new FactObject { Value = "Test" };
-            var tuple = CreateTuple(factObject);
-            var activation = new Activation(rule, tuple);
-            var target = CreateTarget();
-            target.Add(activation);
-            target.Pop();
-
-            target.AddFilter(new RejectingFilter());
-
-            // Act
-            target.Modify(activation);
-
-            // Assert
-            Assert.True(target.IsEmpty);
-        }
-
-        [Fact]
-        public void Remove_CalledAfterAdd_AgendaEmpty()
-        {
-            // Arrange
-            var rule = MockRule();
-            var factObject = new FactObject { Value = "Test" };
-            var tuple = CreateTuple(factObject);
-            var activation = new Activation(rule, tuple);
-            var target = CreateTarget();
-            target.Add(activation);
-
-            _session.Setup(x => x.GetLinkedKeys(activation)).Returns(new object[0]);
-
-            // Act
-            target.Remove(activation);
-
-            // Assert
-            Assert.True(target.IsEmpty);
-        }
-
-        [Fact]
-        public void Add_CalledWithMultipleRules_RulesAreQueuedInOrder()
-        {
-            // Arrange
-            var rule1 = MockRule();
-            var rule2 = MockRule();
-            var activation1 = new Activation(rule1, new Tuple(0));
-            var activation2 = new Activation(rule2, new Tuple(0));
-            var target = CreateTarget();
-
-            // Act
-            target.Add(activation1);
-            target.Add(activation2);
-
-            // Assert
-            Assert.False(target.IsEmpty);
-            Assert.Equal(rule1, target.Pop().CompiledRule);
-            Assert.False(target.IsEmpty);
-            Assert.Equal(rule2, target.Pop().CompiledRule);
-        }
-
-        [Fact]
-        public void Peek_AgendaHasActivations_ReturnsActivationAgendaRemainsNonEmpty()
-        {
-            // Arrange
-            var rule = MockRule();
-            var activation = new Activation(rule, new Tuple(0));
-            var target = CreateTarget();
-
-            target.Add(activation);
-
-            // Act
-            var actualActivation = target.Peek();
-
-            // Assert
-            Assert.False(target.IsEmpty);
-            Assert.Same(activation, actualActivation);
-        }
-
-        [Fact]
-        public void Peek_AgendaEmpty_Throws()
-        {
-            // Arrange
-            var target = CreateTarget();
-
-            // Act - Assert
-            Assert.Throws<InvalidOperationException>(() => target.Peek());
-        }
-
-        [Fact]
-        public void Clear_CalledAfterActivation_AgendaEmpty()
-        {
-            // Arrange
-            var rule = MockRule();
-            var activation = new Activation(rule, new Tuple(0));
-            var target = CreateTarget();
-
-            target.Add(activation);
-
-            // Act
-            target.Clear();
-
-            // Assert
-            Assert.True(target.IsEmpty);
-        }
-
-        private Agenda CreateTarget()
-        {
-            var agenda = new Agenda();
-            agenda.Initialize(_context.Object);
-            return agenda;
-        }
-
-        private static ICompiledRule MockRule()
-        {
-            var compiledRuleMock = new Mock<ICompiledRule>();
-            var ruleDefinitionMock = new Mock<IRuleDefinition>();
-            compiledRuleMock.Setup(x => x.Definition).Returns(ruleDefinitionMock.Object);
-            var actionTrigger = ActionTrigger.Activated | ActionTrigger.Reactivated | ActionTrigger.Deactivated;
-            compiledRuleMock.Setup(x => x.ActionTriggers).Returns(actionTrigger);
-            return compiledRuleMock.Object;
-        }
-
-        private static Tuple CreateTuple(object factObject)
-        {
-            return new Tuple(0, new Tuple(0), new Fact(factObject));
-        }
-
-        private class FactObject
-        {
-            public string Value { get; set; }
-        }
-
-        private class RejectingFilter : IAgendaFilter
-        {
-            public bool Accept(AgendaContext context, Activation activation)
-            {
-                return false;
-            }
-        }
-
-        private class AcceptingFilter : IAgendaFilter
-        {
-            public bool Accept(AgendaContext context, Activation activation)
-            {
-                return true;
-            }
+            return true;
         }
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Aggregators/AggregatorTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Aggregators/AggregatorTest.cs
@@ -4,54 +4,53 @@ using System.Linq;
 using NRules.Aggregators;
 using NRules.RuleModel;
 
-namespace NRules.Tests.Aggregators
+namespace NRules.Tests.Aggregators;
+
+public abstract class AggregatorTest
 {
-    public abstract class AggregatorTest
+    protected Fact[] AsFact<T>(params T[] value)
     {
-        protected Fact[] AsFact<T>(params T[] value)
-        {
-            return value.Select(x => new Fact(x)).ToArray();
-        }
-
-        protected ITuple EmptyTuple()
-        {
-            return new NullTuple();
-        }
-
-        private class NullTuple : ITuple
-        {
-            public IEnumerable<IFact> Facts => new IFact[0];
-            public int Count => 0;
-        }
-
-        public class Fact : IFact
-        {
-            public Fact(object value)
-            {
-                Type = value.GetType();
-                Value = value;
-            }
-
-            public Type Type { get; }
-            public object Value { get; set; }
-            public IFactSource Source { get; set; }
-        }
+        return value.Select(x => new Fact(x)).ToArray();
     }
 
-    public class FactExpression<TFact, TResult> : IAggregateExpression
+    protected ITuple EmptyTuple()
     {
-        private readonly Func<TFact, TResult> _func;
+        return new NullTuple();
+    }
 
-        public FactExpression(Func<TFact, TResult> func)
+    private class NullTuple : ITuple
+    {
+        public IEnumerable<IFact> Facts => new IFact[0];
+        public int Count => 0;
+    }
+
+    public class Fact : IFact
+    {
+        public Fact(object value)
         {
-            _func = func;
+            Type = value.GetType();
+            Value = value;
         }
 
-        public string Name { get; }
+        public Type Type { get; }
+        public object Value { get; set; }
+        public IFactSource Source { get; set; }
+    }
+}
 
-        public object Invoke(AggregationContext context, ITuple tuple, IFact fact)
-        {
-            return _func((TFact)fact.Value);
-        }
+public class FactExpression<TFact, TResult> : IAggregateExpression
+{
+    private readonly Func<TFact, TResult> _func;
+
+    public FactExpression(Func<TFact, TResult> func)
+    {
+        _func = func;
+    }
+
+    public string Name { get; }
+
+    public object Invoke(AggregationContext context, ITuple tuple, IFact fact)
+    {
+        return _func((TFact)fact.Value);
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Aggregators/CollectionAggregatorTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Aggregators/CollectionAggregatorTest.cs
@@ -4,272 +4,271 @@ using System.Linq;
 using NRules.Aggregators;
 using Xunit;
 
-namespace NRules.Tests.Aggregators
+namespace NRules.Tests.Aggregators;
+
+public class CollectionAggregatorTest : AggregatorTest
 {
-    public class CollectionAggregatorTest : AggregatorTest
+    [Fact]
+    public void Add_NewInstance_AddedResult()
     {
-        [Fact]
-        public void Add_NewInstance_AddedResult()
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(new TestFact(1), new TestFact(2));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Added, result[0].Action);
+        var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
+        Assert.Equal(2, aggregate.Count());
+    }
+
+    [Fact]
+    public void Add_NoFacts_AddedResultEmptyCollection()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(new TestFact[0]);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Added, result[0].Action);
+        var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
+        Assert.Empty(aggregate);
+    }
+
+    [Fact]
+    public void Add_NewInstanceUniqueFacts_AddedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(new TestFact(1), new TestFact(2));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Added, result[0].Action);
+        var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
+        Assert.Equal(2, aggregate.Count());
+    }
+
+    [Fact]
+    public void Add_NewInstanceDuplicateFacts_AddedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(new TestFact(1), new TestFact(1));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Added, result[0].Action);
+        var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
+        Assert.Equal(2, aggregate.Count());
+    }
+
+    [Fact]
+    public void Add_OldInstanceNewFacts_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        target.Add(null, EmptyTuple(), AsFact(new TestFact(1)));
+
+        //Act
+        var facts = AsFact(new TestFact(2), new TestFact(3));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
+        Assert.Equal(3, aggregate.Count());
+    }
+
+    [Fact]
+    public void Modify_ExistingFactsSameValues_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(2));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var result = target.Modify(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
+        Assert.Equal(2, aggregate.Count());
+    }
+
+    [Fact]
+    public void Modify_ExistingFactsDifferentValues_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(2));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(3);
+        facts[1].Value = new TestFact(4);
+        var result = target.Modify(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
+        Assert.Equal(2, aggregate.Count());
+    }
+
+    [Fact]
+    public void Modify_ExistingDuplicateFacts_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(1));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var result = target.Modify(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
+        Assert.Equal(2, aggregate.Count());
+    }
+
+    [Fact]
+    public void Modify_NonExistent_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(2));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1), new TestFact(2))));
+    }
+
+    [Fact]
+    public void Remove_ExistingFactsSameValues_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(3));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toRemove = facts.Take(2).ToArray();
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
+        Assert.Single(aggregate);
+        Assert.Equal(3, aggregate.ElementAt(0).Id);
+    }
+
+    [Fact]
+    public void Remove_ExistingFactsDifferentValues_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(3));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(3);
+        facts[1].Value = new TestFact(4);
+        var toRemove = facts.Take(2).ToArray();
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
+        Assert.Single(aggregate);
+        Assert.Equal(3, aggregate.ElementAt(0).Id);
+    }
+
+    [Fact]
+    public void Remove_ExistingDuplicateFacts_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(2));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toRemove = facts.Take(2).ToArray();
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
+        Assert.Single(aggregate);
+        Assert.Equal(2, aggregate.ElementAt(0).Id);
+    }
+
+    [Fact]
+    public void Remove_NonExistent_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+        target.Add(null, EmptyTuple(), AsFact(new TestFact(1), new TestFact(2)));
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1), new TestFact(2))));
+    }
+
+    private CollectionAggregator<TestFact> CreateTarget()
+    {
+        return new CollectionAggregator<TestFact>();
+    }
+
+    private class TestFact : IEquatable<TestFact>
+    {
+        public TestFact(int id)
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(new TestFact(1), new TestFact(2));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Added, result[0].Action);
-            var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
-            Assert.Equal(2, aggregate.Count());
+            Id = id;
         }
 
-        [Fact]
-        public void Add_NoFacts_AddedResultEmptyCollection()
+        public int Id { get; }
+
+        public bool Equals(TestFact other)
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(new TestFact[0]);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Added, result[0].Action);
-            var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
-            Assert.Empty(aggregate);
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Id == other.Id;
         }
 
-        [Fact]
-        public void Add_NewInstanceUniqueFacts_AddedResult()
+        public override bool Equals(object obj)
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(new TestFact(1), new TestFact(2));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Added, result[0].Action);
-            var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
-            Assert.Equal(2, aggregate.Count());
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestFact) obj);
         }
 
-        [Fact]
-        public void Add_NewInstanceDuplicateFacts_AddedResult()
+        public override int GetHashCode()
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(new TestFact(1), new TestFact(1));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Added, result[0].Action);
-            var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
-            Assert.Equal(2, aggregate.Count());
-        }
-
-        [Fact]
-        public void Add_OldInstanceNewFacts_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            target.Add(null, EmptyTuple(), AsFact(new TestFact(1)));
-
-            //Act
-            var facts = AsFact(new TestFact(2), new TestFact(3));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
-            Assert.Equal(3, aggregate.Count());
-        }
-
-        [Fact]
-        public void Modify_ExistingFactsSameValues_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(2));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var result = target.Modify(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
-            Assert.Equal(2, aggregate.Count());
-        }
-
-        [Fact]
-        public void Modify_ExistingFactsDifferentValues_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(2));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(3);
-            facts[1].Value = new TestFact(4);
-            var result = target.Modify(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
-            Assert.Equal(2, aggregate.Count());
-        }
-
-        [Fact]
-        public void Modify_ExistingDuplicateFacts_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(1));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var result = target.Modify(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
-            Assert.Equal(2, aggregate.Count());
-        }
-
-        [Fact]
-        public void Modify_NonExistent_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(2));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1), new TestFact(2))));
-        }
-
-        [Fact]
-        public void Remove_ExistingFactsSameValues_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(3));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var toRemove = facts.Take(2).ToArray();
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
-            Assert.Single(aggregate);
-            Assert.Equal(3, aggregate.ElementAt(0).Id);
-        }
-
-        [Fact]
-        public void Remove_ExistingFactsDifferentValues_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(3));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(3);
-            facts[1].Value = new TestFact(4);
-            var toRemove = facts.Take(2).ToArray();
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
-            Assert.Single(aggregate);
-            Assert.Equal(3, aggregate.ElementAt(0).Id);
-        }
-
-        [Fact]
-        public void Remove_ExistingDuplicateFacts_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(2));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var toRemove = facts.Take(2).ToArray();
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate = (IEnumerable<TestFact>) result[0].Aggregate;
-            Assert.Single(aggregate);
-            Assert.Equal(2, aggregate.ElementAt(0).Id);
-        }
-
-        [Fact]
-        public void Remove_NonExistent_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-            target.Add(null, EmptyTuple(), AsFact(new TestFact(1), new TestFact(2)));
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1), new TestFact(2))));
-        }
-
-        private CollectionAggregator<TestFact> CreateTarget()
-        {
-            return new CollectionAggregator<TestFact>();
-        }
-
-        private class TestFact : IEquatable<TestFact>
-        {
-            public TestFact(int id)
-            {
-                Id = id;
-            }
-
-            public int Id { get; }
-
-            public bool Equals(TestFact other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return Id == other.Id;
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((TestFact) obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return Id;
-            }
+            return Id;
         }
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Aggregators/FlatteningAggregatorTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Aggregators/FlatteningAggregatorTest.cs
@@ -4,274 +4,273 @@ using System.Linq;
 using NRules.Aggregators;
 using Xunit;
 
-namespace NRules.Tests.Aggregators
+namespace NRules.Tests.Aggregators;
+
+public class FlatteningAggregatorTest : AggregatorTest
 {
-    public class FlatteningAggregatorTest : AggregatorTest
+    [Fact]
+    public void Add_Facts_AddedResult()
     {
-        [Fact]
-        public void Add_Facts_AddedResult()
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Equal(4, result.Length);
+        Assert.Equal(AggregationAction.Added, result[0].Action);
+        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal(AggregationAction.Added, result[1].Action);
+        Assert.Equal("value12", result[1].Aggregate);
+        Assert.Equal(AggregationAction.Added, result[2].Action);
+        Assert.Equal("value21", result[2].Aggregate);
+        Assert.Equal(AggregationAction.Added, result[3].Action);
+        Assert.Equal("value22", result[3].Aggregate);
+    }
+
+    [Fact]
+    public void Add_FactsWithDuplicates_AddedDistinctResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(new TestFact(1, "value11", "value12", "value12", "valuex"), new TestFact(2, "value21", "value21", "value22", "valuex"));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Equal(5, result.Length);
+        Assert.Equal(AggregationAction.Added, result[0].Action);
+        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal(AggregationAction.Added, result[1].Action);
+        Assert.Equal("value12", result[1].Aggregate);
+        Assert.Equal(AggregationAction.Added, result[2].Action);
+        Assert.Equal("valuex", result[2].Aggregate);
+        Assert.Equal(AggregationAction.Added, result[3].Action);
+        Assert.Equal("value21", result[3].Aggregate);
+        Assert.Equal(AggregationAction.Added, result[4].Action);
+        Assert.Equal("value22", result[4].Aggregate);
+    }
+
+    [Fact]
+    public void Add_NoFacts_EmptyResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(new TestFact[0]);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Modify_ExistingFactsSameIdentity_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal(AggregationAction.Modified, result[1].Action);
+        Assert.Equal("value12", result[1].Aggregate);
+    }
+
+    [Fact]
+    public void Modify_ExistingFactsDifferentIdentity_RemovedAddedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(3, "value31", "value32");
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Equal(4, result.Length);
+        Assert.Equal(AggregationAction.Removed, result[0].Action);
+        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal(AggregationAction.Removed, result[1].Action);
+        Assert.Equal("value12", result[1].Aggregate);
+        Assert.Equal(AggregationAction.Added, result[2].Action);
+        Assert.Equal("value31", result[2].Aggregate);
+        Assert.Equal(AggregationAction.Added, result[3].Action);
+        Assert.Equal("value32", result[3].Aggregate);
+    }
+
+    [Fact]
+    public void Modify_ExistingFactsHasAdditionsModificationsAndRemovals_CorrectResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(2, "value12", "value13");
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Equal(3, result.Length);
+        Assert.Equal(AggregationAction.Removed, result[0].Action);
+        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal(AggregationAction.Modified, result[1].Action);
+        Assert.Equal("value12", result[1].Aggregate);
+        Assert.Equal(AggregationAction.Added, result[2].Action);
+        Assert.Equal("value13", result[2].Aggregate);
+    }
+
+    [Fact]
+    public void Modify_FactsWithDuplicates_CorrectResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        var facts = AsFact(new TestFact(1, "value11", "value12", "value12", "valuex"), new TestFact(2, "value21", "value21", "value22", "valuex"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(2, "value12", "value13");
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Equal(3, result.Length);
+        Assert.Equal(AggregationAction.Removed, result[0].Action);
+        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal(AggregationAction.Modified, result[1].Action);
+        Assert.Equal("value12", result[1].Aggregate);
+        Assert.Equal(AggregationAction.Added, result[2].Action);
+        Assert.Equal("value13", result[2].Aggregate);
+    }
+
+    [Fact]
+    public void Modify_NonExistent_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"))));
+    }
+
+    [Fact]
+    public void Remove_ExistingFacts_RemovedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toRemove = facts.Take(1).ToArray();
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Removed, result[0].Action);
+        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal(AggregationAction.Removed, result[1].Action);
+        Assert.Equal("value12", result[1].Aggregate);
+    }
+
+    [Fact]
+    public void Remove_FactsWithDuplicates_CorrectResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        var facts = AsFact(new TestFact(1, "value11", "value12", "value12", "valuex"), new TestFact(2, "value21", "value21", "value22", "valuex"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act - I
+        var toRemove1 = facts.Take(1).ToArray();
+        var result1 = target.Remove(null, EmptyTuple(), toRemove1).ToArray();
+
+        //Assert - I
+        Assert.Equal(2, result1.Length);
+        Assert.Equal(AggregationAction.Removed, result1[0].Action);
+        Assert.Equal("value11", result1[0].Aggregate);
+        Assert.Equal(AggregationAction.Removed, result1[1].Action);
+        Assert.Equal("value12", result1[1].Aggregate);
+
+        //Act - II
+        var toRemove2 = facts.Skip(1).Take(1).ToArray();
+        var result2 = target.Remove(null, EmptyTuple(), toRemove2).ToArray();
+
+        //Assert - II
+        Assert.Equal(3, result2.Length);
+        Assert.Equal(AggregationAction.Removed, result2[0].Action);
+        Assert.Equal("value21", result2[0].Aggregate);
+        Assert.Equal(AggregationAction.Removed, result2[1].Action);
+        Assert.Equal("value22", result2[1].Aggregate);
+        Assert.Equal(AggregationAction.Removed, result2[2].Action);
+        Assert.Equal("valuex", result2[2].Aggregate);
+    }
+
+    [Fact]
+    public void Remove_NonExistent_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"))));
+    }
+
+    private FlatteningAggregator<TestFact, string> CreateTarget()
+    {
+        var expression = new FactExpression<TestFact, IEnumerable<string>>(x => x.Values);
+        return new FlatteningAggregator<TestFact, string>(expression);
+    }
+
+    private class TestFact : IEquatable<TestFact>
+    {
+        public TestFact(int id, params string[] values)
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Equal(4, result.Length);
-            Assert.Equal(AggregationAction.Added, result[0].Action);
-            Assert.Equal("value11", result[0].Aggregate);
-            Assert.Equal(AggregationAction.Added, result[1].Action);
-            Assert.Equal("value12", result[1].Aggregate);
-            Assert.Equal(AggregationAction.Added, result[2].Action);
-            Assert.Equal("value21", result[2].Aggregate);
-            Assert.Equal(AggregationAction.Added, result[3].Action);
-            Assert.Equal("value22", result[3].Aggregate);
+            Id = id;
+            Values = values;
         }
 
-        [Fact]
-        public void Add_FactsWithDuplicates_AddedDistinctResult()
+        public int Id { get; }
+        public string[] Values { get; }
+
+        public bool Equals(TestFact other)
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(new TestFact(1, "value11", "value12", "value12", "valuex"), new TestFact(2, "value21", "value21", "value22", "valuex"));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Equal(5, result.Length);
-            Assert.Equal(AggregationAction.Added, result[0].Action);
-            Assert.Equal("value11", result[0].Aggregate);
-            Assert.Equal(AggregationAction.Added, result[1].Action);
-            Assert.Equal("value12", result[1].Aggregate);
-            Assert.Equal(AggregationAction.Added, result[2].Action);
-            Assert.Equal("valuex", result[2].Aggregate);
-            Assert.Equal(AggregationAction.Added, result[3].Action);
-            Assert.Equal("value21", result[3].Aggregate);
-            Assert.Equal(AggregationAction.Added, result[4].Action);
-            Assert.Equal("value22", result[4].Aggregate);
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Id == other.Id;
         }
 
-        [Fact]
-        public void Add_NoFacts_EmptyResult()
+        public override bool Equals(object obj)
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(new TestFact[0]);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Empty(result);
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestFact) obj);
         }
 
-        [Fact]
-        public void Modify_ExistingFactsSameIdentity_ModifiedResult()
+        public override int GetHashCode()
         {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            Assert.Equal("value11", result[0].Aggregate);
-            Assert.Equal(AggregationAction.Modified, result[1].Action);
-            Assert.Equal("value12", result[1].Aggregate);
-        }
-
-        [Fact]
-        public void Modify_ExistingFactsDifferentIdentity_RemovedAddedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(3, "value31", "value32");
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Equal(4, result.Length);
-            Assert.Equal(AggregationAction.Removed, result[0].Action);
-            Assert.Equal("value11", result[0].Aggregate);
-            Assert.Equal(AggregationAction.Removed, result[1].Action);
-            Assert.Equal("value12", result[1].Aggregate);
-            Assert.Equal(AggregationAction.Added, result[2].Action);
-            Assert.Equal("value31", result[2].Aggregate);
-            Assert.Equal(AggregationAction.Added, result[3].Action);
-            Assert.Equal("value32", result[3].Aggregate);
-        }
-
-        [Fact]
-        public void Modify_ExistingFactsHasAdditionsModificationsAndRemovals_CorrectResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(2, "value12", "value13");
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Equal(3, result.Length);
-            Assert.Equal(AggregationAction.Removed, result[0].Action);
-            Assert.Equal("value11", result[0].Aggregate);
-            Assert.Equal(AggregationAction.Modified, result[1].Action);
-            Assert.Equal("value12", result[1].Aggregate);
-            Assert.Equal(AggregationAction.Added, result[2].Action);
-            Assert.Equal("value13", result[2].Aggregate);
-        }
-
-        [Fact]
-        public void Modify_FactsWithDuplicates_CorrectResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            var facts = AsFact(new TestFact(1, "value11", "value12", "value12", "valuex"), new TestFact(2, "value21", "value21", "value22", "valuex"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(2, "value12", "value13");
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Equal(3, result.Length);
-            Assert.Equal(AggregationAction.Removed, result[0].Action);
-            Assert.Equal("value11", result[0].Aggregate);
-            Assert.Equal(AggregationAction.Modified, result[1].Action);
-            Assert.Equal("value12", result[1].Aggregate);
-            Assert.Equal(AggregationAction.Added, result[2].Action);
-            Assert.Equal("value13", result[2].Aggregate);
-        }
-
-        [Fact]
-        public void Modify_NonExistent_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"))));
-        }
-
-        [Fact]
-        public void Remove_ExistingFacts_RemovedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var toRemove = facts.Take(1).ToArray();
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Removed, result[0].Action);
-            Assert.Equal("value11", result[0].Aggregate);
-            Assert.Equal(AggregationAction.Removed, result[1].Action);
-            Assert.Equal("value12", result[1].Aggregate);
-        }
-
-        [Fact]
-        public void Remove_FactsWithDuplicates_CorrectResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            var facts = AsFact(new TestFact(1, "value11", "value12", "value12", "valuex"), new TestFact(2, "value21", "value21", "value22", "valuex"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act - I
-            var toRemove1 = facts.Take(1).ToArray();
-            var result1 = target.Remove(null, EmptyTuple(), toRemove1).ToArray();
-
-            //Assert - I
-            Assert.Equal(2, result1.Length);
-            Assert.Equal(AggregationAction.Removed, result1[0].Action);
-            Assert.Equal("value11", result1[0].Aggregate);
-            Assert.Equal(AggregationAction.Removed, result1[1].Action);
-            Assert.Equal("value12", result1[1].Aggregate);
-
-            //Act - II
-            var toRemove2 = facts.Skip(1).Take(1).ToArray();
-            var result2 = target.Remove(null, EmptyTuple(), toRemove2).ToArray();
-
-            //Assert - II
-            Assert.Equal(3, result2.Length);
-            Assert.Equal(AggregationAction.Removed, result2[0].Action);
-            Assert.Equal("value21", result2[0].Aggregate);
-            Assert.Equal(AggregationAction.Removed, result2[1].Action);
-            Assert.Equal("value22", result2[1].Aggregate);
-            Assert.Equal(AggregationAction.Removed, result2[2].Action);
-            Assert.Equal("valuex", result2[2].Aggregate);
-        }
-
-        [Fact]
-        public void Remove_NonExistent_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"))));
-        }
-
-        private FlatteningAggregator<TestFact, string> CreateTarget()
-        {
-            var expression = new FactExpression<TestFact, IEnumerable<string>>(x => x.Values);
-            return new FlatteningAggregator<TestFact, string>(expression);
-        }
-
-        private class TestFact : IEquatable<TestFact>
-        {
-            public TestFact(int id, params string[] values)
-            {
-                Id = id;
-                Values = values;
-            }
-
-            public int Id { get; }
-            public string[] Values { get; }
-
-            public bool Equals(TestFact other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return Id == other.Id;
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((TestFact) obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return Id;
-            }
+            return Id;
         }
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Aggregators/GroupByAggregatorTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Aggregators/GroupByAggregatorTest.cs
@@ -4,564 +4,563 @@ using System.Linq;
 using NRules.Aggregators;
 using Xunit;
 
-namespace NRules.Tests.Aggregators
+namespace NRules.Tests.Aggregators;
+
+public class GroupByAggregatorTest : AggregatorTest
 {
-    public class GroupByAggregatorTest : AggregatorTest
+    [Fact]
+    public void Add_NewGroupNewInstance_AddedResult()
     {
-        [Fact]
-        public void Add_NewGroupNewInstance_AddedResult()
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"), new TestFact(3, "key2"));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Added, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal("key1", aggregate1.Key.Value);
+        Assert.Equal(2, aggregate1.Count());
+        Assert.Equal(AggregationAction.Added, result[1].Action);
+        var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
+        Assert.Equal("key2", aggregate2.Key.Value);
+        Assert.Single(aggregate2);
+    }
+
+    [Fact]
+    public void Add_NewGroupHasDefaultKey_AddedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, null));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Added, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal("key1", aggregate1.Key.Value);
+        Assert.Single(aggregate1);
+        Assert.Equal(AggregationAction.Added, result[1].Action);
+        var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
+        Assert.Null(aggregate2.Key);
+        Assert.Single(aggregate2);
+    }
+
+    [Fact]
+    public void Add_NewGroupExistingInstance_AddedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toAdd = AsFact(new TestFact(3, "key2"), new TestFact(4, "key2"));
+        var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Added, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal("key2", aggregate1.Key.Value);
+        Assert.Equal(2, aggregate1.Count());
+    }
+
+    [Fact]
+    public void Add_ExistingGroup_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toAdd = AsFact(new TestFact(3, "key1"), new TestFact(4, "key2"));
+        var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal("key1", aggregate1.Key.Value);
+        Assert.Equal(2, aggregate1.Count());
+        Assert.Equal(AggregationAction.Modified, result[1].Action);
+        var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
+        Assert.Equal("key2", aggregate2.Key.Value);
+        Assert.Equal(2, aggregate2.Count());
+    }
+
+    [Fact]
+    public void Add_KeyPayloadChanges_KeyPayloadUpdated()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1") {Payload = 1}, new TestFact(2, "key2") {Payload = 1});
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toAdd = AsFact(new TestFact(3, "key1") {Payload = 2});
+        var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>)result[0].Aggregate;
+        Assert.Equal("key1", aggregate1.Key.Value);
+        Assert.Equal(2, aggregate1.Key.CachedPayload);
+    }
+
+    [Fact]
+    public void Add_ExistingGroupHasDefaultKey_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, null));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toAdd = AsFact(new TestFact(3, "key1"), new TestFact(4, null));
+        var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal("key1", aggregate1.Key.Value);
+        Assert.Equal(2, aggregate1.Count());
+        Assert.Equal(AggregationAction.Modified, result[1].Action);
+        var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
+        Assert.Null(aggregate2.Key);
+        Assert.Equal(2, aggregate2.Count());
+    }
+
+    [Fact]
+    public void Add_NewAndExistingGroups_AddedAndModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toAdd = AsFact(new TestFact(2, "key1"), new TestFact(3, "key2"), new TestFact(4, "key2"));
+        var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal("key1", aggregate1.Key.Value);
+        Assert.Equal(2, aggregate1.Count());
+        Assert.Equal(AggregationAction.Added, result[1].Action);
+        var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
+        Assert.Equal("key2", aggregate2.Key.Value);
+        Assert.Equal(2, aggregate2.Count());
+    }
+
+    [Fact]
+    public void Add_EmptyGroup_NoResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var result = target.Add(null, EmptyTuple(), AsFact(new TestFact[0])).ToArray();
+
+        //Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Modify_ExistingGroupsSameIdentity_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, "key1");
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+    }
+
+    [Fact]
+    public void Modify_ExistingGroupsDifferentIdentity_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(3, "key1");
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+    }
+
+    [Fact]
+    public void Modify_KeyPayloadChanges_CachedPayloadUpdated()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1") {Payload = 1}, new TestFact(2, "key1") {Payload = 1});
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, "key1") {Payload = 2};
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>)result[0].Aggregate;
+        Assert.Equal(2, aggregate1.Key.CachedPayload);
+    }
+
+    [Fact]
+    public void Modify_ExistingGroupsHasDefaultKey_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, null), new TestFact(2, null));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, null);
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+    }
+
+    [Fact]
+    public void Modify_GroupRemovedAndAdded_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"), new TestFact(3, "key2"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, "key2");
+        facts[1].Value = new TestFact(2, "key1");
+        var toUpdate = facts.Take(2).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        Assert.Equal(AggregationAction.Modified, result[1].Action);
+        Assert.Same(result[0].Previous, result[0].Aggregate);
+        Assert.Same(result[1].Previous, result[1].Aggregate);
+        Assert.Single(((IEnumerable<GroupElement>) result[0].Aggregate));
+        Assert.Equal(2, ((IEnumerable<GroupElement>) result[1].Aggregate).Count());
+    }
+
+    [Fact]
+    public void Modify_ExistingGroupKeyChanged_ModifiedAndAddedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(2, "key2");
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal("key1", aggregate1.Key.Value);
+        Assert.Single(aggregate1);
+        Assert.Equal(AggregationAction.Added, result[1].Action);
+        var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
+        Assert.Equal("key2", aggregate2.Key.Value);
+        Assert.Single(aggregate2);
+    }
+
+    [Fact]
+    public void Modify_ExistingGroupKeyChangedToDefault_ModifiedAndAddedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(2, null);
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal("key1", aggregate1.Key.Value);
+        Assert.Single(aggregate1);
+        Assert.Equal(AggregationAction.Added, result[1].Action);
+        var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
+        Assert.Null(aggregate2.Key);
+        Assert.Single(aggregate2);
+    }
+
+    [Fact]
+    public void Modify_ExistingGroupAllElementsHaveKeyChanged_RemovedAndAddedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, "key2");
+        facts[1].Value = new TestFact(2, "key2");
+        var toUpdate = facts.Take(2).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Removed, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal("key1", aggregate1.Key.Value);
+        Assert.Empty(aggregate1);
+        Assert.Equal(AggregationAction.Added, result[1].Action);
+        var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
+        Assert.Equal("key2", aggregate2.Key.Value);
+        Assert.Equal(2, aggregate2.Count());
+    }
+
+    [Fact]
+    public void Modify_NonExistent_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"))));
+    }
+
+    [Fact]
+    public void Modify_NonExistentDefaultKey_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, null))));
+    }
+
+    [Fact]
+    public void Remove_ExistingGroup_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, "key1");
+        var toRemove = facts.Take(1).ToArray();
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal("key1", aggregate1.Key.Value);
+        Assert.Single(aggregate1);
+    }
+
+    [Fact]
+    public void Remove_ExistingGroupWithDefaultKey_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, null), new TestFact(2, null));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, null);
+        var toRemove = facts.Take(1).ToArray();
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Null(aggregate1.Key);
+        Assert.Single(aggregate1);
+    }
+
+    [Fact]
+    public void Remove_ExistingGroupAllElementsRemoved_RemovedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var result = target.Remove(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Removed, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal("key1", aggregate1.Key.Value);
+        Assert.Empty(aggregate1);
+    }
+
+    [Fact]
+    public void Remove_ExistingGroupAllElementsRemovedDefaultKey_RemovedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, null), new TestFact(2, null));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var result = target.Remove(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Removed, result[0].Action);
+        var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Null(aggregate1.Key);
+        Assert.Empty(aggregate1);
+    }
+
+    [Fact]
+    public void Remove_NonExistent_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"))));
+    }
+
+    [Fact]
+    public void Remove_NonExistentDefaultKey_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, null))));
+    }
+
+    private GroupByAggregator<TestFact, GroupKey, GroupElement> CreateTarget()
+    {
+        var keyExpression = new FactExpression<TestFact, GroupKey>(GetGroupKey);
+        var elementExpression = new FactExpression<TestFact, GroupElement>(x => new GroupElement(x));
+        return new GroupByAggregator<TestFact, GroupKey, GroupElement>(keyExpression, elementExpression);
+    }
+
+    private static GroupKey GetGroupKey(TestFact fact)
+    {
+        return fact.Key == null ? null : new GroupKey(fact.Key, fact.Payload);
+    }
+
+    private class TestFact : IEquatable<TestFact>
+    {
+        public TestFact(int id, string key)
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"), new TestFact(3, "key2"));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Added, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal("key1", aggregate1.Key.Value);
-            Assert.Equal(2, aggregate1.Count());
-            Assert.Equal(AggregationAction.Added, result[1].Action);
-            var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
-            Assert.Equal("key2", aggregate2.Key.Value);
-            Assert.Single(aggregate2);
+            Id = id;
+            Key = key;
         }
 
-        [Fact]
-        public void Add_NewGroupHasDefaultKey_AddedResult()
+        public int Id { get; }
+        public string Key { get; }
+        public int Payload { get; set; } = 0;
+
+        public bool Equals(TestFact other)
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, null));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Added, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal("key1", aggregate1.Key.Value);
-            Assert.Single(aggregate1);
-            Assert.Equal(AggregationAction.Added, result[1].Action);
-            var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
-            Assert.Null(aggregate2.Key);
-            Assert.Single(aggregate2);
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Id == other.Id;
         }
 
-        [Fact]
-        public void Add_NewGroupExistingInstance_AddedResult()
+        public override bool Equals(object obj)
         {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var toAdd = AsFact(new TestFact(3, "key2"), new TestFact(4, "key2"));
-            var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Added, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal("key2", aggregate1.Key.Value);
-            Assert.Equal(2, aggregate1.Count());
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestFact) obj);
         }
 
-        [Fact]
-        public void Add_ExistingGroup_ModifiedResult()
+        public override int GetHashCode()
         {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"));
-            target.Add(null, EmptyTuple(), facts);
+            return Id;
+        }
+    }
 
-            //Act
-            var toAdd = AsFact(new TestFact(3, "key1"), new TestFact(4, "key2"));
-            var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal("key1", aggregate1.Key.Value);
-            Assert.Equal(2, aggregate1.Count());
-            Assert.Equal(AggregationAction.Modified, result[1].Action);
-            var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
-            Assert.Equal("key2", aggregate2.Key.Value);
-            Assert.Equal(2, aggregate2.Count());
+    private class GroupKey : IEquatable<GroupKey>
+    {
+        public GroupKey(string value, int payload)
+        {
+            Value = value;
+            CachedPayload = payload;
         }
 
-        [Fact]
-        public void Add_KeyPayloadChanges_KeyPayloadUpdated()
+        public string Value { get; }
+        public int CachedPayload { get; }
+
+        public bool Equals(GroupKey other)
         {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1") {Payload = 1}, new TestFact(2, "key2") {Payload = 1});
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var toAdd = AsFact(new TestFact(3, "key1") {Payload = 2});
-            var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>)result[0].Aggregate;
-            Assert.Equal("key1", aggregate1.Key.Value);
-            Assert.Equal(2, aggregate1.Key.CachedPayload);
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(Value, other.Value);
         }
 
-        [Fact]
-        public void Add_ExistingGroupHasDefaultKey_ModifiedResult()
+        public override bool Equals(object obj)
         {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, null));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var toAdd = AsFact(new TestFact(3, "key1"), new TestFact(4, null));
-            var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal("key1", aggregate1.Key.Value);
-            Assert.Equal(2, aggregate1.Count());
-            Assert.Equal(AggregationAction.Modified, result[1].Action);
-            var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
-            Assert.Null(aggregate2.Key);
-            Assert.Equal(2, aggregate2.Count());
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((GroupKey)obj);
         }
 
-        [Fact]
-        public void Add_NewAndExistingGroups_AddedAndModifiedResult()
+        public override int GetHashCode()
         {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"));
-            target.Add(null, EmptyTuple(), facts);
+            return (Value != null ? Value.GetHashCode() : 0);
+        }
+    }
 
-            //Act
-            var toAdd = AsFact(new TestFact(2, "key1"), new TestFact(3, "key2"), new TestFact(4, "key2"));
-            var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal("key1", aggregate1.Key.Value);
-            Assert.Equal(2, aggregate1.Count());
-            Assert.Equal(AggregationAction.Added, result[1].Action);
-            var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
-            Assert.Equal("key2", aggregate2.Key.Value);
-            Assert.Equal(2, aggregate2.Count());
+    private class GroupElement
+    {
+        public GroupElement(TestFact fact)
+        {
+            Id = fact.Id;
+            Key = fact.Key;
         }
 
-        [Fact]
-        public void Add_EmptyGroup_NoResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var result = target.Add(null, EmptyTuple(), AsFact(new TestFact[0])).ToArray();
-
-            //Assert
-            Assert.Empty(result);
-        }
-
-        [Fact]
-        public void Modify_ExistingGroupsSameIdentity_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, "key1");
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-        }
-
-        [Fact]
-        public void Modify_ExistingGroupsDifferentIdentity_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(3, "key1");
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-        }
-
-        [Fact]
-        public void Modify_KeyPayloadChanges_CachedPayloadUpdated()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1") {Payload = 1}, new TestFact(2, "key1") {Payload = 1});
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, "key1") {Payload = 2};
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>)result[0].Aggregate;
-            Assert.Equal(2, aggregate1.Key.CachedPayload);
-        }
-
-        [Fact]
-        public void Modify_ExistingGroupsHasDefaultKey_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, null), new TestFact(2, null));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, null);
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-        }
-
-        [Fact]
-        public void Modify_GroupRemovedAndAdded_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"), new TestFact(3, "key2"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, "key2");
-            facts[1].Value = new TestFact(2, "key1");
-            var toUpdate = facts.Take(2).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            Assert.Equal(AggregationAction.Modified, result[1].Action);
-            Assert.Same(result[0].Previous, result[0].Aggregate);
-            Assert.Same(result[1].Previous, result[1].Aggregate);
-            Assert.Single(((IEnumerable<GroupElement>) result[0].Aggregate));
-            Assert.Equal(2, ((IEnumerable<GroupElement>) result[1].Aggregate).Count());
-        }
-
-        [Fact]
-        public void Modify_ExistingGroupKeyChanged_ModifiedAndAddedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(2, "key2");
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal("key1", aggregate1.Key.Value);
-            Assert.Single(aggregate1);
-            Assert.Equal(AggregationAction.Added, result[1].Action);
-            var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
-            Assert.Equal("key2", aggregate2.Key.Value);
-            Assert.Single(aggregate2);
-        }
-
-        [Fact]
-        public void Modify_ExistingGroupKeyChangedToDefault_ModifiedAndAddedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(2, null);
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal("key1", aggregate1.Key.Value);
-            Assert.Single(aggregate1);
-            Assert.Equal(AggregationAction.Added, result[1].Action);
-            var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
-            Assert.Null(aggregate2.Key);
-            Assert.Single(aggregate2);
-        }
-
-        [Fact]
-        public void Modify_ExistingGroupAllElementsHaveKeyChanged_RemovedAndAddedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, "key2");
-            facts[1].Value = new TestFact(2, "key2");
-            var toUpdate = facts.Take(2).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Removed, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal("key1", aggregate1.Key.Value);
-            Assert.Empty(aggregate1);
-            Assert.Equal(AggregationAction.Added, result[1].Action);
-            var aggregate2 = (IGrouping<GroupKey, GroupElement>) result[1].Aggregate;
-            Assert.Equal("key2", aggregate2.Key.Value);
-            Assert.Equal(2, aggregate2.Count());
-        }
-
-        [Fact]
-        public void Modify_NonExistent_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"))));
-        }
-
-        [Fact]
-        public void Modify_NonExistentDefaultKey_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, null))));
-        }
-
-        [Fact]
-        public void Remove_ExistingGroup_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, "key1");
-            var toRemove = facts.Take(1).ToArray();
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal("key1", aggregate1.Key.Value);
-            Assert.Single(aggregate1);
-        }
-
-        [Fact]
-        public void Remove_ExistingGroupWithDefaultKey_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, null), new TestFact(2, null));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, null);
-            var toRemove = facts.Take(1).ToArray();
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Null(aggregate1.Key);
-            Assert.Single(aggregate1);
-        }
-
-        [Fact]
-        public void Remove_ExistingGroupAllElementsRemoved_RemovedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var result = target.Remove(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Removed, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal("key1", aggregate1.Key.Value);
-            Assert.Empty(aggregate1);
-        }
-
-        [Fact]
-        public void Remove_ExistingGroupAllElementsRemovedDefaultKey_RemovedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, null), new TestFact(2, null));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var result = target.Remove(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Removed, result[0].Action);
-            var aggregate1 = (IGrouping<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Null(aggregate1.Key);
-            Assert.Empty(aggregate1);
-        }
-
-        [Fact]
-        public void Remove_NonExistent_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"))));
-        }
-
-        [Fact]
-        public void Remove_NonExistentDefaultKey_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, null))));
-        }
-
-        private GroupByAggregator<TestFact, GroupKey, GroupElement> CreateTarget()
-        {
-            var keyExpression = new FactExpression<TestFact, GroupKey>(GetGroupKey);
-            var elementExpression = new FactExpression<TestFact, GroupElement>(x => new GroupElement(x));
-            return new GroupByAggregator<TestFact, GroupKey, GroupElement>(keyExpression, elementExpression);
-        }
-
-        private static GroupKey GetGroupKey(TestFact fact)
-        {
-            return fact.Key == null ? null : new GroupKey(fact.Key, fact.Payload);
-        }
-
-        private class TestFact : IEquatable<TestFact>
-        {
-            public TestFact(int id, string key)
-            {
-                Id = id;
-                Key = key;
-            }
-
-            public int Id { get; }
-            public string Key { get; }
-            public int Payload { get; set; } = 0;
-
-            public bool Equals(TestFact other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return Id == other.Id;
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((TestFact) obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return Id;
-            }
-        }
-
-        private class GroupKey : IEquatable<GroupKey>
-        {
-            public GroupKey(string value, int payload)
-            {
-                Value = value;
-                CachedPayload = payload;
-            }
-
-            public string Value { get; }
-            public int CachedPayload { get; }
-
-            public bool Equals(GroupKey other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return string.Equals(Value, other.Value);
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((GroupKey)obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return (Value != null ? Value.GetHashCode() : 0);
-            }
-        }
-
-        private class GroupElement
-        {
-            public GroupElement(TestFact fact)
-            {
-                Id = fact.Id;
-                Key = fact.Key;
-            }
-
-            public int Id { get; }
-            public string Key { get; }
-        }
+        public int Id { get; }
+        public string Key { get; }
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Aggregators/LookupAggregatorTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Aggregators/LookupAggregatorTest.cs
@@ -4,547 +4,546 @@ using System.Linq;
 using NRules.Aggregators;
 using Xunit;
 
-namespace NRules.Tests.Aggregators
+namespace NRules.Tests.Aggregators;
+
+public class LookupAggregatorTest : AggregatorTest
 {
-    public class LookupAggregatorTest : AggregatorTest
+    [Fact]
+    public void Add_NoFacts_AddedResultEmptyLookupNonExistentKeysEmpty()
     {
-        [Fact]
-        public void Add_NoFacts_AddedResultEmptyLookupNonExistentKeysEmpty()
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(Array.Empty<TestFact>());
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Added, result[0].Action);
+        var aggregate = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Empty(aggregate);
+        Assert.Empty(aggregate[GetKey("key1")]);
+        Assert.Empty(aggregate[GetKey(null)]);
+    }
+
+    [Fact]
+    public void Add_NewGroupNewInstance_AddedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"), new TestFact(3, "key2"));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Added, result[0].Action);
+        var aggregate = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal(2, aggregate.Count());
+        Assert.Equal(2, aggregate[GetKey("key1")].Count());
+        Assert.Single(aggregate[GetKey("key2")]);
+    }
+
+    [Fact]
+    public void Add_NewGroupHasDefaultKey_AddedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, null));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Added, result[0].Action);
+        var aggregate = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal(2, aggregate.Count());
+        Assert.Single(aggregate[GetKey("key1")]);
+        Assert.Single(aggregate[GetKey(null)]);
+    }
+
+    [Fact]
+    public void Add_NewGroupExistingInstance_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toAdd = AsFact(new TestFact(3, "key2"), new TestFact(4, "key2"));
+        var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal(2, aggregate1.Count());
+        Assert.Equal(2, aggregate1[GetKey("key1")].Count());
+        Assert.Equal(2, aggregate1[GetKey("key2")].Count());
+    }
+
+    [Fact]
+    public void Add_ExistingGroup_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toAdd = AsFact(new TestFact(3, "key1"), new TestFact(4, "key2"));
+        var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal(2, aggregate1.Count());
+        Assert.Equal(2, aggregate1[GetKey("key1")].Count());
+        Assert.Equal(2, aggregate1[GetKey("key2")].Count());
+    }
+
+    [Fact]
+    public void Add_KeyPayloadChanges_KeyPayloadUpdated()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1") {Payload = 1}, new TestFact(2, "key2") {Payload = 1});
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toAdd = AsFact(new TestFact(3, "key1") {Payload = 2});
+        var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>)result[0].Aggregate;
+        Assert.Equal(2, aggregate1.Single(x => x.Key.Value == "key1").Key.CachedPayload);
+    }
+
+    [Fact]
+    public void Add_ExistingGroupHasDefaultKey_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, null));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toAdd = AsFact(new TestFact(3, "key1"), new TestFact(4, null));
+        var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal(2, aggregate1.Count());
+        Assert.Equal(2, aggregate1[GetKey("key1")].Count());
+        Assert.Equal(2, aggregate1[GetKey(null)].Count());
+    }
+
+    [Fact]
+    public void Add_NewAndExistingGroups_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toAdd = AsFact(new TestFact(2, "key1"), new TestFact(3, "key2"), new TestFact(4, "key2"));
+        var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal(2, aggregate1.Count());
+        Assert.Equal(2, aggregate1[GetKey("key1")].Count());
+        Assert.Equal(2, aggregate1[GetKey("key2")].Count());
+    }
+
+    [Fact]
+    public void Modify_ExistingGroupsSameIdentity_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, "key1");
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+    }
+
+    [Fact]
+    public void Modify_ExistingGroupsDifferentIdentity_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(3, "key1");
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+    }
+
+    [Fact]
+    public void Modify_KeyPayloadChanges_CachedPayloadUpdated()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1") {Payload = 1}, new TestFact(2, "key1") {Payload = 1});
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, "key1") {Payload = 2};
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>)result[0].Aggregate;
+        Assert.Equal(2, aggregate1.Single(x => x.Key.Value == "key1").Key.CachedPayload);
+    }
+
+    [Fact]
+    public void Modify_ExistingGroupsHasDefaultKey_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, null), new TestFact(2, null));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, null);
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+    }
+
+    [Fact]
+    public void Modify_GroupRemovedAndAdded_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"), new TestFact(3, "key2"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, "key2");
+        facts[1].Value = new TestFact(2, "key1");
+        var toUpdate = facts.Take(2).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal(2, aggregate1.Count());
+        Assert.Single(aggregate1[GetKey("key1")]);
+        Assert.Equal(2, aggregate1[GetKey("key2")].Count());
+    }
+
+    [Fact]
+    public void Modify_ExistingGroupKeyChanged_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(2, "key2");
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal(2, aggregate1.Count());
+        Assert.Single(aggregate1[GetKey("key1")]);
+        Assert.Single(aggregate1[GetKey("key2")]);
+    }
+
+    [Fact]
+    public void Modify_ExistingGroupKeyChangedToDefault_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(2, null);
+        var toUpdate = facts.Take(1).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Equal(2, aggregate1.Count());
+        Assert.Single(aggregate1[GetKey("key1")]);
+        Assert.Single(aggregate1[GetKey(null)]);
+    }
+
+    [Fact]
+    public void Modify_ExistingGroupAllElementsHaveKeyChanged_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, "key2");
+        facts[1].Value = new TestFact(2, "key2");
+        var toUpdate = facts.Take(2).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Single(aggregate1);
+        Assert.Equal(2, aggregate1[GetKey("key2")].Count());
+    }
+
+    [Fact]
+    public void Modify_NonExistent_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"))));
+    }
+
+    [Fact]
+    public void Modify_NonExistentDefaultKey_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, null))));
+    }
+
+    [Fact]
+    public void Remove_ExistingGroup_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, "key1");
+        var toRemove = facts.Take(1).ToArray();
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Single(aggregate1);
+        Assert.Single(aggregate1[GetKey("key1")]);
+    }
+
+    [Fact]
+    public void Remove_ExistingGroupWithDefaultKey_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, null), new TestFact(2, null));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, null);
+        var toRemove = facts.Take(1).ToArray();
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Single(aggregate1);
+        Assert.Single(aggregate1[GetKey(null)]);
+    }
+
+    [Fact]
+    public void Remove_ExistingGroupAllElementsRemoved_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var result = target.Remove(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Empty(aggregate1);
+    }
+
+    [Fact]
+    public void Remove_ExistingGroupAllElementsRemovedDefaultKey_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, null), new TestFact(2, null));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var result = target.Remove(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
+        Assert.Empty(aggregate1);
+    }
+
+    [Fact]
+    public void Remove_NonExistent_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"))));
+    }
+
+    [Fact]
+    public void Remove_NonExistentDefaultKey_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, null))));
+    }
+
+    private LookupAggregator<TestFact, GroupKey, GroupElement> CreateTarget()
+    {
+        var keyExpression = new FactExpression<TestFact, GroupKey>(GetGroupKey);
+        var elementExpression = new FactExpression<TestFact, GroupElement>(x => new GroupElement(x));
+        return new LookupAggregator<TestFact, GroupKey, GroupElement>(keyExpression, elementExpression);
+    }
+    
+    private static GroupKey GetGroupKey(TestFact fact)
+    {
+        return fact.Key == null ? null : new GroupKey(fact.Key, fact.Payload);
+    }
+
+    private static GroupKey GetKey(string key)
+    {
+        return key == null ? null : new GroupKey(key, 0);
+    }
+
+    private class TestFact : IEquatable<TestFact>
+    {
+        public TestFact(int id, string key)
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(Array.Empty<TestFact>());
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Added, result[0].Action);
-            var aggregate = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Empty(aggregate);
-            Assert.Empty(aggregate[GetKey("key1")]);
-            Assert.Empty(aggregate[GetKey(null)]);
+            Id = id;
+            Key = key;
         }
 
-        [Fact]
-        public void Add_NewGroupNewInstance_AddedResult()
+        public int Id { get; }
+        public string Key { get; }
+        public int Payload { get; set; } = 0;
+
+        public bool Equals(TestFact other)
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"), new TestFact(3, "key2"));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Added, result[0].Action);
-            var aggregate = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal(2, aggregate.Count());
-            Assert.Equal(2, aggregate[GetKey("key1")].Count());
-            Assert.Single(aggregate[GetKey("key2")]);
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Id == other.Id;
         }
 
-        [Fact]
-        public void Add_NewGroupHasDefaultKey_AddedResult()
+        public override bool Equals(object obj)
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, null));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Added, result[0].Action);
-            var aggregate = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal(2, aggregate.Count());
-            Assert.Single(aggregate[GetKey("key1")]);
-            Assert.Single(aggregate[GetKey(null)]);
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestFact) obj);
         }
 
-        [Fact]
-        public void Add_NewGroupExistingInstance_ModifiedResult()
+        public override int GetHashCode()
         {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
+            return Id;
+        }
+    }
 
-            //Act
-            var toAdd = AsFact(new TestFact(3, "key2"), new TestFact(4, "key2"));
-            var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal(2, aggregate1.Count());
-            Assert.Equal(2, aggregate1[GetKey("key1")].Count());
-            Assert.Equal(2, aggregate1[GetKey("key2")].Count());
+    private class GroupKey : IEquatable<GroupKey>
+    {
+        public GroupKey(string value, int payload)
+        {
+            Value = value;
+            CachedPayload = payload;
         }
 
-        [Fact]
-        public void Add_ExistingGroup_ModifiedResult()
+        public string Value { get; }
+        public int CachedPayload { get; }
+
+        public bool Equals(GroupKey other)
         {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var toAdd = AsFact(new TestFact(3, "key1"), new TestFact(4, "key2"));
-            var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal(2, aggregate1.Count());
-            Assert.Equal(2, aggregate1[GetKey("key1")].Count());
-            Assert.Equal(2, aggregate1[GetKey("key2")].Count());
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(Value, other.Value);
         }
 
-        [Fact]
-        public void Add_KeyPayloadChanges_KeyPayloadUpdated()
+        public override bool Equals(object obj)
         {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1") {Payload = 1}, new TestFact(2, "key2") {Payload = 1});
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var toAdd = AsFact(new TestFact(3, "key1") {Payload = 2});
-            var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>)result[0].Aggregate;
-            Assert.Equal(2, aggregate1.Single(x => x.Key.Value == "key1").Key.CachedPayload);
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((GroupKey)obj);
         }
 
-        [Fact]
-        public void Add_ExistingGroupHasDefaultKey_ModifiedResult()
+        public override int GetHashCode()
         {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, null));
-            target.Add(null, EmptyTuple(), facts);
+            return (Value != null ? Value.GetHashCode() : 0);
+        }
+    }
 
-            //Act
-            var toAdd = AsFact(new TestFact(3, "key1"), new TestFact(4, null));
-            var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal(2, aggregate1.Count());
-            Assert.Equal(2, aggregate1[GetKey("key1")].Count());
-            Assert.Equal(2, aggregate1[GetKey(null)].Count());
+    private class GroupElement
+    {
+        public GroupElement(TestFact fact)
+        {
+            Id = fact.Id;
+            Key = fact.Key;
         }
 
-        [Fact]
-        public void Add_NewAndExistingGroups_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var toAdd = AsFact(new TestFact(2, "key1"), new TestFact(3, "key2"), new TestFact(4, "key2"));
-            var result = target.Add(null, EmptyTuple(), toAdd).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal(2, aggregate1.Count());
-            Assert.Equal(2, aggregate1[GetKey("key1")].Count());
-            Assert.Equal(2, aggregate1[GetKey("key2")].Count());
-        }
-
-        [Fact]
-        public void Modify_ExistingGroupsSameIdentity_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, "key1");
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-        }
-
-        [Fact]
-        public void Modify_ExistingGroupsDifferentIdentity_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(3, "key1");
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-        }
-
-        [Fact]
-        public void Modify_KeyPayloadChanges_CachedPayloadUpdated()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1") {Payload = 1}, new TestFact(2, "key1") {Payload = 1});
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, "key1") {Payload = 2};
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>)result[0].Aggregate;
-            Assert.Equal(2, aggregate1.Single(x => x.Key.Value == "key1").Key.CachedPayload);
-        }
-
-        [Fact]
-        public void Modify_ExistingGroupsHasDefaultKey_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, null), new TestFact(2, null));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, null);
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-        }
-
-        [Fact]
-        public void Modify_GroupRemovedAndAdded_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"), new TestFact(3, "key2"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, "key2");
-            facts[1].Value = new TestFact(2, "key1");
-            var toUpdate = facts.Take(2).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal(2, aggregate1.Count());
-            Assert.Single(aggregate1[GetKey("key1")]);
-            Assert.Equal(2, aggregate1[GetKey("key2")].Count());
-        }
-
-        [Fact]
-        public void Modify_ExistingGroupKeyChanged_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(2, "key2");
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal(2, aggregate1.Count());
-            Assert.Single(aggregate1[GetKey("key1")]);
-            Assert.Single(aggregate1[GetKey("key2")]);
-        }
-
-        [Fact]
-        public void Modify_ExistingGroupKeyChangedToDefault_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(2, null);
-            var toUpdate = facts.Take(1).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Equal(2, aggregate1.Count());
-            Assert.Single(aggregate1[GetKey("key1")]);
-            Assert.Single(aggregate1[GetKey(null)]);
-        }
-
-        [Fact]
-        public void Modify_ExistingGroupAllElementsHaveKeyChanged_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, "key2");
-            facts[1].Value = new TestFact(2, "key2");
-            var toUpdate = facts.Take(2).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Single(aggregate1);
-            Assert.Equal(2, aggregate1[GetKey("key2")].Count());
-        }
-
-        [Fact]
-        public void Modify_NonExistent_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"))));
-        }
-
-        [Fact]
-        public void Modify_NonExistentDefaultKey_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, null))));
-        }
-
-        [Fact]
-        public void Remove_ExistingGroup_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, "key1");
-            var toRemove = facts.Take(1).ToArray();
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Single(aggregate1);
-            Assert.Single(aggregate1[GetKey("key1")]);
-        }
-
-        [Fact]
-        public void Remove_ExistingGroupWithDefaultKey_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, null), new TestFact(2, null));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, null);
-            var toRemove = facts.Take(1).ToArray();
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Single(aggregate1);
-            Assert.Single(aggregate1[GetKey(null)]);
-        }
-
-        [Fact]
-        public void Remove_ExistingGroupAllElementsRemoved_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "key1"), new TestFact(2, "key1"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var result = target.Remove(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Empty(aggregate1);
-        }
-
-        [Fact]
-        public void Remove_ExistingGroupAllElementsRemovedDefaultKey_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, null), new TestFact(2, null));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var result = target.Remove(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Single(result);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            var aggregate1 = (ILookup<GroupKey, GroupElement>) result[0].Aggregate;
-            Assert.Empty(aggregate1);
-        }
-
-        [Fact]
-        public void Remove_NonExistent_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, "key1"), new TestFact(2, "key2"))));
-        }
-
-        [Fact]
-        public void Remove_NonExistentDefaultKey_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, null))));
-        }
-
-        private LookupAggregator<TestFact, GroupKey, GroupElement> CreateTarget()
-        {
-            var keyExpression = new FactExpression<TestFact, GroupKey>(GetGroupKey);
-            var elementExpression = new FactExpression<TestFact, GroupElement>(x => new GroupElement(x));
-            return new LookupAggregator<TestFact, GroupKey, GroupElement>(keyExpression, elementExpression);
-        }
-        
-        private static GroupKey GetGroupKey(TestFact fact)
-        {
-            return fact.Key == null ? null : new GroupKey(fact.Key, fact.Payload);
-        }
-
-        private static GroupKey GetKey(string key)
-        {
-            return key == null ? null : new GroupKey(key, 0);
-        }
-
-        private class TestFact : IEquatable<TestFact>
-        {
-            public TestFact(int id, string key)
-            {
-                Id = id;
-                Key = key;
-            }
-
-            public int Id { get; }
-            public string Key { get; }
-            public int Payload { get; set; } = 0;
-
-            public bool Equals(TestFact other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return Id == other.Id;
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((TestFact) obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return Id;
-            }
-        }
-
-        private class GroupKey : IEquatable<GroupKey>
-        {
-            public GroupKey(string value, int payload)
-            {
-                Value = value;
-                CachedPayload = payload;
-            }
-
-            public string Value { get; }
-            public int CachedPayload { get; }
-
-            public bool Equals(GroupKey other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return string.Equals(Value, other.Value);
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((GroupKey)obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return (Value != null ? Value.GetHashCode() : 0);
-            }
-        }
-
-        private class GroupElement
-        {
-            public GroupElement(TestFact fact)
-            {
-                Id = fact.Id;
-                Key = fact.Key;
-            }
-
-            public int Id { get; }
-            public string Key { get; }
-        }
+        public int Id { get; }
+        public string Key { get; }
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Aggregators/MultiKeySortedAggregatorTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Aggregators/MultiKeySortedAggregatorTest.cs
@@ -5,491 +5,490 @@ using NRules.Aggregators;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.Tests.Aggregators
+namespace NRules.Tests.Aggregators;
+
+public class MultiKeySortedAggregatorTest : AggregatorTest
 {
-    public class MultiKeySortedAggregatorTest : AggregatorTest
+    [Fact]
+    public void Add_NewInstance_AddedResult_AscendingThenAscending()
     {
-        [Fact]
-        public void Add_NewInstance_AddedResult_AscendingThenAscending()
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndInt2(SortDirection.Ascending, SortDirection.Ascending);
+        var fact1_2 = new TestFact(1, 2);
+        var fact1_1 = new TestFact(1, 1);
+        var fact2_3 = new TestFact(2, 3);
+
+        // Act
+        var facts = AsFact(fact2_3, fact1_2, fact1_1);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added, fact1_1, fact1_2, fact2_3);
+    }
+
+    [Fact]
+    public void Add_NewInstance_AddedResult_AscendingThenDescending()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndInt2(SortDirection.Ascending, SortDirection.Descending);
+        var fact1_2 = new TestFact(1, 2);
+        var fact1_1 = new TestFact(1, 1);
+        var fact2_3 = new TestFact(2, 3);
+
+        // Act
+        
+        var facts = AsFact(fact2_3, fact1_2, fact1_1);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added, fact1_2, fact1_1, fact2_3);
+    }
+
+    [Fact]
+    public void Add_NewInstance_AddedResult_DescendingThenAscending()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndInt2(SortDirection.Descending, SortDirection.Ascending);
+        var fact1_2 = new TestFact(1, 2);
+        var fact1_1 = new TestFact(1, 1);
+        var fact2_3 = new TestFact(2, 3);
+
+        // Act
+        var facts = AsFact(fact2_3, fact1_2, fact1_1);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added, fact2_3, fact1_1, fact1_2);
+    }
+
+    [Fact]
+    public void Add_NewInstance_AddedResult_DescendingThenDescending()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndInt2(SortDirection.Descending, SortDirection.Descending);
+        var fact1_2 = new TestFact(1, 2);
+        var fact1_1 = new TestFact(1, 1);
+        var fact2_3 = new TestFact(2, 3);
+
+        // Act
+        var facts = AsFact(fact2_3, fact1_2, fact1_1);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added, fact2_3, fact1_2, fact1_1);
+    }
+
+    [Fact]
+    public void Add_NewInstance_AddedResult_IntThenString_DescendingThenAscending()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Descending, SortDirection.Ascending);
+        var fact1_B = new TestFact(1, "B");
+        var fact1_A = new TestFact(1, "A");
+        var fact2_C = new TestFact(2, "C");
+
+        // Act
+        var facts = AsFact(fact2_C, fact1_B, fact1_A);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added, fact2_C, fact1_A, fact1_B);
+    }
+
+    [Fact]
+    public void Add_NewInstance_AddedResult_IntThenString_DescendingThenDescending()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Descending, SortDirection.Descending);
+        var fact1_B = new TestFact(1, "B");
+        var fact1_A = new TestFact(1, "A");
+        var fact2_C = new TestFact(2, "C");
+
+        // Act
+        var facts = AsFact(fact2_C, fact1_B, fact1_A);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added, fact2_C, fact1_B, fact1_A);
+    }
+
+    [Fact]
+    public void Add_NoFacts_AddedResultEmptyCollection()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndInt2(SortDirection.Descending, SortDirection.Descending);
+
+        // Act
+        var facts = AsFact(new TestFact[0]);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added);
+    }
+
+    [Fact]
+    public void Add_NewInstanceDuplicateFacts_AddedResult()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Descending, SortDirection.Ascending);
+        var duplicateFact1 = new TestFact(1, "A");
+        var duplicateFact2 = new TestFact(1, "A");
+
+        // Act
+        var facts = AsFact(duplicateFact1, duplicateFact2);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added, duplicateFact1, duplicateFact2);
+    }
+
+    [Fact]
+    public void Add_OldInstanceNewFacts_ModifiedResult_AscendingThenDescending()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Descending);
+        var fact1 = new TestFact(1, "B");
+        var fact3 = new TestFact(2, "C");
+        target.Add(null, EmptyTuple(), AsFact(fact1, fact3));
+
+        // Act
+        var fact2 = new TestFact(1, "A");
+        var facts = AsFact(fact2);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, fact1, fact2, fact3);
+    }
+
+    [Fact]
+    public void Add_OldInstanceNewFacts_ModifiedResult_DescendingThenAscending()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Descending);
+        var fact1 = new TestFact(1, "B");
+        var fact2 = new TestFact(1, "A");
+        var fact3 = new TestFact(2, "C");
+        target.Add(null, EmptyTuple(), AsFact(fact1, fact3));
+
+        // Act
+        var facts = AsFact(fact2);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, fact1, fact2, fact3);
+    }
+
+    [Fact]
+    public void Add_OldInstanceDuplicateFacts_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
+        var duplicateFact1 = new TestFact(1, "A");
+        var duplicateFact2 = new TestFact(1, "A");
+
+        // Act
+        var facts1 = AsFact(duplicateFact1);
+        target.Add(null, EmptyTuple(), facts1).ToArray();
+
+        var facts2 = AsFact(duplicateFact2);
+        var result = target.Add(null, EmptyTuple(), facts2).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, duplicateFact1, duplicateFact2);
+    }
+
+    [Fact]
+    public void Modify_ExistingFactsSameValues_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
+        var fact1 = new TestFact(1, "A");
+        var fact2 = new TestFact(2, "B");
+
+        var facts = AsFact(fact1, fact2);
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        var result = target.Modify(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, fact1, fact2);
+    }
+
+    [Fact]
+    public void Modify_ExistingFactsDifferentValues_ModifiedResult_AscendingThenAscending()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
+        var fact1 = new TestFact(1, "A");
+        var fact2 = new TestFact(1, "B");
+        var facts = AsFact(fact1, fact2);
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        facts[0].Value = new TestFact(1, "D");
+        facts[1].Value = new TestFact(1, "C");
+        var result = target.Modify(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, new TestFact(1, "C"), new TestFact(1, "D"));
+    }
+
+    [Fact]
+    public void Modify_ExistingFactsDifferentValues_ModifiedResult_AscendingThenDescending()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Descending);
+        var fact1 = new TestFact(1, "A");
+        var fact2 = new TestFact(1, "B");
+
+        var facts = AsFact(fact1, fact1);
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        facts[0].Value = new TestFact(1, "D");
+        facts[1].Value = new TestFact(1, "C");
+        var result = target.Modify(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, new TestFact(1, "D"), new TestFact(1, "C"));
+    }
+
+    [Fact]
+    public void Modify_ExistingDuplicateFacts_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
+        var fact1 = new TestFact(1, "A");
+        var fact2 = new TestFact(1, "A");
+        var facts = AsFact(fact1, fact2);
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        var result = target.Modify(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, fact1, fact2);
+    }
+
+    [Fact]
+    public void Modify_ExistingDuplicateFactsDeduplicated_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
+        var fact1 = new TestFact(1, "A");
+        var fact2 = new TestFact(1, "A");
+        var facts = AsFact(fact1, fact2);
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        fact1 = new TestFact(1, "B");
+        facts[0].Value = fact1;
+        var result = target.Modify(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, fact2, fact1);
+    }
+
+    [Fact]
+    public void Modify_ExistingDuplicateFactsDeduplicatedOneByOne_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
+        var facts = AsFact(new TestFact(1, "A"), new TestFact(1, "A"));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        var fact1 = new TestFact(1, "B");
+        facts[0].Value = fact1;
+        target.Modify(null, EmptyTuple(), facts.Take(1)).ToArray();
+
+        var fact2 = new TestFact(1, "C");
+        facts[1].Value = fact2;
+        var result = target.Modify(null, EmptyTuple(), facts.Skip(1).Take(1)).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, fact1, fact2);
+    }
+
+    [Fact]
+    public void Modify_NonExistent_Throws()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
+        var facts = AsFact(new TestFact(1, "A"), new TestFact(1, "B"));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, "A"), new TestFact(1, "B"))));
+    }
+
+    [Fact]
+    public void Remove_ExistingFactsSameValues_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
+        var fact1 = new TestFact(1, "A");
+        var fact2 = new TestFact(1, "B");
+        var fact3 = new TestFact(1, "C");
+        var facts = AsFact(fact1, fact2, fact3);
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        var toRemove = new[] { facts.ElementAt(1) };
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, fact1, fact3);
+    }
+
+    [Fact]
+    public void Remove_ExistingFactsDifferentValues_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
+        var fact1 = new TestFact(1, "A");
+        var fact2 = new TestFact(1, "B");
+        var fact3 = new TestFact(1, "C");
+        var facts = AsFact(fact1, fact2, fact3);
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        facts[0].Value = new TestFact(2, "A");
+        facts[1].Value = new TestFact(2, "B");
+        var toRemove = facts.Take(2).ToArray();
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, fact3);
+    }
+
+    [Fact]
+    public void Remove_ExistingDuplicateFacts_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
+        var fact1 = new TestFact(1, "A");
+        var fact2 = new TestFact(1, "B");
+        var fact3 = new TestFact(1, "B");
+        var facts = AsFact(fact1, fact2, fact3);
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        var toRemove = facts.Take(2).ToArray();
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, fact3);
+    }
+
+    [Fact]
+    public void Remove_ExistingDuplicateFactsRemovedOneByOne_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
+        var fact1 = new TestFact(1, "A");
+        var fact2 = new TestFact(1, "B");
+        var fact3 = new TestFact(1, "B");
+        var facts = AsFact(fact1, fact2, fact3);
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        target.Remove(null, EmptyTuple(), facts.Skip(1).Take(1).ToArray()).ToArray();
+        var result = target.Remove(null, EmptyTuple(), facts.Skip(2).Take(1).ToArray()).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, fact1);
+    }
+
+    [Fact]
+    public void Remove_NonExistent_Throws()
+    {
+        // Arrange
+        var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
+        var facts = AsFact(new TestFact(1, "A"), new TestFact(1, "B"));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, "A"), new TestFact(1, "B"))));
+    }
+
+    private static MultiKeySortedAggregator<TestFact> CreateTarget_SortWithInt1AndInt2(SortDirection sortDirection1, SortDirection sortDirection2)
+    {
+        var expression1 = new FactExpression<TestFact, int>(x => x.Int1);
+        var expression2 = new FactExpression<TestFact, int>(x => x.Int2);
+        var sortCondition1 = new SortCondition(AggregateElement.KeySelectorAscendingName, sortDirection1, expression1);
+        var sortCondition2 = new SortCondition(AggregateElement.KeySelectorAscendingName, sortDirection2, expression2);
+        return new MultiKeySortedAggregator<TestFact>(new[] { sortCondition1, sortCondition2 });
+    }
+
+    private static MultiKeySortedAggregator<TestFact> CreateTarget_SortWithInt1AndString(SortDirection sortDirectionInt, SortDirection sortDirectionString)
+    {
+        var expressionInt = new FactExpression<TestFact, int>(x => x.Int1);
+        var expressionString = new FactExpression<TestFact, string>(x => x.String);
+        var sortCondition1 = new SortCondition(AggregateElement.KeySelectorAscendingName, sortDirectionInt, expressionInt);
+        var sortCondition2 = new SortCondition(AggregateElement.KeySelectorAscendingName, sortDirectionString, expressionString);
+        return new MultiKeySortedAggregator<TestFact>(new[] { sortCondition1, sortCondition2 });
+    }
+
+    private static void AssertAggregationResult(AggregationResult[] results, AggregationAction action, params TestFact[] orderedFacts)
+    {
+        Assert.Single(results);
+
+        var result = results[0];
+        Assert.Equal(action, result.Action);
+
+        var aggregate = (IEnumerable<TestFact>)result.Aggregate;
+        Assert.Equal(action == AggregationAction.Added ? null : aggregate, result.Previous);
+
+        var actualAggregateFacts = aggregate.ToArray();
+        var actualSourceFacts = result.Source.Select(f => (TestFact)f.Value).ToArray();
+        Assert.Equal(orderedFacts.Length, actualSourceFacts.Length);
+        for (var i = 0; i < orderedFacts.Length; i++)
         {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndInt2(SortDirection.Ascending, SortDirection.Ascending);
-            var fact1_2 = new TestFact(1, 2);
-            var fact1_1 = new TestFact(1, 1);
-            var fact2_3 = new TestFact(2, 3);
+            Assert.Equal(orderedFacts[i], actualAggregateFacts[i]);
+            Assert.Equal(orderedFacts[i], actualSourceFacts[i]);
+        }
+    }
 
-            // Act
-            var facts = AsFact(fact2_3, fact1_2, fact1_1);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added, fact1_1, fact1_2, fact2_3);
+    private class TestFact : IEquatable<TestFact>
+    {
+        public TestFact(int value1, int value2)
+        {
+            Int1 = value1;
+            Int2 = value2;
         }
 
-        [Fact]
-        public void Add_NewInstance_AddedResult_AscendingThenDescending()
+        public TestFact(int value1, string stringValue)
         {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndInt2(SortDirection.Ascending, SortDirection.Descending);
-            var fact1_2 = new TestFact(1, 2);
-            var fact1_1 = new TestFact(1, 1);
-            var fact2_3 = new TestFact(2, 3);
-
-            // Act
-            
-            var facts = AsFact(fact2_3, fact1_2, fact1_1);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added, fact1_2, fact1_1, fact2_3);
+            Int1 = value1;
+            String = stringValue;
         }
 
-        [Fact]
-        public void Add_NewInstance_AddedResult_DescendingThenAscending()
+        public int Int1 { get; }
+        public int Int2 { get; }
+        public string String { get; }
+
+        public bool Equals(TestFact other)
         {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndInt2(SortDirection.Descending, SortDirection.Ascending);
-            var fact1_2 = new TestFact(1, 2);
-            var fact1_1 = new TestFact(1, 1);
-            var fact2_3 = new TestFact(2, 3);
-
-            // Act
-            var facts = AsFact(fact2_3, fact1_2, fact1_1);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added, fact2_3, fact1_1, fact1_2);
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Int1 == other.Int1 && Int2 == other.Int2 && String == other.String;
         }
 
-        [Fact]
-        public void Add_NewInstance_AddedResult_DescendingThenDescending()
+        public override bool Equals(object obj)
         {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndInt2(SortDirection.Descending, SortDirection.Descending);
-            var fact1_2 = new TestFact(1, 2);
-            var fact1_1 = new TestFact(1, 1);
-            var fact2_3 = new TestFact(2, 3);
-
-            // Act
-            var facts = AsFact(fact2_3, fact1_2, fact1_1);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added, fact2_3, fact1_2, fact1_1);
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestFact)obj);
         }
 
-        [Fact]
-        public void Add_NewInstance_AddedResult_IntThenString_DescendingThenAscending()
+        public override int GetHashCode()
         {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Descending, SortDirection.Ascending);
-            var fact1_B = new TestFact(1, "B");
-            var fact1_A = new TestFact(1, "A");
-            var fact2_C = new TestFact(2, "C");
-
-            // Act
-            var facts = AsFact(fact2_C, fact1_B, fact1_A);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added, fact2_C, fact1_A, fact1_B);
-        }
-
-        [Fact]
-        public void Add_NewInstance_AddedResult_IntThenString_DescendingThenDescending()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Descending, SortDirection.Descending);
-            var fact1_B = new TestFact(1, "B");
-            var fact1_A = new TestFact(1, "A");
-            var fact2_C = new TestFact(2, "C");
-
-            // Act
-            var facts = AsFact(fact2_C, fact1_B, fact1_A);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added, fact2_C, fact1_B, fact1_A);
-        }
-
-        [Fact]
-        public void Add_NoFacts_AddedResultEmptyCollection()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndInt2(SortDirection.Descending, SortDirection.Descending);
-
-            // Act
-            var facts = AsFact(new TestFact[0]);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added);
-        }
-
-        [Fact]
-        public void Add_NewInstanceDuplicateFacts_AddedResult()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Descending, SortDirection.Ascending);
-            var duplicateFact1 = new TestFact(1, "A");
-            var duplicateFact2 = new TestFact(1, "A");
-
-            // Act
-            var facts = AsFact(duplicateFact1, duplicateFact2);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added, duplicateFact1, duplicateFact2);
-        }
-
-        [Fact]
-        public void Add_OldInstanceNewFacts_ModifiedResult_AscendingThenDescending()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Descending);
-            var fact1 = new TestFact(1, "B");
-            var fact3 = new TestFact(2, "C");
-            target.Add(null, EmptyTuple(), AsFact(fact1, fact3));
-
-            // Act
-            var fact2 = new TestFact(1, "A");
-            var facts = AsFact(fact2);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, fact1, fact2, fact3);
-        }
-
-        [Fact]
-        public void Add_OldInstanceNewFacts_ModifiedResult_DescendingThenAscending()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Descending);
-            var fact1 = new TestFact(1, "B");
-            var fact2 = new TestFact(1, "A");
-            var fact3 = new TestFact(2, "C");
-            target.Add(null, EmptyTuple(), AsFact(fact1, fact3));
-
-            // Act
-            var facts = AsFact(fact2);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, fact1, fact2, fact3);
-        }
-
-        [Fact]
-        public void Add_OldInstanceDuplicateFacts_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
-            var duplicateFact1 = new TestFact(1, "A");
-            var duplicateFact2 = new TestFact(1, "A");
-
-            // Act
-            var facts1 = AsFact(duplicateFact1);
-            target.Add(null, EmptyTuple(), facts1).ToArray();
-
-            var facts2 = AsFact(duplicateFact2);
-            var result = target.Add(null, EmptyTuple(), facts2).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, duplicateFact1, duplicateFact2);
-        }
-
-        [Fact]
-        public void Modify_ExistingFactsSameValues_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
-            var fact1 = new TestFact(1, "A");
-            var fact2 = new TestFact(2, "B");
-
-            var facts = AsFact(fact1, fact2);
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            var result = target.Modify(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, fact1, fact2);
-        }
-
-        [Fact]
-        public void Modify_ExistingFactsDifferentValues_ModifiedResult_AscendingThenAscending()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
-            var fact1 = new TestFact(1, "A");
-            var fact2 = new TestFact(1, "B");
-            var facts = AsFact(fact1, fact2);
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            facts[0].Value = new TestFact(1, "D");
-            facts[1].Value = new TestFact(1, "C");
-            var result = target.Modify(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, new TestFact(1, "C"), new TestFact(1, "D"));
-        }
-
-        [Fact]
-        public void Modify_ExistingFactsDifferentValues_ModifiedResult_AscendingThenDescending()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Descending);
-            var fact1 = new TestFact(1, "A");
-            var fact2 = new TestFact(1, "B");
-
-            var facts = AsFact(fact1, fact1);
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            facts[0].Value = new TestFact(1, "D");
-            facts[1].Value = new TestFact(1, "C");
-            var result = target.Modify(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, new TestFact(1, "D"), new TestFact(1, "C"));
-        }
-
-        [Fact]
-        public void Modify_ExistingDuplicateFacts_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
-            var fact1 = new TestFact(1, "A");
-            var fact2 = new TestFact(1, "A");
-            var facts = AsFact(fact1, fact2);
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            var result = target.Modify(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, fact1, fact2);
-        }
-
-        [Fact]
-        public void Modify_ExistingDuplicateFactsDeduplicated_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
-            var fact1 = new TestFact(1, "A");
-            var fact2 = new TestFact(1, "A");
-            var facts = AsFact(fact1, fact2);
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            fact1 = new TestFact(1, "B");
-            facts[0].Value = fact1;
-            var result = target.Modify(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, fact2, fact1);
-        }
-
-        [Fact]
-        public void Modify_ExistingDuplicateFactsDeduplicatedOneByOne_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
-            var facts = AsFact(new TestFact(1, "A"), new TestFact(1, "A"));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            var fact1 = new TestFact(1, "B");
-            facts[0].Value = fact1;
-            target.Modify(null, EmptyTuple(), facts.Take(1)).ToArray();
-
-            var fact2 = new TestFact(1, "C");
-            facts[1].Value = fact2;
-            var result = target.Modify(null, EmptyTuple(), facts.Skip(1).Take(1)).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, fact1, fact2);
-        }
-
-        [Fact]
-        public void Modify_NonExistent_Throws()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
-            var facts = AsFact(new TestFact(1, "A"), new TestFact(1, "B"));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, "A"), new TestFact(1, "B"))));
-        }
-
-        [Fact]
-        public void Remove_ExistingFactsSameValues_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
-            var fact1 = new TestFact(1, "A");
-            var fact2 = new TestFact(1, "B");
-            var fact3 = new TestFact(1, "C");
-            var facts = AsFact(fact1, fact2, fact3);
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            var toRemove = new[] { facts.ElementAt(1) };
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, fact1, fact3);
-        }
-
-        [Fact]
-        public void Remove_ExistingFactsDifferentValues_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
-            var fact1 = new TestFact(1, "A");
-            var fact2 = new TestFact(1, "B");
-            var fact3 = new TestFact(1, "C");
-            var facts = AsFact(fact1, fact2, fact3);
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            facts[0].Value = new TestFact(2, "A");
-            facts[1].Value = new TestFact(2, "B");
-            var toRemove = facts.Take(2).ToArray();
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, fact3);
-        }
-
-        [Fact]
-        public void Remove_ExistingDuplicateFacts_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
-            var fact1 = new TestFact(1, "A");
-            var fact2 = new TestFact(1, "B");
-            var fact3 = new TestFact(1, "B");
-            var facts = AsFact(fact1, fact2, fact3);
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            var toRemove = facts.Take(2).ToArray();
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, fact3);
-        }
-
-        [Fact]
-        public void Remove_ExistingDuplicateFactsRemovedOneByOne_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
-            var fact1 = new TestFact(1, "A");
-            var fact2 = new TestFact(1, "B");
-            var fact3 = new TestFact(1, "B");
-            var facts = AsFact(fact1, fact2, fact3);
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            target.Remove(null, EmptyTuple(), facts.Skip(1).Take(1).ToArray()).ToArray();
-            var result = target.Remove(null, EmptyTuple(), facts.Skip(2).Take(1).ToArray()).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, fact1);
-        }
-
-        [Fact]
-        public void Remove_NonExistent_Throws()
-        {
-            // Arrange
-            var target = CreateTarget_SortWithInt1AndString(SortDirection.Ascending, SortDirection.Ascending);
-            var facts = AsFact(new TestFact(1, "A"), new TestFact(1, "B"));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, "A"), new TestFact(1, "B"))));
-        }
-
-        private static MultiKeySortedAggregator<TestFact> CreateTarget_SortWithInt1AndInt2(SortDirection sortDirection1, SortDirection sortDirection2)
-        {
-            var expression1 = new FactExpression<TestFact, int>(x => x.Int1);
-            var expression2 = new FactExpression<TestFact, int>(x => x.Int2);
-            var sortCondition1 = new SortCondition(AggregateElement.KeySelectorAscendingName, sortDirection1, expression1);
-            var sortCondition2 = new SortCondition(AggregateElement.KeySelectorAscendingName, sortDirection2, expression2);
-            return new MultiKeySortedAggregator<TestFact>(new[] { sortCondition1, sortCondition2 });
-        }
-
-        private static MultiKeySortedAggregator<TestFact> CreateTarget_SortWithInt1AndString(SortDirection sortDirectionInt, SortDirection sortDirectionString)
-        {
-            var expressionInt = new FactExpression<TestFact, int>(x => x.Int1);
-            var expressionString = new FactExpression<TestFact, string>(x => x.String);
-            var sortCondition1 = new SortCondition(AggregateElement.KeySelectorAscendingName, sortDirectionInt, expressionInt);
-            var sortCondition2 = new SortCondition(AggregateElement.KeySelectorAscendingName, sortDirectionString, expressionString);
-            return new MultiKeySortedAggregator<TestFact>(new[] { sortCondition1, sortCondition2 });
-        }
-
-        private static void AssertAggregationResult(AggregationResult[] results, AggregationAction action, params TestFact[] orderedFacts)
-        {
-            Assert.Single(results);
-
-            var result = results[0];
-            Assert.Equal(action, result.Action);
-
-            var aggregate = (IEnumerable<TestFact>)result.Aggregate;
-            Assert.Equal(action == AggregationAction.Added ? null : aggregate, result.Previous);
-
-            var actualAggregateFacts = aggregate.ToArray();
-            var actualSourceFacts = result.Source.Select(f => (TestFact)f.Value).ToArray();
-            Assert.Equal(orderedFacts.Length, actualSourceFacts.Length);
-            for (var i = 0; i < orderedFacts.Length; i++)
-            {
-                Assert.Equal(orderedFacts[i], actualAggregateFacts[i]);
-                Assert.Equal(orderedFacts[i], actualSourceFacts[i]);
-            }
-        }
-
-        private class TestFact : IEquatable<TestFact>
-        {
-            public TestFact(int value1, int value2)
-            {
-                Int1 = value1;
-                Int2 = value2;
-            }
-
-            public TestFact(int value1, string stringValue)
-            {
-                Int1 = value1;
-                String = stringValue;
-            }
-
-            public int Int1 { get; }
-            public int Int2 { get; }
-            public string String { get; }
-
-            public bool Equals(TestFact other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return Int1 == other.Int1 && Int2 == other.Int2 && String == other.String;
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((TestFact)obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return Int1.GetHashCode() ^ Int2.GetHashCode() ^ String.GetHashCode();
-            }
+            return Int1.GetHashCode() ^ Int2.GetHashCode() ^ String.GetHashCode();
         }
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Aggregators/ProjectionAggregatorTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Aggregators/ProjectionAggregatorTest.cs
@@ -4,188 +4,187 @@ using System.Linq;
 using NRules.Aggregators;
 using Xunit;
 
-namespace NRules.Tests.Aggregators
+namespace NRules.Tests.Aggregators;
+
+public class ProjectionAggregatorTest : AggregatorTest
 {
-    public class ProjectionAggregatorTest : AggregatorTest
+    [Fact]
+    public void Add_Facts_AddedResult()
     {
-        [Fact]
-        public void Add_Facts_AddedResult()
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Added, result[0].Action);
+        Assert.Equal("value1", result[0].Aggregate);
+        Assert.Equal(AggregationAction.Added, result[1].Action);
+        Assert.Equal("value2", result[1].Aggregate);
+    }
+
+    [Fact]
+    public void Add_NoFacts_EmptyResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act
+        var facts = AsFact(new TestFact[0]);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        //Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Modify_Existing_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"), new TestFact(3, "value3"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toUpdate = facts.Take(2).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        Assert.Equal("value1", result[0].Aggregate);
+        Assert.Equal(AggregationAction.Modified, result[1].Action);
+        Assert.Equal("value2", result[1].Aggregate);
+    }
+
+    [Fact]
+    public void Modify_ProjectionChangedSameIdentity_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"), new TestFact(3, "value3"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(1, "value1x");
+        facts[1].Value = new TestFact(2, "value2x");
+        var toUpdate = facts.Take(2).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        Assert.Equal("value1", result[0].Previous);
+        Assert.Equal("value1x", result[0].Aggregate);
+        Assert.Equal(AggregationAction.Modified, result[1].Action);
+        Assert.Equal("value2", result[1].Previous);
+        Assert.Equal("value2x", result[1].Aggregate);
+    }
+
+    [Fact]
+    public void Modify_ProjectionChangedDifferentIdentity_ModifiedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"), new TestFact(3, "value3"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        facts[0].Value = new TestFact(4, "value4x");
+        facts[1].Value = new TestFact(5, "value5x");
+        var toUpdate = facts.Take(2).ToArray();
+        var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Modified, result[0].Action);
+        Assert.Equal("value1", result[0].Previous);
+        Assert.Equal("value4x", result[0].Aggregate);
+        Assert.Equal(AggregationAction.Modified, result[1].Action);
+        Assert.Equal("value2", result[1].Previous);
+        Assert.Equal("value5x", result[1].Aggregate);
+    }
+
+    [Fact]
+    public void Modify_NonExistent_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"))));
+    }
+
+    [Fact]
+    public void Remove_Existing_RemovedResult()
+    {
+        //Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"), new TestFact(3, "value3"));
+        target.Add(null, EmptyTuple(), facts);
+
+        //Act
+        var toRemove = facts.Take(2).ToArray();
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        //Assert
+        Assert.Equal(2, result.Length);
+        Assert.Equal(AggregationAction.Removed, result[0].Action);
+        Assert.Equal("value1", result[0].Aggregate);
+        Assert.Equal(AggregationAction.Removed, result[1].Action);
+        Assert.Equal("value2", result[1].Aggregate);
+    }
+
+    [Fact]
+    public void Remove_NonExistent_Throws()
+    {
+        //Arrange
+        var target = CreateTarget();
+
+        //Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"))));
+    }
+
+    private ProjectionAggregator<TestFact, string> CreateTarget()
+    {
+        var expression = new FactExpression<TestFact, string>(x => x.Value);
+        return new ProjectionAggregator<TestFact, string>(expression);
+    }
+
+    private class TestFact : IEquatable<TestFact>
+    {
+        public TestFact(int id, string value)
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Added, result[0].Action);
-            Assert.Equal("value1", result[0].Aggregate);
-            Assert.Equal(AggregationAction.Added, result[1].Action);
-            Assert.Equal("value2", result[1].Aggregate);
+            Id = id;
+            Value = value;
         }
 
-        [Fact]
-        public void Add_NoFacts_EmptyResult()
+        public int Id { get; }
+        public string Value { get; }
+
+        public bool Equals(TestFact other)
         {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act
-            var facts = AsFact(new TestFact[0]);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            //Assert
-            Assert.Empty(result);
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Id == other.Id;
         }
 
-        [Fact]
-        public void Modify_Existing_ModifiedResult()
+        public override bool Equals(object obj)
         {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"), new TestFact(3, "value3"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var toUpdate = facts.Take(2).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            Assert.Equal("value1", result[0].Aggregate);
-            Assert.Equal(AggregationAction.Modified, result[1].Action);
-            Assert.Equal("value2", result[1].Aggregate);
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestFact) obj);
         }
 
-        [Fact]
-        public void Modify_ProjectionChangedSameIdentity_ModifiedResult()
+        public override int GetHashCode()
         {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"), new TestFact(3, "value3"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(1, "value1x");
-            facts[1].Value = new TestFact(2, "value2x");
-            var toUpdate = facts.Take(2).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            Assert.Equal("value1", result[0].Previous);
-            Assert.Equal("value1x", result[0].Aggregate);
-            Assert.Equal(AggregationAction.Modified, result[1].Action);
-            Assert.Equal("value2", result[1].Previous);
-            Assert.Equal("value2x", result[1].Aggregate);
-        }
-
-        [Fact]
-        public void Modify_ProjectionChangedDifferentIdentity_ModifiedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"), new TestFact(3, "value3"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            facts[0].Value = new TestFact(4, "value4x");
-            facts[1].Value = new TestFact(5, "value5x");
-            var toUpdate = facts.Take(2).ToArray();
-            var result = target.Modify(null, EmptyTuple(), toUpdate).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Modified, result[0].Action);
-            Assert.Equal("value1", result[0].Previous);
-            Assert.Equal("value4x", result[0].Aggregate);
-            Assert.Equal(AggregationAction.Modified, result[1].Action);
-            Assert.Equal("value2", result[1].Previous);
-            Assert.Equal("value5x", result[1].Aggregate);
-        }
-
-        [Fact]
-        public void Modify_NonExistent_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"))));
-        }
-
-        [Fact]
-        public void Remove_Existing_RemovedResult()
-        {
-            //Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"), new TestFact(3, "value3"));
-            target.Add(null, EmptyTuple(), facts);
-
-            //Act
-            var toRemove = facts.Take(2).ToArray();
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            //Assert
-            Assert.Equal(2, result.Length);
-            Assert.Equal(AggregationAction.Removed, result[0].Action);
-            Assert.Equal("value1", result[0].Aggregate);
-            Assert.Equal(AggregationAction.Removed, result[1].Action);
-            Assert.Equal("value2", result[1].Aggregate);
-        }
-
-        [Fact]
-        public void Remove_NonExistent_Throws()
-        {
-            //Arrange
-            var target = CreateTarget();
-
-            //Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1, "value1"), new TestFact(2, "value2"))));
-        }
-
-        private ProjectionAggregator<TestFact, string> CreateTarget()
-        {
-            var expression = new FactExpression<TestFact, string>(x => x.Value);
-            return new ProjectionAggregator<TestFact, string>(expression);
-        }
-
-        private class TestFact : IEquatable<TestFact>
-        {
-            public TestFact(int id, string value)
-            {
-                Id = id;
-                Value = value;
-            }
-
-            public int Id { get; }
-            public string Value { get; }
-
-            public bool Equals(TestFact other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return Id == other.Id;
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((TestFact) obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return Id;
-            }
+            return Id;
         }
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Aggregators/SortedAggregatorTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Aggregators/SortedAggregatorTest.cs
@@ -5,409 +5,408 @@ using NRules.Aggregators;
 using NRules.RuleModel;
 using Xunit;
 
-namespace NRules.Tests.Aggregators
+namespace NRules.Tests.Aggregators;
+
+public class SortedAggregatorTest : AggregatorTest
 {
-    public class SortedAggregatorTest : AggregatorTest
+    [Fact]
+    public void Add_NewInstance_AddedResult_Ascending()
     {
-        [Fact]
-        public void Add_NewInstance_AddedResult_Ascending()
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var facts = AsFact(new TestFact(3), new TestFact(1), new TestFact(2));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added, 1, 2, 3);
+    }
+
+    [Fact]
+    public void Add_NewInstance_AddedResult_Descending()
+    {
+        // Arrange
+        var target = CreateTarget(SortDirection.Descending);
+
+        // Act
+        var facts = AsFact(new TestFact(2), new TestFact(1), new TestFact(3));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added, 3, 2, 1);
+    }
+
+    [Fact]
+    public void Add_NewInstance_AddedResult_String_Ascending()
+    {
+        // Arrange
+        var target = CreateTarget_SortByValue();
+
+        // Act
+        var facts = AsFact(new TestFact(3, "A"), new TestFact(1, "C"), new TestFact(2, "B"));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added, "A", "B", "C");
+    }
+
+    [Fact]
+    public void Add_NewInstance_AddedResult_String_Descending()
+    {
+        // Arrange
+        var target = CreateTarget_SortByValue(SortDirection.Descending);
+
+        // Act
+        var facts = AsFact(new TestFact(2, "C"), new TestFact(1, "B"), new TestFact(3, "A"));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added, "C", "B", "A");
+    }
+
+    [Fact]
+    public void Add_NoFacts_AddedResultEmptyCollection()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var facts = AsFact(new TestFact[0]);
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added, new int[0]);
+    }
+
+    [Fact]
+    public void Add_NewInstanceDuplicateFacts_AddedResult()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var facts = AsFact(new TestFact(1), new TestFact(1));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Added, 1, 1);
+    }
+
+    [Fact]
+    public void Add_OldInstanceNewFacts_ModifiedResult_Ascending()
+    {
+        // Arrange
+        var target = CreateTarget();
+        target.Add(null, EmptyTuple(), AsFact(new TestFact(5)));
+
+        // Act
+        var facts = AsFact(new TestFact(6), new TestFact(4));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, 4, 5, 6);
+    }
+
+    [Fact]
+    public void Add_OldInstanceNewFacts_ModifiedResult_Descending()
+    {
+        // Arrange
+        var target = CreateTarget(SortDirection.Descending);
+        target.Add(null, EmptyTuple(), AsFact(new TestFact(5)));
+
+        // Act
+        var facts = AsFact(new TestFact(4), new TestFact(6));
+        var result = target.Add(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, 6, 5, 4);
+    }
+
+    [Fact]
+    public void Add_OldInstanceDuplicateFacts_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var facts1 = AsFact(new TestFact(1));
+        target.Add(null, EmptyTuple(), facts1).ToArray();
+
+        var facts2 = AsFact(new TestFact(1));
+        var result = target.Add(null, EmptyTuple(), facts2).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, 1, 1);
+    }
+
+    [Fact]
+    public void Modify_ExistingFactsSameValues_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(2));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        var result = target.Modify(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, 1, 2);
+    }
+
+    [Fact]
+    public void Modify_ExistingFactsDifferentValues_ModifiedResult_Ascending()
+    {
+        // Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(2));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        facts[0].Value = new TestFact(4);
+        facts[1].Value = new TestFact(3);
+        var result = target.Modify(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, 3, 4);
+    }
+
+    [Fact]
+    public void Modify_ExistingFactsDifferentValues_ModifiedResult_Descending()
+    {
+        // Arrange
+        var target = CreateTarget(SortDirection.Descending);
+        var facts = AsFact(new TestFact(1), new TestFact(2));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        facts[0].Value = new TestFact(3);
+        facts[1].Value = new TestFact(4);
+        var result = target.Modify(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, 4, 3);
+    }
+
+    [Fact]
+    public void Modify_ExistingDuplicateFacts_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(1));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        var result = target.Modify(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, 1, 1);
+    }
+
+    [Fact]
+    public void Modify_ExistingDuplicateFactsDeduplicated_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(1));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        facts[0].Value = new TestFact(2);
+        var result = target.Modify(null, EmptyTuple(), facts).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, 1, 2);
+    }
+
+    [Fact]
+    public void Modify_ExistingDuplicateFactsDeduplicatedOneByOne_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(1));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        facts[0].Value = new TestFact(3);
+        target.Modify(null, EmptyTuple(), facts.Take(1)).ToArray();
+
+        facts[1].Value = new TestFact(2);
+        var result = target.Modify(null, EmptyTuple(), facts.Skip(1).Take(1)).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, 2, 3);
+    }
+
+    [Fact]
+    public void Modify_NonExistent_Throws()
+    {
+        // Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(2));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1), new TestFact(2))));
+    }
+
+    [Fact]
+    public void Remove_ExistingFactsSameValues_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(3));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        var toRemove = new[] { facts.ElementAt(1) };
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, 1, 3);
+    }
+
+    [Fact]
+    public void Remove_ExistingFactsDifferentValues_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(3));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        facts[0].Value = new TestFact(3);
+        facts[1].Value = new TestFact(4);
+        var toRemove = facts.Take(2).ToArray();
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, 3);
+    }
+
+    [Fact]
+    public void Remove_ExistingDuplicateFacts_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(2));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        var toRemove = facts.Take(2).ToArray();
+        var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, 2);
+    }
+
+    [Fact]
+    public void Remove_ExistingDuplicateFactsRemovedOneByOne_ModifiedResult()
+    {
+        // Arrange
+        var target = CreateTarget();
+        var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(2));
+        target.Add(null, EmptyTuple(), facts);
+
+        // Act
+        target.Remove(null, EmptyTuple(), facts.Skip(1).Take(1).ToArray()).ToArray();
+        var result = target.Remove(null, EmptyTuple(), facts.Skip(2).Take(1).ToArray()).ToArray();
+
+        // Assert
+        AssertAggregationResult(result, AggregationAction.Modified, 1);
+    }
+
+    [Fact]
+    public void Remove_NonExistent_Throws()
+    {
+        // Arrange
+        var target = CreateTarget();
+        target.Add(null, EmptyTuple(), AsFact(new TestFact(1), new TestFact(2)));
+
+        // Act - Assert
+        Assert.Throws<KeyNotFoundException>(
+            () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1), new TestFact(2))));
+    }
+
+    private static SortedAggregator<TestFact, int> CreateTarget(SortDirection sortDirection = SortDirection.Ascending)
+    {
+        var expression = new FactExpression<TestFact, int>(x => x.Id);
+        return new SortedAggregator<TestFact, int>(expression, sortDirection);
+    }
+
+    private static SortedAggregator<TestFact, string> CreateTarget_SortByValue(SortDirection sortDirection = SortDirection.Ascending)
+    {
+        var expression = new FactExpression<TestFact, string>(x => x.Value);
+        return new SortedAggregator<TestFact, string>(expression, sortDirection);
+    }
+
+    private static void AssertAggregationResult(AggregationResult[] results, AggregationAction action, params int[] orderedKeys)
+    {
+        AssertAggregationResult(results, action, f => f.Id, orderedKeys);
+    }
+
+    private static void AssertAggregationResult(AggregationResult[] results, AggregationAction action, params string[] orderedKeys)
+    {
+        AssertAggregationResult(results, action, f => f.Value, orderedKeys);
+    }
+
+    private static void AssertAggregationResult<TKey>(AggregationResult[] results, AggregationAction action, Func<TestFact, TKey> keySelector, params TKey[] orderedKeys)
+    {
+        Assert.Single(results);
+
+        var result = results[0];
+        var distinctKeys = orderedKeys.Distinct().ToArray();
+        Assert.Equal(action, result.Action);
+
+        var aggregate = (IEnumerable<TestFact>)result.Aggregate;
+        Assert.Equal(action == AggregationAction.Added ? null : aggregate, result.Previous);
+
+        var actualAggregateKeys = aggregate.Select(keySelector).ToArray();
+        var actualSourceKeys = result.Source.Select(f => keySelector((TestFact)f.Value)).ToArray();
+        Assert.Equal(orderedKeys.Length, actualSourceKeys.Length);
+        for (var i = 0; i < orderedKeys.Length; i++)
         {
-            // Arrange
-            var target = CreateTarget();
+            Assert.Equal(orderedKeys[i], actualAggregateKeys[i]);
+            Assert.Equal(orderedKeys[i], actualSourceKeys[i]);
+        }
+    }
 
-            // Act
-            var facts = AsFact(new TestFact(3), new TestFact(1), new TestFact(2));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added, 1, 2, 3);
+    private class TestFact : IEquatable<TestFact>
+    {
+        public TestFact(int id)
+            : this(id, id.ToString())
+        {
         }
 
-        [Fact]
-        public void Add_NewInstance_AddedResult_Descending()
+        public TestFact(int id, string value)
         {
-            // Arrange
-            var target = CreateTarget(SortDirection.Descending);
-
-            // Act
-            var facts = AsFact(new TestFact(2), new TestFact(1), new TestFact(3));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added, 3, 2, 1);
+            Id = id;
+            Value = value;
         }
 
-        [Fact]
-        public void Add_NewInstance_AddedResult_String_Ascending()
+        public int Id { get; }
+        public string Value { get; }
+
+        public bool Equals(TestFact other)
         {
-            // Arrange
-            var target = CreateTarget_SortByValue();
-
-            // Act
-            var facts = AsFact(new TestFact(3, "A"), new TestFact(1, "C"), new TestFact(2, "B"));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added, "A", "B", "C");
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Id == other.Id;
         }
 
-        [Fact]
-        public void Add_NewInstance_AddedResult_String_Descending()
+        public override bool Equals(object obj)
         {
-            // Arrange
-            var target = CreateTarget_SortByValue(SortDirection.Descending);
-
-            // Act
-            var facts = AsFact(new TestFact(2, "C"), new TestFact(1, "B"), new TestFact(3, "A"));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added, "C", "B", "A");
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestFact)obj);
         }
 
-        [Fact]
-        public void Add_NoFacts_AddedResultEmptyCollection()
+        public override int GetHashCode()
         {
-            // Arrange
-            var target = CreateTarget();
-
-            // Act
-            var facts = AsFact(new TestFact[0]);
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added, new int[0]);
-        }
-
-        [Fact]
-        public void Add_NewInstanceDuplicateFacts_AddedResult()
-        {
-            // Arrange
-            var target = CreateTarget();
-
-            // Act
-            var facts = AsFact(new TestFact(1), new TestFact(1));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Added, 1, 1);
-        }
-
-        [Fact]
-        public void Add_OldInstanceNewFacts_ModifiedResult_Ascending()
-        {
-            // Arrange
-            var target = CreateTarget();
-            target.Add(null, EmptyTuple(), AsFact(new TestFact(5)));
-
-            // Act
-            var facts = AsFact(new TestFact(6), new TestFact(4));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, 4, 5, 6);
-        }
-
-        [Fact]
-        public void Add_OldInstanceNewFacts_ModifiedResult_Descending()
-        {
-            // Arrange
-            var target = CreateTarget(SortDirection.Descending);
-            target.Add(null, EmptyTuple(), AsFact(new TestFact(5)));
-
-            // Act
-            var facts = AsFact(new TestFact(4), new TestFact(6));
-            var result = target.Add(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, 6, 5, 4);
-        }
-
-        [Fact]
-        public void Add_OldInstanceDuplicateFacts_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget();
-
-            // Act
-            var facts1 = AsFact(new TestFact(1));
-            target.Add(null, EmptyTuple(), facts1).ToArray();
-
-            var facts2 = AsFact(new TestFact(1));
-            var result = target.Add(null, EmptyTuple(), facts2).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, 1, 1);
-        }
-
-        [Fact]
-        public void Modify_ExistingFactsSameValues_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(2));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            var result = target.Modify(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, 1, 2);
-        }
-
-        [Fact]
-        public void Modify_ExistingFactsDifferentValues_ModifiedResult_Ascending()
-        {
-            // Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(2));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            facts[0].Value = new TestFact(4);
-            facts[1].Value = new TestFact(3);
-            var result = target.Modify(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, 3, 4);
-        }
-
-        [Fact]
-        public void Modify_ExistingFactsDifferentValues_ModifiedResult_Descending()
-        {
-            // Arrange
-            var target = CreateTarget(SortDirection.Descending);
-            var facts = AsFact(new TestFact(1), new TestFact(2));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            facts[0].Value = new TestFact(3);
-            facts[1].Value = new TestFact(4);
-            var result = target.Modify(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, 4, 3);
-        }
-
-        [Fact]
-        public void Modify_ExistingDuplicateFacts_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(1));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            var result = target.Modify(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, 1, 1);
-        }
-
-        [Fact]
-        public void Modify_ExistingDuplicateFactsDeduplicated_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(1));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            facts[0].Value = new TestFact(2);
-            var result = target.Modify(null, EmptyTuple(), facts).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, 1, 2);
-        }
-
-        [Fact]
-        public void Modify_ExistingDuplicateFactsDeduplicatedOneByOne_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(1));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            facts[0].Value = new TestFact(3);
-            target.Modify(null, EmptyTuple(), facts.Take(1)).ToArray();
-
-            facts[1].Value = new TestFact(2);
-            var result = target.Modify(null, EmptyTuple(), facts.Skip(1).Take(1)).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, 2, 3);
-        }
-
-        [Fact]
-        public void Modify_NonExistent_Throws()
-        {
-            // Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(2));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Modify(null, EmptyTuple(), AsFact(new TestFact(1), new TestFact(2))));
-        }
-
-        [Fact]
-        public void Remove_ExistingFactsSameValues_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(3));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            var toRemove = new[] { facts.ElementAt(1) };
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, 1, 3);
-        }
-
-        [Fact]
-        public void Remove_ExistingFactsDifferentValues_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(3));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            facts[0].Value = new TestFact(3);
-            facts[1].Value = new TestFact(4);
-            var toRemove = facts.Take(2).ToArray();
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, 3);
-        }
-
-        [Fact]
-        public void Remove_ExistingDuplicateFacts_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(2));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            var toRemove = facts.Take(2).ToArray();
-            var result = target.Remove(null, EmptyTuple(), toRemove).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, 2);
-        }
-
-        [Fact]
-        public void Remove_ExistingDuplicateFactsRemovedOneByOne_ModifiedResult()
-        {
-            // Arrange
-            var target = CreateTarget();
-            var facts = AsFact(new TestFact(1), new TestFact(2), new TestFact(2));
-            target.Add(null, EmptyTuple(), facts);
-
-            // Act
-            target.Remove(null, EmptyTuple(), facts.Skip(1).Take(1).ToArray()).ToArray();
-            var result = target.Remove(null, EmptyTuple(), facts.Skip(2).Take(1).ToArray()).ToArray();
-
-            // Assert
-            AssertAggregationResult(result, AggregationAction.Modified, 1);
-        }
-
-        [Fact]
-        public void Remove_NonExistent_Throws()
-        {
-            // Arrange
-            var target = CreateTarget();
-            target.Add(null, EmptyTuple(), AsFact(new TestFact(1), new TestFact(2)));
-
-            // Act - Assert
-            Assert.Throws<KeyNotFoundException>(
-                () => target.Remove(null, EmptyTuple(), AsFact(new TestFact(1), new TestFact(2))));
-        }
-
-        private static SortedAggregator<TestFact, int> CreateTarget(SortDirection sortDirection = SortDirection.Ascending)
-        {
-            var expression = new FactExpression<TestFact, int>(x => x.Id);
-            return new SortedAggregator<TestFact, int>(expression, sortDirection);
-        }
-
-        private static SortedAggregator<TestFact, string> CreateTarget_SortByValue(SortDirection sortDirection = SortDirection.Ascending)
-        {
-            var expression = new FactExpression<TestFact, string>(x => x.Value);
-            return new SortedAggregator<TestFact, string>(expression, sortDirection);
-        }
-
-        private static void AssertAggregationResult(AggregationResult[] results, AggregationAction action, params int[] orderedKeys)
-        {
-            AssertAggregationResult(results, action, f => f.Id, orderedKeys);
-        }
-
-        private static void AssertAggregationResult(AggregationResult[] results, AggregationAction action, params string[] orderedKeys)
-        {
-            AssertAggregationResult(results, action, f => f.Value, orderedKeys);
-        }
-
-        private static void AssertAggregationResult<TKey>(AggregationResult[] results, AggregationAction action, Func<TestFact, TKey> keySelector, params TKey[] orderedKeys)
-        {
-            Assert.Single(results);
-
-            var result = results[0];
-            var distinctKeys = orderedKeys.Distinct().ToArray();
-            Assert.Equal(action, result.Action);
-
-            var aggregate = (IEnumerable<TestFact>)result.Aggregate;
-            Assert.Equal(action == AggregationAction.Added ? null : aggregate, result.Previous);
-
-            var actualAggregateKeys = aggregate.Select(keySelector).ToArray();
-            var actualSourceKeys = result.Source.Select(f => keySelector((TestFact)f.Value)).ToArray();
-            Assert.Equal(orderedKeys.Length, actualSourceKeys.Length);
-            for (var i = 0; i < orderedKeys.Length; i++)
-            {
-                Assert.Equal(orderedKeys[i], actualAggregateKeys[i]);
-                Assert.Equal(orderedKeys[i], actualSourceKeys[i]);
-            }
-        }
-
-        private class TestFact : IEquatable<TestFact>
-        {
-            public TestFact(int id)
-                : this(id, id.ToString())
-            {
-            }
-
-            public TestFact(int id, string value)
-            {
-                Id = id;
-                Value = value;
-            }
-
-            public int Id { get; }
-            public string Value { get; }
-
-            public bool Equals(TestFact other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return Id == other.Id;
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((TestFact)obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return Id;
-            }
+            return Id;
         }
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Collections/OrderedPriorityQueueTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Collections/OrderedPriorityQueueTest.cs
@@ -1,56 +1,55 @@
 ﻿using NRules.Collections;
 using Xunit;
 
-namespace NRules.Tests.Collections
+namespace NRules.Tests.Collections;
+
+public class OrderedPriorityQueueTest
 {
-    public class OrderedPriorityQueueTest
+    [Fact]
+    public void Queue_Enqueue_DequeueReturnsByPriority()
     {
-        [Fact]
-        public void Queue_Enqueue_DequeueReturnsByPriority()
-        {
-            //Arrange
-            var queue = new OrderedPriorityQueue<int, string>();
+        //Arrange
+        var queue = new OrderedPriorityQueue<int, string>();
 
-            //Act
-            queue.Enqueue(1, "e");
-            queue.Enqueue(2, "d");
-            queue.Enqueue(3, "c");
-            queue.Enqueue(5, "a");
-            queue.Enqueue(4, "b");
+        //Act
+        queue.Enqueue(1, "e");
+        queue.Enqueue(2, "d");
+        queue.Enqueue(3, "c");
+        queue.Enqueue(5, "a");
+        queue.Enqueue(4, "b");
 
-            //Assert
-            Assert.Equal("a", queue.Dequeue());
-            Assert.Equal("b", queue.Dequeue());
-            Assert.Equal("c", queue.Dequeue());
-            Assert.Equal("d", queue.Dequeue());
-            Assert.Equal("e", queue.Dequeue());
-        }
+        //Assert
+        Assert.Equal("a", queue.Dequeue());
+        Assert.Equal("b", queue.Dequeue());
+        Assert.Equal("c", queue.Dequeue());
+        Assert.Equal("d", queue.Dequeue());
+        Assert.Equal("e", queue.Dequeue());
+    }
 
-        [Fact]
-        public void Queue_EnqueueWithDupPriorities_DequeueReturnsByPriorityThenByOrderOfInsertion()
-        {
-            //Arrange
-            var queue = new OrderedPriorityQueue<int, string>();
+    [Fact]
+    public void Queue_EnqueueWithDupPriorities_DequeueReturnsByPriorityThenByOrderOfInsertion()
+    {
+        //Arrange
+        var queue = new OrderedPriorityQueue<int, string>();
 
-            //Act
-            queue.Enqueue(1, "h");
-            queue.Enqueue(2, "e");
-            queue.Enqueue(2, "f");
-            queue.Enqueue(2, "g");
-            queue.Enqueue(3, "d");
-            queue.Enqueue(5, "a");
-            queue.Enqueue(4, "b");
-            queue.Enqueue(4, "c");
+        //Act
+        queue.Enqueue(1, "h");
+        queue.Enqueue(2, "e");
+        queue.Enqueue(2, "f");
+        queue.Enqueue(2, "g");
+        queue.Enqueue(3, "d");
+        queue.Enqueue(5, "a");
+        queue.Enqueue(4, "b");
+        queue.Enqueue(4, "c");
 
-            //Assert
-            Assert.Equal("a", queue.Dequeue());
-            Assert.Equal("b", queue.Dequeue());
-            Assert.Equal("c", queue.Dequeue());
-            Assert.Equal("d", queue.Dequeue());
-            Assert.Equal("e", queue.Dequeue());
-            Assert.Equal("f", queue.Dequeue());
-            Assert.Equal("g", queue.Dequeue());
-            Assert.Equal("h", queue.Dequeue());
-        }
+        //Assert
+        Assert.Equal("a", queue.Dequeue());
+        Assert.Equal("b", queue.Dequeue());
+        Assert.Equal("c", queue.Dequeue());
+        Assert.Equal("d", queue.Dequeue());
+        Assert.Equal("e", queue.Dequeue());
+        Assert.Equal("f", queue.Dequeue());
+        Assert.Equal("g", queue.Dequeue());
+        Assert.Equal("h", queue.Dequeue());
     }
 }

--- a/src/NRules/Tests/NRules.Tests/NRules.Tests.csproj
+++ b/src/NRules/Tests/NRules.Tests/NRules.Tests.csproj
@@ -6,7 +6,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NRules/Tests/NRules.Tests/Rete/FactTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Rete/FactTest.cs
@@ -2,23 +2,22 @@
 using NRules.Rete;
 using Xunit;
 
-namespace NRules.Tests.Rete
+namespace NRules.Tests.Rete;
+
+public class FactTest
 {
-    public class FactTest
+    [Fact]
+    public void FactType_WhenObjectPassed_ReturnsItsType()
     {
-        [Fact]
-        public void FactType_WhenObjectPassed_ReturnsItsType()
-        {
-            //Arrange
-            var obj = new DateTime();
-            var target = new Fact(obj);
+        //Arrange
+        var obj = new DateTime();
+        var target = new Fact(obj);
 
-            //Act
-            var actual = target.FactType;
-            var expected = typeof (DateTime);
+        //Act
+        var actual = target.FactType;
+        var expected = typeof (DateTime);
 
-            //Assert
-            Assert.Equal(expected, actual);
-        }
+        //Assert
+        Assert.Equal(expected, actual);
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Rete/TupleTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Rete/TupleTest.cs
@@ -2,99 +2,98 @@
 using NRules.Rete;
 using Xunit;
 
-namespace NRules.Tests.Rete
+namespace NRules.Tests.Rete;
+
+public class TupleTest
 {
-    public class TupleTest
+    [Fact]
+    public void Ctor_WhenFactPassed_ExposedAsRightFact()
     {
-        [Fact]
-        public void Ctor_WhenFactPassed_ExposedAsRightFact()
-        {
-            //Arrange
-            var fact = new Fact(1);
+        //Arrange
+        var fact = new Fact(1);
 
-            //Act
-            var target = new Tuple(0, new Tuple(0), fact);
+        //Act
+        var target = new Tuple(0, new Tuple(0), fact);
 
-            //Assert
-            Assert.Equal(fact, target.RightFact);
-        }
+        //Assert
+        Assert.Equal(fact, target.RightFact);
+    }
 
-        [Fact]
-        public void Ctor_WhenTuplePassed_ExposedAsLeftTuple()
-        {
-            //Arrange
-            var tuple1 = new Tuple(0, new Tuple(0), new Fact(1));
+    [Fact]
+    public void Ctor_WhenTuplePassed_ExposedAsLeftTuple()
+    {
+        //Arrange
+        var tuple1 = new Tuple(0, new Tuple(0), new Fact(1));
 
-            //Act
-            var tuple2 = new Tuple(0, tuple1, new Fact(2));
+        //Act
+        var tuple2 = new Tuple(0, tuple1, new Fact(2));
 
-            //Assert
-            Assert.Equal(tuple1, tuple2.LeftTuple);
-        }
+        //Assert
+        Assert.Equal(tuple1, tuple2.LeftTuple);
+    }
 
-        [Fact]
-        public void Enumerator_WhenEnumeratesNTuple_WalksTuplesInReverseOrder()
-        {
-            //Arrange
-            var tuple0 = new Tuple(0);
-            var tuple1 = new Tuple(0, tuple0, new Fact(1));
-            var tuple2 = new Tuple(0, tuple1, new Fact(2));
-            var tuple3 = new Tuple(0, tuple2, new Fact(3));
+    [Fact]
+    public void Enumerator_WhenEnumeratesNTuple_WalksTuplesInReverseOrder()
+    {
+        //Arrange
+        var tuple0 = new Tuple(0);
+        var tuple1 = new Tuple(0, tuple0, new Fact(1));
+        var tuple2 = new Tuple(0, tuple1, new Fact(2));
+        var tuple3 = new Tuple(0, tuple2, new Fact(3));
 
-            //Act
-            var target = tuple3.Facts.ToArray();
+        //Act
+        var target = tuple3.Facts.ToArray();
 
-            //Assert
-            Assert.Equal(3, target.Length);
-            Assert.Equal(tuple1.RightFact, target[2]);
-            Assert.Equal(tuple2.RightFact, target[1]);
-            Assert.Equal(tuple3.RightFact, target[0]);
-        }
+        //Assert
+        Assert.Equal(3, target.Length);
+        Assert.Equal(tuple1.RightFact, target[2]);
+        Assert.Equal(tuple2.RightFact, target[1]);
+        Assert.Equal(tuple3.RightFact, target[0]);
+    }
 
-        [Fact]
-        public void Enumerator_WhenEnumerated_ReturnsUnderlyingFactObjectsInReverseOrder()
-        {
-            //Arrange
-            var tuple0 = new Tuple(0);
-            var tuple1 = new Tuple(0, tuple0, new Fact(1));
-            var tuple2 = new Tuple(0, tuple1, new Fact(2));
-            var tuple3 = new Tuple(0, tuple2, new Fact(3));
+    [Fact]
+    public void Enumerator_WhenEnumerated_ReturnsUnderlyingFactObjectsInReverseOrder()
+    {
+        //Arrange
+        var tuple0 = new Tuple(0);
+        var tuple1 = new Tuple(0, tuple0, new Fact(1));
+        var tuple2 = new Tuple(0, tuple1, new Fact(2));
+        var tuple3 = new Tuple(0, tuple2, new Fact(3));
 
-            //Act
-            var target = tuple3.Facts.Select(f => f.Value).ToArray();
+        //Act
+        var target = tuple3.Facts.Select(f => f.Value).ToArray();
 
-            //Assert
-            Assert.Equal(3, target.Length);
-            Assert.Equal(1, target[2]);
-            Assert.Equal(2, target[1]);
-            Assert.Equal(3, target[0]);
-        }
+        //Assert
+        Assert.Equal(3, target.Length);
+        Assert.Equal(1, target[2]);
+        Assert.Equal(2, target[1]);
+        Assert.Equal(3, target[0]);
+    }
 
-        [Fact]
-        public void Enumerator_WhenEnumerates1Tuple_ReturnsSelf()
-        {
-            //Arrange
-            var tuple = new Tuple(0, new Tuple(0), new Fact(1));
+    [Fact]
+    public void Enumerator_WhenEnumerates1Tuple_ReturnsSelf()
+    {
+        //Arrange
+        var tuple = new Tuple(0, new Tuple(0), new Fact(1));
 
-            //Act
-            var target = tuple.Facts.ToArray();
+        //Act
+        var target = tuple.Facts.ToArray();
 
-            //Assert
-            Assert.Single(target);
-            Assert.Equal(tuple.RightFact, target[0]);
-        }
+        //Assert
+        Assert.Single(target);
+        Assert.Equal(tuple.RightFact, target[0]);
+    }
 
-        [Fact]
-        public void Enumerator_WhenEnumerates0Tuple_ReturnsEmpty()
-        {
-            //Arrange
-            var tuple = new Tuple(0);
+    [Fact]
+    public void Enumerator_WhenEnumerates0Tuple_ReturnsEmpty()
+    {
+        //Arrange
+        var tuple = new Tuple(0);
 
-            //Act
-            var target = tuple.Facts.ToArray();
+        //Act
+        var target = tuple.Facts.ToArray();
 
-            //Assert
-            Assert.Empty(target);
-        }
+        //Assert
+        Assert.Empty(target);
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Rete/TypeNodeTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Rete/TypeNodeTest.cs
@@ -2,22 +2,21 @@
 using NRules.Rete;
 using Xunit;
 
-namespace NRules.Tests.Rete
+namespace NRules.Tests.Rete;
+
+public class TypeNodeTest
 {
-    public class TypeNodeTest
+    [Fact]
+    public void FilterType_PassedToCtor_Returns()
     {
-        [Fact]
-        public void FilterType_PassedToCtor_Returns()
-        {
-            //Arrange
-            var target = new TypeNode(typeof (DateTime));
+        //Arrange
+        var target = new TypeNode(typeof (DateTime));
 
-            //Act
-            var actual = target.FilterType;
-            var expected = typeof (DateTime);
+        //Act
+        var actual = target.FilterType;
+        var expected = typeof (DateTime);
 
-            //Assert
-            Assert.Equal(expected, actual);
-        }
+        //Assert
+        Assert.Equal(expected, actual);
     }
 }

--- a/src/NRules/Tests/NRules.Tests/RuleCompilerTest.cs
+++ b/src/NRules/Tests/NRules.Tests/RuleCompilerTest.cs
@@ -5,124 +5,123 @@ using System.Linq;
 using System.Threading;
 using Xunit;
 
-namespace NRules.Tests
+namespace NRules.Tests;
+
+public class RuleCompilerTest
 {
-    public class RuleCompilerTest
+    [Fact]
+    public void Compile_CancellationRequested()
     {
-        [Fact]
-        public void Compile_CancellationRequested()
+        using (var cancellationSource = new CancellationTokenSource())
         {
-            using (var cancellationSource = new CancellationTokenSource())
-            {
-                // Arrange
-                var ruleCompiler = new RuleCompiler();
+            // Arrange
+            var ruleCompiler = new RuleCompiler();
 
-                var rule1 = CreateRuleDefinitionMock();
-                var rule2 = CreateRuleDefinitionMock();
-                rule2.Setup(r => r.LeftHandSide).Returns(() =>
-                    {
-                        cancellationSource.Cancel();
-                        return new AndElement(Enumerable.Empty<RuleElement>());
-                    });
-
-                var rule3 = CreateRuleDefinitionMock();
-                var rules = new[] { rule1.Object, rule2.Object, rule3.Object };
-
-                // Act
-                ruleCompiler.Compile(rules, cancellationSource.Token);
-
-                // Assert
-                rule1.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
-                rule2.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
-                rule3.Verify(r => r.LeftHandSide, Times.Never);
-            }
-        }
-
-        [Fact]
-        public void Compile_RuleSets_CancellationRequested()
-        {
-            using (var cancellationSource = new CancellationTokenSource())
-            {
-                // Arrange
-                var ruleCompiler = new RuleCompiler();
-
-                var rule1_1 = CreateRuleDefinitionMock();
-                var rule2_1 = CreateRuleDefinitionMock();
-                var rule2_2 = CreateRuleDefinitionMock();
-                rule2_2.Setup(r => r.LeftHandSide).Returns(() =>
+            var rule1 = CreateRuleDefinitionMock();
+            var rule2 = CreateRuleDefinitionMock();
+            rule2.Setup(r => r.LeftHandSide).Returns(() =>
                 {
                     cancellationSource.Cancel();
                     return new AndElement(Enumerable.Empty<RuleElement>());
                 });
 
-                var rule2_3 = CreateRuleDefinitionMock();
-                var rule3_1 = CreateRuleDefinitionMock();
+            var rule3 = CreateRuleDefinitionMock();
+            var rules = new[] { rule1.Object, rule2.Object, rule3.Object };
 
-                var rules1 = new RuleSet("R1");
-                rules1.Add(new[] { rule1_1.Object });
+            // Act
+            ruleCompiler.Compile(rules, cancellationSource.Token);
 
-                var rules2 = new RuleSet("R1");
-                rules2.Add(new[] { rule2_1.Object, rule2_2.Object, rule2_3.Object });
-
-                var rules3 = new RuleSet("R1"); ;
-                rules3.Add(new[] { rule3_1.Object });
-
-                var ruleSets = new[] { rules1, rules2, rules3 };
-
-                // Act
-                ruleCompiler.Compile(ruleSets, cancellationSource.Token);
-
-                // Assert
-                rule1_1.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
-                rule2_1.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
-                rule2_2.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
-                rule2_3.Verify(r => r.LeftHandSide, Times.Never);
-                rule3_1.Verify(r => r.LeftHandSide, Times.Never);
-            }
+            // Assert
+            rule1.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
+            rule2.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
+            rule3.Verify(r => r.LeftHandSide, Times.Never);
         }
+    }
 
-        [Fact]
-        public void RuleRepositoryExtension_Compile_CancellationRequested()
+    [Fact]
+    public void Compile_RuleSets_CancellationRequested()
+    {
+        using (var cancellationSource = new CancellationTokenSource())
         {
-            using (var cancellationSource = new CancellationTokenSource())
+            // Arrange
+            var ruleCompiler = new RuleCompiler();
+
+            var rule1_1 = CreateRuleDefinitionMock();
+            var rule2_1 = CreateRuleDefinitionMock();
+            var rule2_2 = CreateRuleDefinitionMock();
+            rule2_2.Setup(r => r.LeftHandSide).Returns(() =>
             {
-                // Arrange
-                var ruleCompiler = new RuleCompiler();
+                cancellationSource.Cancel();
+                return new AndElement(Enumerable.Empty<RuleElement>());
+            });
 
-                var rule1 = CreateRuleDefinitionMock();
-                var rule2 = CreateRuleDefinitionMock();
-                rule2.Setup(r => r.LeftHandSide).Returns(() =>
-                {
-                    cancellationSource.Cancel();
-                    return new AndElement(Enumerable.Empty<RuleElement>());
-                });
+            var rule2_3 = CreateRuleDefinitionMock();
+            var rule3_1 = CreateRuleDefinitionMock();
 
-                var rule3 = CreateRuleDefinitionMock();
-                var rules = new RuleSet("R1");
-                rules.Add(new[] { rule1.Object, rule2.Object, rule3.Object });
+            var rules1 = new RuleSet("R1");
+            rules1.Add(new[] { rule1_1.Object });
 
-                var ruleRepository = new RuleRepository();
-                ruleRepository.Add(rules);
+            var rules2 = new RuleSet("R1");
+            rules2.Add(new[] { rule2_1.Object, rule2_2.Object, rule2_3.Object });
 
-                // Act
-                ruleRepository.Compile(cancellationSource.Token);
+            var rules3 = new RuleSet("R1"); ;
+            rules3.Add(new[] { rule3_1.Object });
 
-                // Assert
-                rule1.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
-                rule2.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
-                rule3.Verify(r => r.LeftHandSide, Times.Never);
-            }
+            var ruleSets = new[] { rules1, rules2, rules3 };
+
+            // Act
+            ruleCompiler.Compile(ruleSets, cancellationSource.Token);
+
+            // Assert
+            rule1_1.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
+            rule2_1.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
+            rule2_2.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
+            rule2_3.Verify(r => r.LeftHandSide, Times.Never);
+            rule3_1.Verify(r => r.LeftHandSide, Times.Never);
         }
+    }
 
-        private Mock<IRuleDefinition> CreateRuleDefinitionMock()
+    [Fact]
+    public void RuleRepositoryExtension_Compile_CancellationRequested()
+    {
+        using (var cancellationSource = new CancellationTokenSource())
         {
-            var rule = new Mock<IRuleDefinition>();
-            rule.Setup(r => r.Name).Returns("Rule");
-            rule.Setup(r => r.LeftHandSide).Returns(new AndElement(Enumerable.Empty<RuleElement>()));
-            rule.Setup(r => r.DependencyGroup).Returns(new DependencyGroupElement(Enumerable.Empty<DependencyElement>()));
-            rule.Setup(r => r.RightHandSide).Returns(new ActionGroupElement(Enumerable.Empty<ActionElement>()));
-            rule.Setup(r => r.FilterGroup).Returns(new FilterGroupElement(Enumerable.Empty<FilterElement>()));
-            return rule;
+            // Arrange
+            var ruleCompiler = new RuleCompiler();
+
+            var rule1 = CreateRuleDefinitionMock();
+            var rule2 = CreateRuleDefinitionMock();
+            rule2.Setup(r => r.LeftHandSide).Returns(() =>
+            {
+                cancellationSource.Cancel();
+                return new AndElement(Enumerable.Empty<RuleElement>());
+            });
+
+            var rule3 = CreateRuleDefinitionMock();
+            var rules = new RuleSet("R1");
+            rules.Add(new[] { rule1.Object, rule2.Object, rule3.Object });
+
+            var ruleRepository = new RuleRepository();
+            ruleRepository.Add(rules);
+
+            // Act
+            ruleRepository.Compile(cancellationSource.Token);
+
+            // Assert
+            rule1.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
+            rule2.Verify(r => r.LeftHandSide, Times.AtLeastOnce);
+            rule3.Verify(r => r.LeftHandSide, Times.Never);
         }
+    }
+
+    private Mock<IRuleDefinition> CreateRuleDefinitionMock()
+    {
+        var rule = new Mock<IRuleDefinition>();
+        rule.Setup(r => r.Name).Returns("Rule");
+        rule.Setup(r => r.LeftHandSide).Returns(new AndElement(Enumerable.Empty<RuleElement>()));
+        rule.Setup(r => r.DependencyGroup).Returns(new DependencyGroupElement(Enumerable.Empty<DependencyElement>()));
+        rule.Setup(r => r.RightHandSide).Returns(new ActionGroupElement(Enumerable.Empty<ActionElement>()));
+        rule.Setup(r => r.FilterGroup).Returns(new FilterGroupElement(Enumerable.Empty<FilterElement>()));
+        return rule;
     }
 }

--- a/src/NRules/Tests/NRules.Tests/RuleModel/RuleBuilderTest.cs
+++ b/src/NRules/Tests/NRules.Tests/RuleModel/RuleBuilderTest.cs
@@ -5,187 +5,186 @@ using NRules.RuleModel;
 using NRules.RuleModel.Builders;
 using Xunit;
 
-namespace NRules.Tests.RuleModel
+namespace NRules.Tests.RuleModel;
+
+public class RuleBuilderTest
 {
-    public class RuleBuilderTest
+    [Fact]
+    public void Build_ValidRule_Builds()
     {
-        [Fact]
-        public void Build_ValidRule_Builds()
-        {
-            //Arrange
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
+        //Arrange
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
 
-            var lhs = builder.LeftHandSide();
+        var lhs = builder.LeftHandSide();
 
-            var patternBuilder1 = lhs.Pattern(typeof(FactType1), "fact1");
-            Expression<Func<FactType1, bool>> condition11 = fact1 => fact1.TestProperty.StartsWith("Valid");
-            patternBuilder1.Condition(condition11);
+        var patternBuilder1 = lhs.Pattern(typeof(FactType1), "fact1");
+        Expression<Func<FactType1, bool>> condition11 = fact1 => fact1.TestProperty.StartsWith("Valid");
+        patternBuilder1.Condition(condition11);
 
-            var patternBuilder2 = lhs.Pattern(typeof(FactType2), "fact2");
-            Expression<Func<FactType2, bool>> condition21 = fact2 => fact2.TestProperty.StartsWith("Valid");
-            patternBuilder2.Condition(condition21);
-            Expression<Func<FactType1, FactType2, bool>> condition22 = (fact1, fact2) => fact2.JoinProperty == fact1.TestProperty;
-            patternBuilder2.Condition(condition22);
+        var patternBuilder2 = lhs.Pattern(typeof(FactType2), "fact2");
+        Expression<Func<FactType2, bool>> condition21 = fact2 => fact2.TestProperty.StartsWith("Valid");
+        patternBuilder2.Condition(condition21);
+        Expression<Func<FactType1, FactType2, bool>> condition22 = (fact1, fact2) => fact2.JoinProperty == fact1.TestProperty;
+        patternBuilder2.Condition(condition22);
 
-            Expression<Func<FactType1, bool>> filter1 = fact1 => fact1.TestProperty == "Valid Value";
-            builder.Filters().Filter(FilterType.Predicate, filter1);
+        Expression<Func<FactType1, bool>> filter1 = fact1 => fact1.TestProperty == "Valid Value";
+        builder.Filters().Filter(FilterType.Predicate, filter1);
 
-            Expression<Action<IContext, FactType1, FactType2>> action = (context, fact1, fact2) => NoOp();
-            builder.RightHandSide().Action(action);
+        Expression<Action<IContext, FactType1, FactType2>> action = (context, fact1, fact2) => NoOp();
+        builder.RightHandSide().Action(action);
 
-            //Act
-            var rule = builder.Build();
+        //Act
+        var rule = builder.Build();
 
-            //Assert
-            Assert.Equal(2, rule.LeftHandSide.ChildElements.Count());
-        }
-
-        [Fact]
-        public void Build_InvalidConditionDependency_Throws()
-        {
-            //Arrange
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
-
-            var lhs = builder.LeftHandSide();
-
-            var patternBuilder1 = lhs.Pattern(typeof(FactType1), "fact1");
-            Expression<Func<FactType1, bool>> condition11 = invalidName => invalidName.TestProperty.StartsWith("Valid");
-            patternBuilder1.Condition(condition11);
-            
-            Expression<Action<IContext>> action = context => NoOp();
-            builder.RightHandSide().Action(action);
-
-            //Act - Assert
-            var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
-            Assert.Equal("Undefined variables in rule match conditions. Variables=invalidName", ex.Message);
-        }
-
-        [Fact]
-        public void Build_InvalidFilterDependency_Throws()
-        {
-            //Arrange
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
-
-            var lhs = builder.LeftHandSide();
-
-            var patternBuilder1 = lhs.Pattern(typeof(FactType1), "fact1");
-            Expression<Func<FactType1, bool>> condition11 = fact1 => fact1.TestProperty.StartsWith("Valid");
-            patternBuilder1.Condition(condition11);
-            
-            Expression<Func<FactType1, bool>> filter1 = invalidName => invalidName.TestProperty == "Valid Value";
-            builder.Filters().Filter(FilterType.Predicate, filter1);
-
-            Expression<Action<IContext>> action = context => NoOp();
-            builder.RightHandSide().Action(action);
-
-            //Act - Assert
-            var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
-            Assert.Equal("Undefined variables in rule filter. Variables=invalidName", ex.Message);
-        }
-
-        [Fact]
-        public void Build_InvalidActionDependency_Throws()
-        {
-            //Arrange
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
-
-            var lhs = builder.LeftHandSide();
-
-            var patternBuilder1 = lhs.Pattern(typeof(FactType1), "fact1");
-            Expression<Func<FactType1, bool>> condition11 = fact1 => fact1.TestProperty.StartsWith("Valid");
-            patternBuilder1.Condition(condition11);
-            
-            Expression<Action<IContext, FactType1>> action = (context, invalidName) => NoOp();
-            builder.RightHandSide().Action(action);
-
-            //Act - Assert
-            var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
-            Assert.Equal("Undefined variables in rule actions. Variables=invalidName", ex.Message);
-        }
-        
-        [Fact]
-        public void Build_DuplicatePatternDefinition_Throws()
-        {
-            //Arrange
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
-
-            var lhs = builder.LeftHandSide();
-            lhs.Pattern(typeof(FactType1), "fact1");
-            lhs.Pattern(typeof(FactType2), "fact1");
-            
-            Expression<Action<IContext>> action = (context) => NoOp();
-            builder.RightHandSide().Action(action);
-
-            //Act - Assert
-            var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
-            Assert.Equal("Duplicate declarations. Declaration=fact1", ex.Message);
-        }
-        
-        [Fact]
-        public void Build_DuplicatePatternAndDependencyDefinition_Throws()
-        {
-            //Arrange
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
-
-            var dgb = builder.Dependencies();
-            dgb.Dependency(typeof(ITestService), "variable1");
-
-            var lhs = builder.LeftHandSide();
-            lhs.Pattern(typeof(FactType1), "variable1");
-            
-            Expression<Action<IContext>> action = (context) => NoOp();
-            builder.RightHandSide().Action(action);
-
-            //Act - Assert
-            var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
-            Assert.Equal("Duplicate declarations. Declaration=variable1", ex.Message);
-        }
-        
-        [Fact]
-        public void Build_DuplicateDependencyDefinition_Throws()
-        {
-            //Arrange
-            var builder = new RuleBuilder();
-            builder.Name("Test Rule");
-
-            var dgb = builder.Dependencies();
-            dgb.Dependency(typeof(ITestService), "variable1");
-            dgb.Dependency(typeof(ITestService), "variable1");
-
-            var lhs = builder.LeftHandSide();
-            lhs.Pattern(typeof(FactType1), "fact1");
-            
-            Expression<Action<IContext>> action = (context) => NoOp();
-            builder.RightHandSide().Action(action);
-
-            //Act - Assert
-            var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
-            Assert.Equal("Duplicate declarations. Declaration=variable1", ex.Message);
-        }
-
-        internal static void NoOp()
-        {
-        }
-
-        public class FactType1
-        {
-            public string TestProperty { get; set; }
-        }
-
-        public class FactType2
-        {
-            public string TestProperty { get; set; }
-            public string JoinProperty { get; set; }
-        }
-
-        public interface ITestService
-        {
-        }    
+        //Assert
+        Assert.Equal(2, rule.LeftHandSide.ChildElements.Count());
     }
+
+    [Fact]
+    public void Build_InvalidConditionDependency_Throws()
+    {
+        //Arrange
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
+
+        var lhs = builder.LeftHandSide();
+
+        var patternBuilder1 = lhs.Pattern(typeof(FactType1), "fact1");
+        Expression<Func<FactType1, bool>> condition11 = invalidName => invalidName.TestProperty.StartsWith("Valid");
+        patternBuilder1.Condition(condition11);
+        
+        Expression<Action<IContext>> action = context => NoOp();
+        builder.RightHandSide().Action(action);
+
+        //Act - Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
+        Assert.Equal("Undefined variables in rule match conditions. Variables=invalidName", ex.Message);
+    }
+
+    [Fact]
+    public void Build_InvalidFilterDependency_Throws()
+    {
+        //Arrange
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
+
+        var lhs = builder.LeftHandSide();
+
+        var patternBuilder1 = lhs.Pattern(typeof(FactType1), "fact1");
+        Expression<Func<FactType1, bool>> condition11 = fact1 => fact1.TestProperty.StartsWith("Valid");
+        patternBuilder1.Condition(condition11);
+        
+        Expression<Func<FactType1, bool>> filter1 = invalidName => invalidName.TestProperty == "Valid Value";
+        builder.Filters().Filter(FilterType.Predicate, filter1);
+
+        Expression<Action<IContext>> action = context => NoOp();
+        builder.RightHandSide().Action(action);
+
+        //Act - Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
+        Assert.Equal("Undefined variables in rule filter. Variables=invalidName", ex.Message);
+    }
+
+    [Fact]
+    public void Build_InvalidActionDependency_Throws()
+    {
+        //Arrange
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
+
+        var lhs = builder.LeftHandSide();
+
+        var patternBuilder1 = lhs.Pattern(typeof(FactType1), "fact1");
+        Expression<Func<FactType1, bool>> condition11 = fact1 => fact1.TestProperty.StartsWith("Valid");
+        patternBuilder1.Condition(condition11);
+        
+        Expression<Action<IContext, FactType1>> action = (context, invalidName) => NoOp();
+        builder.RightHandSide().Action(action);
+
+        //Act - Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
+        Assert.Equal("Undefined variables in rule actions. Variables=invalidName", ex.Message);
+    }
+    
+    [Fact]
+    public void Build_DuplicatePatternDefinition_Throws()
+    {
+        //Arrange
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
+
+        var lhs = builder.LeftHandSide();
+        lhs.Pattern(typeof(FactType1), "fact1");
+        lhs.Pattern(typeof(FactType2), "fact1");
+        
+        Expression<Action<IContext>> action = (context) => NoOp();
+        builder.RightHandSide().Action(action);
+
+        //Act - Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
+        Assert.Equal("Duplicate declarations. Declaration=fact1", ex.Message);
+    }
+    
+    [Fact]
+    public void Build_DuplicatePatternAndDependencyDefinition_Throws()
+    {
+        //Arrange
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
+
+        var dgb = builder.Dependencies();
+        dgb.Dependency(typeof(ITestService), "variable1");
+
+        var lhs = builder.LeftHandSide();
+        lhs.Pattern(typeof(FactType1), "variable1");
+        
+        Expression<Action<IContext>> action = (context) => NoOp();
+        builder.RightHandSide().Action(action);
+
+        //Act - Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
+        Assert.Equal("Duplicate declarations. Declaration=variable1", ex.Message);
+    }
+    
+    [Fact]
+    public void Build_DuplicateDependencyDefinition_Throws()
+    {
+        //Arrange
+        var builder = new RuleBuilder();
+        builder.Name("Test Rule");
+
+        var dgb = builder.Dependencies();
+        dgb.Dependency(typeof(ITestService), "variable1");
+        dgb.Dependency(typeof(ITestService), "variable1");
+
+        var lhs = builder.LeftHandSide();
+        lhs.Pattern(typeof(FactType1), "fact1");
+        
+        Expression<Action<IContext>> action = (context) => NoOp();
+        builder.RightHandSide().Action(action);
+
+        //Act - Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
+        Assert.Equal("Duplicate declarations. Declaration=variable1", ex.Message);
+    }
+
+    internal static void NoOp()
+    {
+    }
+
+    public class FactType1
+    {
+        public string TestProperty { get; set; }
+    }
+
+    public class FactType2
+    {
+        public string TestProperty { get; set; }
+        public string JoinProperty { get; set; }
+    }
+
+    public interface ITestService
+    {
+    }    
 }

--- a/src/NRules/Tests/NRules.Tests/SessionTest.cs
+++ b/src/NRules/Tests/NRules.Tests/SessionTest.cs
@@ -7,509 +7,508 @@ using NRules.Extensibility;
 using NRules.Rete;
 using Xunit;
 
-namespace NRules.Tests
+namespace NRules.Tests;
+
+public class SessionTest
 {
-    public class SessionTest
+    private readonly Mock<IAgendaInternal> _agenda;
+    private readonly Mock<INetwork> _network;
+    private readonly Mock<IWorkingMemory> _workingMemory;
+    private readonly Mock<IEventAggregator> _eventAggregator;
+    private readonly Mock<IMetricsAggregator> _metricsAggregator;
+    private readonly Mock<IActionExecutor> _actionExecutor;
+    private readonly Mock<IIdGenerator> _idGenerator;
+    private readonly Mock<IDependencyResolver> _dependencyResolver;
+    private readonly Mock<IActionInterceptor> _actionInterceptor;
+        
+    public SessionTest()
     {
-        private readonly Mock<IAgendaInternal> _agenda;
-        private readonly Mock<INetwork> _network;
-        private readonly Mock<IWorkingMemory> _workingMemory;
-        private readonly Mock<IEventAggregator> _eventAggregator;
-        private readonly Mock<IMetricsAggregator> _metricsAggregator;
-        private readonly Mock<IActionExecutor> _actionExecutor;
-        private readonly Mock<IIdGenerator> _idGenerator;
-        private readonly Mock<IDependencyResolver> _dependencyResolver;
-        private readonly Mock<IActionInterceptor> _actionInterceptor;
-            
-        public SessionTest()
-        {
-            _agenda = new Mock<IAgendaInternal>();
-            _network = new Mock<INetwork>();
-            _workingMemory = new Mock<IWorkingMemory>();
-            _eventAggregator = new Mock<IEventAggregator>();
-            _metricsAggregator = new Mock<IMetricsAggregator>();
-            _actionExecutor = new Mock<IActionExecutor>();
-            _idGenerator = new Mock<IIdGenerator>();
-            _dependencyResolver = new Mock<IDependencyResolver>();
-            _actionInterceptor = new Mock<IActionInterceptor>();
-        }
+        _agenda = new Mock<IAgendaInternal>();
+        _network = new Mock<INetwork>();
+        _workingMemory = new Mock<IWorkingMemory>();
+        _eventAggregator = new Mock<IEventAggregator>();
+        _metricsAggregator = new Mock<IMetricsAggregator>();
+        _actionExecutor = new Mock<IActionExecutor>();
+        _idGenerator = new Mock<IIdGenerator>();
+        _dependencyResolver = new Mock<IDependencyResolver>();
+        _actionInterceptor = new Mock<IActionInterceptor>();
+    }
 
-        [Fact]
-        public void Insert_FactDoesNotExist_PropagatesAssert()
+    [Fact]
+    public void Insert_FactDoesNotExist_PropagatesAssert()
+    {
+        // Arrange
+        var fact = new object();
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(fact)).Returns(() => null);
+
+        // Act
+        target.Insert(fact);
+
+        // Assert
+        _network.Verify(x => x.PropagateAssert(
+                It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
+                It.Is<List<Fact>>(p => p.Count == 1 && p[0].Object == fact)),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public void InsertAll_FactsDoNotExist_PropagatesAssert()
+    {
+        // Arrange
+        var facts = new[] { new object(), new object() };
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns(() => null);
+
+        // Act
+        target.InsertAll(facts);
+
+        // Assert
+        _network.Verify(x => x.PropagateAssert(
+                It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
+                It.Is<List<Fact>>(p => p.Count == 2 && p[0].Object == facts[0] && p[1].Object == facts[1])),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public void InsertAll_SomeFactsExist_Throws()
+    {
+        // Arrange
+        var facts = new[] { new object(), new object() };
+        var factWrappers = new Dictionary<object, Fact>
+        {
+            {facts[0], new Fact(facts[0])},
+            {facts[1], null}
+        };
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
+
+        // Act - Assert
+        Assert.Throws<ArgumentException>(() => target.InsertAll(facts));
+    }
+
+    [Fact]
+    public void TryInsertAll_SomeFactsExistOptionsAllOrNothing_DoesNotPropagateAssert()
+    {
+        // Arrange
+        var facts = new[] { new object(), new object() };
+        var factWrappers = new Dictionary<object, Fact>
+        {
+            {facts[0], new Fact(facts[0])},
+            {facts[1], null}
+        };
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
+
+        // Act
+        var result = target.TryInsertAll(facts, BatchOptions.AllOrNothing);
+
+        // Assert
+        Assert.Equal(1, result.FailedCount);
+        _network.Verify(x => x.PropagateAssert(
+                It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
+                It.IsAny<List<Fact>>()),
+            Times.Never());
+    }
+
+    [Fact]
+    public void TryInsertAll_SomeFactsExistOptionsSkipFailed_PropagatesAssertForNonFailed()
+    {
+        // Arrange
+        var facts = new[] { new object(), new object() };
+        var factWrappers = new Dictionary<object, Fact>
+        {
+            {facts[0], new Fact(facts[0])},
+            {facts[1], null}
+        };
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
+
+        // Act
+        var result = target.TryInsertAll(facts, BatchOptions.SkipFailed);
+
+        // Assert
+        Assert.Equal(1, result.FailedCount);
+        _network.Verify(x => x.PropagateAssert(
+                It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
+                It.Is<List<Fact>>(p => p.Count == 1 && p[0].Object == facts[1])),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public void Update_FactExists_PropagatesUpdate()
+    {
+        // Arrange
+        var fact = new object();
+        var factWrapper = new Fact(fact);
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(fact)).Returns(factWrapper);
+
+        // Act
+        target.Update(fact);
+
+        // Assert
+        _network.Verify(x => x.PropagateUpdate(
+                It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
+                It.Is<List<Fact>>(p => p.Count == 1 && p[0].Object == fact)),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public void UpdateAll_FactsExist_PropagatesUpdate()
+    {
+        // Arrange
+        var facts = new[] { new object(), new object() };
+        var factWrappers = new Dictionary<object, Fact>
+        {
+            {facts[0], new Fact(facts[0])},
+            {facts[1], new Fact(facts[1])}
+        };
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
+
+        // Act
+        target.UpdateAll(facts);
+
+        // Assert
+        _network.Verify(x => x.PropagateUpdate(
+                It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
+                It.Is<List<Fact>>(p => p.Count == 2 && p[0].Object == facts[0] && p[1].Object == facts[1])),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public void UpdateAll_SomeFactsDoNotExist_Throws()
+    {
+        // Arrange
+        var facts = new[] {new object(), new object()};
+        var factWrappers = new Dictionary<object, Fact>
+        {
+            {facts[0], new Fact(facts[0])},
+            {facts[1], null}
+        };
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
+
+        // Act - Assert
+        Assert.Throws<ArgumentException>(() => target.UpdateAll(facts));
+    }
+
+    [Fact]
+    public void TryUpdateAll_SomeFactsDoNotExistOptionsAllOrNothing_DoesNotPropagateUpdate()
+    {
+        // Arrange
+        var facts = new[] { new object(), new object() };
+        var factWrappers = new Dictionary<object, Fact>
+        {
+            {facts[0], new Fact(facts[0])},
+            {facts[1], null}
+        };
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
+
+        // Act
+        var result = target.TryUpdateAll(facts, BatchOptions.AllOrNothing);
+
+        // Assert
+        Assert.Equal(1, result.FailedCount);
+        _network.Verify(x => x.PropagateUpdate(
+                It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
+                It.IsAny<List<Fact>>()),
+            Times.Never());
+    }
+
+    [Fact]
+    public void TryUpdateAll_SomeFactsDoNotExistOptionsSkipFailed_PropagateUpdateNonFailed()
+    {
+        // Arrange
+        var facts = new[] { new object(), new object() };
+        var factWrappers = new Dictionary<object, Fact>
+        {
+            {facts[0], new Fact(facts[0])},
+            {facts[1], null}
+        };
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
+
+        // Act
+        var result = target.TryUpdateAll(facts, BatchOptions.SkipFailed);
+
+        // Assert
+        Assert.Equal(1, result.FailedCount);
+        _network.Verify(x => x.PropagateUpdate(
+                It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
+                It.Is<List<Fact>>(p => p.Count == 1 && p[0].Object == facts[0])),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public void Retract_FactExists_PropagatesRetract()
+    {
+        // Arrange
+        var fact = new object();
+        var factWrapper = new Fact(fact);
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(fact)).Returns(factWrapper);
+
+        // Act
+        target.Retract(fact);
+
+        // Assert
+        _network.Verify(x => x.PropagateRetract(
+                It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
+                It.Is<List<Fact>>(p => p.Count == 1 && p[0] == factWrapper)),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public void RetractAll_FactsExist_PropagatesRetract()
+    {
+        // Arrange
+        var facts = new[] { new object(), new object() };
+        var factWrappers = new Dictionary<object, Fact>
+        {
+            {facts[0], new Fact(facts[0])},
+            {facts[1], new Fact(facts[1])}
+        };
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
+
+        // Act
+        target.RetractAll(facts);
+
+        // Assert
+        _network.Verify(x => x.PropagateRetract(
+                It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
+                It.Is<List<Fact>>(p => p.Count == 2 && p[0].Object == facts[0] && p[1].Object == facts[1])),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public void RetractAll_SomeFactsDoNotExist_Throws()
+    {
+        // Arrange
+        var facts = new[] { new object(), new object() };
+        var factWrappers = new Dictionary<object, Fact>
+        {
+            {facts[0], new Fact(facts[0])},
+            {facts[1], null}
+        };
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
+
+        // Act - Assert
+        Assert.Throws<ArgumentException>(() => target.RetractAll(facts));
+    }
+
+
+    [Fact]
+    public void TryRetractAll_SomeFactsDoNotExistOptionsAllOrNothing_DoesNotPropagateRetract()
+    {
+        // Arrange
+        var facts = new[] { new object(), new object() };
+        var factWrappers = new Dictionary<object, Fact>
+        {
+            {facts[0], new Fact(facts[0])},
+            {facts[1], null}
+        };
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
+
+        // Act
+        var result = target.TryRetractAll(facts, BatchOptions.AllOrNothing);
+
+        // Assert
+        Assert.Equal(1, result.FailedCount);
+        _network.Verify(x => x.PropagateRetract(
+                It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
+                It.IsAny<List<Fact>>()),
+            Times.Never());
+    }
+
+    [Fact]
+    public void TryRetractAll_SomeFactsDoNotExistOptionsSkipFailed_PropagateRetractNonFailed()
+    {
+        // Arrange
+        var facts = new[] { new object(), new object() };
+        var factWrappers = new Dictionary<object, Fact>
+        {
+            {facts[0], new Fact(facts[0])},
+            {facts[1], null}
+        };
+        var target = CreateTarget();
+        _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
+
+        // Act
+        var result = target.TryRetractAll(facts, BatchOptions.SkipFailed);
+
+        // Assert
+        Assert.Equal(1, result.FailedCount);
+        _network.Verify(x => x.PropagateRetract(
+                It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
+                It.Is<List<Fact>>(p => p.Count == 1 && p[0].Object == facts[0])),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public void Fire_NoActiveRules_ReturnsZero()
+    {
+        // Arrange
+        var target = CreateTarget();
+        _agenda.Setup(x => x.IsEmpty).Returns(true);
+
+        // Act
+        var actual = target.Fire();
+
+        // Assert
+        Assert.Equal(0, actual);
+    }
+
+    [Fact]
+    public void Fire_ActiveRules_ReturnsNumberOfRulesFired()
+    {
+        // Arrange
+        var target = CreateTarget();
+        _agenda.Setup(x => x.Pop()).Returns(StubActivation());
+        _agenda.SetupSequence(x => x.IsEmpty)
+            .Returns(false).Returns(false).Returns(true);
+
+        // Act
+        var actual = target.Fire();
+
+        // Assert
+        Assert.Equal(2, actual);
+    }
+
+    [Fact]
+    public void Fire_ActiveRulesMoreThanMax_FiresMaxRules()
+    {
+        // Arrange
+        var target = CreateTarget();
+        _agenda.Setup(x => x.Pop()).Returns(StubActivation());
+        _agenda.SetupSequence(x => x.IsEmpty)
+            .Returns(false).Returns(false).Returns(true);
+
+        // Act
+        var actual = target.Fire(1);
+
+        // Assert
+        Assert.Equal(1, actual);
+    }
+
+    [Fact]
+    public void Fire_CancellationRequested()
+    {
+        using (var cancellationSource = new CancellationTokenSource())
         {
             // Arrange
-            var fact = new object();
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(fact)).Returns(() => null);
-
-            // Act
-            target.Insert(fact);
-
-            // Assert
-            _network.Verify(x => x.PropagateAssert(
-                    It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
-                    It.Is<List<Fact>>(p => p.Count == 1 && p[0].Object == fact)),
-                Times.Exactly(1));
-        }
-
-        [Fact]
-        public void InsertAll_FactsDoNotExist_PropagatesAssert()
-        {
-            // Arrange
-            var facts = new[] { new object(), new object() };
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns(() => null);
-
-            // Act
-            target.InsertAll(facts);
-
-            // Assert
-            _network.Verify(x => x.PropagateAssert(
-                    It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
-                    It.Is<List<Fact>>(p => p.Count == 2 && p[0].Object == facts[0] && p[1].Object == facts[1])),
-                Times.Exactly(1));
-        }
-
-        [Fact]
-        public void InsertAll_SomeFactsExist_Throws()
-        {
-            // Arrange
-            var facts = new[] { new object(), new object() };
-            var factWrappers = new Dictionary<object, Fact>
-            {
-                {facts[0], new Fact(facts[0])},
-                {facts[1], null}
-            };
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
-
-            // Act - Assert
-            Assert.Throws<ArgumentException>(() => target.InsertAll(facts));
-        }
-
-        [Fact]
-        public void TryInsertAll_SomeFactsExistOptionsAllOrNothing_DoesNotPropagateAssert()
-        {
-            // Arrange
-            var facts = new[] { new object(), new object() };
-            var factWrappers = new Dictionary<object, Fact>
-            {
-                {facts[0], new Fact(facts[0])},
-                {facts[1], null}
-            };
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
-
-            // Act
-            var result = target.TryInsertAll(facts, BatchOptions.AllOrNothing);
-
-            // Assert
-            Assert.Equal(1, result.FailedCount);
-            _network.Verify(x => x.PropagateAssert(
-                    It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
-                    It.IsAny<List<Fact>>()),
-                Times.Never());
-        }
-
-        [Fact]
-        public void TryInsertAll_SomeFactsExistOptionsSkipFailed_PropagatesAssertForNonFailed()
-        {
-            // Arrange
-            var facts = new[] { new object(), new object() };
-            var factWrappers = new Dictionary<object, Fact>
-            {
-                {facts[0], new Fact(facts[0])},
-                {facts[1], null}
-            };
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
-
-            // Act
-            var result = target.TryInsertAll(facts, BatchOptions.SkipFailed);
-
-            // Assert
-            Assert.Equal(1, result.FailedCount);
-            _network.Verify(x => x.PropagateAssert(
-                    It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
-                    It.Is<List<Fact>>(p => p.Count == 1 && p[0].Object == facts[1])),
-                Times.Exactly(1));
-        }
-
-        [Fact]
-        public void Update_FactExists_PropagatesUpdate()
-        {
-            // Arrange
-            var fact = new object();
-            var factWrapper = new Fact(fact);
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(fact)).Returns(factWrapper);
-
-            // Act
-            target.Update(fact);
-
-            // Assert
-            _network.Verify(x => x.PropagateUpdate(
-                    It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
-                    It.Is<List<Fact>>(p => p.Count == 1 && p[0].Object == fact)),
-                Times.Exactly(1));
-        }
-
-        [Fact]
-        public void UpdateAll_FactsExist_PropagatesUpdate()
-        {
-            // Arrange
-            var facts = new[] { new object(), new object() };
-            var factWrappers = new Dictionary<object, Fact>
-            {
-                {facts[0], new Fact(facts[0])},
-                {facts[1], new Fact(facts[1])}
-            };
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
-
-            // Act
-            target.UpdateAll(facts);
-
-            // Assert
-            _network.Verify(x => x.PropagateUpdate(
-                    It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
-                    It.Is<List<Fact>>(p => p.Count == 2 && p[0].Object == facts[0] && p[1].Object == facts[1])),
-                Times.Exactly(1));
-        }
-
-        [Fact]
-        public void UpdateAll_SomeFactsDoNotExist_Throws()
-        {
-            // Arrange
-            var facts = new[] {new object(), new object()};
-            var factWrappers = new Dictionary<object, Fact>
-            {
-                {facts[0], new Fact(facts[0])},
-                {facts[1], null}
-            };
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
-
-            // Act - Assert
-            Assert.Throws<ArgumentException>(() => target.UpdateAll(facts));
-        }
-
-        [Fact]
-        public void TryUpdateAll_SomeFactsDoNotExistOptionsAllOrNothing_DoesNotPropagateUpdate()
-        {
-            // Arrange
-            var facts = new[] { new object(), new object() };
-            var factWrappers = new Dictionary<object, Fact>
-            {
-                {facts[0], new Fact(facts[0])},
-                {facts[1], null}
-            };
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
-
-            // Act
-            var result = target.TryUpdateAll(facts, BatchOptions.AllOrNothing);
-
-            // Assert
-            Assert.Equal(1, result.FailedCount);
-            _network.Verify(x => x.PropagateUpdate(
-                    It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
-                    It.IsAny<List<Fact>>()),
-                Times.Never());
-        }
-
-        [Fact]
-        public void TryUpdateAll_SomeFactsDoNotExistOptionsSkipFailed_PropagateUpdateNonFailed()
-        {
-            // Arrange
-            var facts = new[] { new object(), new object() };
-            var factWrappers = new Dictionary<object, Fact>
-            {
-                {facts[0], new Fact(facts[0])},
-                {facts[1], null}
-            };
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
-
-            // Act
-            var result = target.TryUpdateAll(facts, BatchOptions.SkipFailed);
-
-            // Assert
-            Assert.Equal(1, result.FailedCount);
-            _network.Verify(x => x.PropagateUpdate(
-                    It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
-                    It.Is<List<Fact>>(p => p.Count == 1 && p[0].Object == facts[0])),
-                Times.Exactly(1));
-        }
-
-        [Fact]
-        public void Retract_FactExists_PropagatesRetract()
-        {
-            // Arrange
-            var fact = new object();
-            var factWrapper = new Fact(fact);
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(fact)).Returns(factWrapper);
-
-            // Act
-            target.Retract(fact);
-
-            // Assert
-            _network.Verify(x => x.PropagateRetract(
-                    It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
-                    It.Is<List<Fact>>(p => p.Count == 1 && p[0] == factWrapper)),
-                Times.Exactly(1));
-        }
-
-        [Fact]
-        public void RetractAll_FactsExist_PropagatesRetract()
-        {
-            // Arrange
-            var facts = new[] { new object(), new object() };
-            var factWrappers = new Dictionary<object, Fact>
-            {
-                {facts[0], new Fact(facts[0])},
-                {facts[1], new Fact(facts[1])}
-            };
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
-
-            // Act
-            target.RetractAll(facts);
-
-            // Assert
-            _network.Verify(x => x.PropagateRetract(
-                    It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
-                    It.Is<List<Fact>>(p => p.Count == 2 && p[0].Object == facts[0] && p[1].Object == facts[1])),
-                Times.Exactly(1));
-        }
-
-        [Fact]
-        public void RetractAll_SomeFactsDoNotExist_Throws()
-        {
-            // Arrange
-            var facts = new[] { new object(), new object() };
-            var factWrappers = new Dictionary<object, Fact>
-            {
-                {facts[0], new Fact(facts[0])},
-                {facts[1], null}
-            };
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
-
-            // Act - Assert
-            Assert.Throws<ArgumentException>(() => target.RetractAll(facts));
-        }
-
-
-        [Fact]
-        public void TryRetractAll_SomeFactsDoNotExistOptionsAllOrNothing_DoesNotPropagateRetract()
-        {
-            // Arrange
-            var facts = new[] { new object(), new object() };
-            var factWrappers = new Dictionary<object, Fact>
-            {
-                {facts[0], new Fact(facts[0])},
-                {facts[1], null}
-            };
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
-
-            // Act
-            var result = target.TryRetractAll(facts, BatchOptions.AllOrNothing);
-
-            // Assert
-            Assert.Equal(1, result.FailedCount);
-            _network.Verify(x => x.PropagateRetract(
-                    It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
-                    It.IsAny<List<Fact>>()),
-                Times.Never());
-        }
-
-        [Fact]
-        public void TryRetractAll_SomeFactsDoNotExistOptionsSkipFailed_PropagateRetractNonFailed()
-        {
-            // Arrange
-            var facts = new[] { new object(), new object() };
-            var factWrappers = new Dictionary<object, Fact>
-            {
-                {facts[0], new Fact(facts[0])},
-                {facts[1], null}
-            };
-            var target = CreateTarget();
-            _workingMemory.Setup(x => x.GetFact(It.IsAny<object>())).Returns<object>(x => factWrappers[x]);
-
-            // Act
-            var result = target.TryRetractAll(facts, BatchOptions.SkipFailed);
-
-            // Assert
-            Assert.Equal(1, result.FailedCount);
-            _network.Verify(x => x.PropagateRetract(
-                    It.Is<IExecutionContext>(p => p.WorkingMemory == _workingMemory.Object),
-                    It.Is<List<Fact>>(p => p.Count == 1 && p[0].Object == facts[0])),
-                Times.Exactly(1));
-        }
-
-        [Fact]
-        public void Fire_NoActiveRules_ReturnsZero()
-        {
-            // Arrange
-            var target = CreateTarget();
-            _agenda.Setup(x => x.IsEmpty).Returns(true);
-
-            // Act
-            var actual = target.Fire();
-
-            // Assert
-            Assert.Equal(0, actual);
-        }
-
-        [Fact]
-        public void Fire_ActiveRules_ReturnsNumberOfRulesFired()
-        {
-            // Arrange
+            var hitCount = 0;
             var target = CreateTarget();
             _agenda.Setup(x => x.Pop()).Returns(StubActivation());
-            _agenda.SetupSequence(x => x.IsEmpty)
-                .Returns(false).Returns(false).Returns(true);
+            _agenda
+                .Setup(x => x.IsEmpty)
+                .Returns(() =>
+                {
+                    if (++hitCount == 2)
+                    {
+                        cancellationSource.Cancel();
+                    }
+
+                    return hitCount >= 5;
+                });
 
             // Act
-            var actual = target.Fire();
+            var actual = target.Fire(cancellationSource.Token);
 
             // Assert
             Assert.Equal(2, actual);
+            _actionExecutor.Verify(ae => ae.Execute(It.IsAny<IExecutionContext>(), It.Is<IActionContext>(ac => ac.CancellationToken == cancellationSource.Token)));
         }
+    }
 
-        [Fact]
-        public void Fire_ActiveRulesMoreThanMax_FiresMaxRules()
+    [Fact]
+    public void Fire_CancellationRequested_WithMaxRules()
+    {
+        using (var cancellationSource = new CancellationTokenSource())
+        {
+            // Arrange
+            var hitCount = 0;
+            var target = CreateTarget();
+            _agenda.Setup(x => x.Pop()).Returns(StubActivation());
+            _agenda
+                .Setup(x => x.IsEmpty)
+                .Returns(() =>
+                {
+                    if (++hitCount == 2)
+                    {
+                        cancellationSource.Cancel();
+                    }
+
+                    return hitCount >= 5;
+                });
+
+            // Act
+            var actual = target.Fire(5, cancellationSource.Token);
+
+            // Assert
+            Assert.Equal(2, actual);
+            _actionExecutor.Verify(ae => ae.Execute(It.IsAny<IExecutionContext>(), It.Is<IActionContext>(ac => ac.CancellationToken == cancellationSource.Token)));
+        }
+    }
+
+    [Fact]
+    public void Fire_PassesCancellationTokenToActionContext()
+    {
+        using (var cancellationSource = new CancellationTokenSource())
         {
             // Arrange
             var target = CreateTarget();
             _agenda.Setup(x => x.Pop()).Returns(StubActivation());
             _agenda.SetupSequence(x => x.IsEmpty)
-                .Returns(false).Returns(false).Returns(true);
+                .Returns(false).Returns(true);
 
             // Act
-            var actual = target.Fire(1);
+            var actual = target.Fire(cancellationSource.Token);
 
             // Assert
             Assert.Equal(1, actual);
+            _actionExecutor.Verify(ae => ae.Execute(It.IsAny<IExecutionContext>(), It.Is<IActionContext>(ac => ac.CancellationToken == cancellationSource.Token)));
         }
+    }
 
-        [Fact]
-        public void Fire_CancellationRequested()
+    [Fact]
+    public void Fire_PassesCancellationTokenToActionContext_WithMaxRules()
+    {
+        using (var cancellationSource = new CancellationTokenSource())
         {
-            using (var cancellationSource = new CancellationTokenSource())
-            {
-                // Arrange
-                var hitCount = 0;
-                var target = CreateTarget();
-                _agenda.Setup(x => x.Pop()).Returns(StubActivation());
-                _agenda
-                    .Setup(x => x.IsEmpty)
-                    .Returns(() =>
-                    {
-                        if (++hitCount == 2)
-                        {
-                            cancellationSource.Cancel();
-                        }
+            // Arrange
+            var target = CreateTarget();
+            _agenda.Setup(x => x.Pop()).Returns(StubActivation());
+            _agenda.SetupSequence(x => x.IsEmpty)
+                .Returns(false).Returns(true);
 
-                        return hitCount >= 5;
-                    });
+            // Act
+            var actual = target.Fire(2, cancellationSource.Token);
 
-                // Act
-                var actual = target.Fire(cancellationSource.Token);
-
-                // Assert
-                Assert.Equal(2, actual);
-                _actionExecutor.Verify(ae => ae.Execute(It.IsAny<IExecutionContext>(), It.Is<IActionContext>(ac => ac.CancellationToken == cancellationSource.Token)));
-            }
+            // Assert
+            Assert.Equal(1, actual);
+            _actionExecutor.Verify(ae => ae.Execute(It.IsAny<IExecutionContext>(), It.Is<IActionContext>(ac => ac.CancellationToken == cancellationSource.Token)));
         }
+    }
 
-        [Fact]
-        public void Fire_CancellationRequested_WithMaxRules()
-        {
-            using (var cancellationSource = new CancellationTokenSource())
-            {
-                // Arrange
-                var hitCount = 0;
-                var target = CreateTarget();
-                _agenda.Setup(x => x.Pop()).Returns(StubActivation());
-                _agenda
-                    .Setup(x => x.IsEmpty)
-                    .Returns(() =>
-                    {
-                        if (++hitCount == 2)
-                        {
-                            cancellationSource.Cancel();
-                        }
+    private Session CreateTarget()
+    {
+        var session = new Session(_network.Object, _agenda.Object, _workingMemory.Object,
+            _eventAggregator.Object, _metricsAggregator.Object, _actionExecutor.Object,
+            _idGenerator.Object, _dependencyResolver.Object, _actionInterceptor.Object);
+        return session;
+    }
 
-                        return hitCount >= 5;
-                    });
-
-                // Act
-                var actual = target.Fire(5, cancellationSource.Token);
-
-                // Assert
-                Assert.Equal(2, actual);
-                _actionExecutor.Verify(ae => ae.Execute(It.IsAny<IExecutionContext>(), It.Is<IActionContext>(ac => ac.CancellationToken == cancellationSource.Token)));
-            }
-        }
-
-        [Fact]
-        public void Fire_PassesCancellationTokenToActionContext()
-        {
-            using (var cancellationSource = new CancellationTokenSource())
-            {
-                // Arrange
-                var target = CreateTarget();
-                _agenda.Setup(x => x.Pop()).Returns(StubActivation());
-                _agenda.SetupSequence(x => x.IsEmpty)
-                    .Returns(false).Returns(true);
-
-                // Act
-                var actual = target.Fire(cancellationSource.Token);
-
-                // Assert
-                Assert.Equal(1, actual);
-                _actionExecutor.Verify(ae => ae.Execute(It.IsAny<IExecutionContext>(), It.Is<IActionContext>(ac => ac.CancellationToken == cancellationSource.Token)));
-            }
-        }
-
-        [Fact]
-        public void Fire_PassesCancellationTokenToActionContext_WithMaxRules()
-        {
-            using (var cancellationSource = new CancellationTokenSource())
-            {
-                // Arrange
-                var target = CreateTarget();
-                _agenda.Setup(x => x.Pop()).Returns(StubActivation());
-                _agenda.SetupSequence(x => x.IsEmpty)
-                    .Returns(false).Returns(true);
-
-                // Act
-                var actual = target.Fire(2, cancellationSource.Token);
-
-                // Assert
-                Assert.Equal(1, actual);
-                _actionExecutor.Verify(ae => ae.Execute(It.IsAny<IExecutionContext>(), It.Is<IActionContext>(ac => ac.CancellationToken == cancellationSource.Token)));
-            }
-        }
-
-        private Session CreateTarget()
-        {
-            var session = new Session(_network.Object, _agenda.Object, _workingMemory.Object,
-                _eventAggregator.Object, _metricsAggregator.Object, _actionExecutor.Object,
-                _idGenerator.Object, _dependencyResolver.Object, _actionInterceptor.Object);
-            return session;
-        }
-
-        private static Activation StubActivation()
-        {
-            var rule = new Mock<ICompiledRule>();
-            rule.Setup(x => x.Actions).Returns(new IRuleAction[0]);
-            var activation = new Activation(rule.Object, null);
-            return activation;
-        }
+    private static Activation StubActivation()
+    {
+        var rule = new Mock<ICompiledRule>();
+        rule.Setup(x => x.Actions).Returns(new IRuleAction[0]);
+        var activation = new Activation(rule.Object, null);
+        return activation;
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Utilities/ExpressionComparerTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Utilities/ExpressionComparerTest.cs
@@ -5,767 +5,766 @@ using System.Linq.Expressions;
 using NRules.Utilities;
 using Xunit;
 
-namespace NRules.Tests.Utilities
+namespace NRules.Tests.Utilities;
+
+public class ExpressionComparerTest
 {
-    public class ExpressionComparerTest
+    [Fact]
+    public void AreEqual_BothNull_True()
     {
-        [Fact]
-        public void AreEqual_BothNull_True()
-        {
-            AssertEqual(null, null);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentNewArray_True()
-        {
-            // Arrange
-            Expression<Func<IEnumerable<string>>> first = () => new[] {"string1", "string2"};
-            Expression<Func<IEnumerable<string>>> second = () => new[] {"string1", "string2"};
-
-            // Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentNewArray_False()
-        {
-            // Arrange
-            Expression<Func<IEnumerable<string>>> first = () => new[] {"string1", "string2", "string3"};
-            Expression<Func<IEnumerable<string>>> second = () => new[] {"string1", "string2"};
-
-            // Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentConditionalArray_True()
-        {
-            // Arrange
-            var strings = new[] {"string1", "string2"};
-            Expression<Func<IEnumerable<string>>> first = () => strings.Length > 1 ? new string[0] : strings;
-            Expression<Func<IEnumerable<string>>> second = () => strings.Length > 1 ? new string[0] : strings;
-
-            // Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentConditionalArray_False()
-        {
-            // Arrange
-            var strings = new[] {"string1", "string2"};
-            Expression<Func<IEnumerable<string>>> first = () => strings.Length > 1 ? new string[0] : strings;
-            Expression<Func<IEnumerable<string>>> second = () => strings.Length > 1 ? strings : new string[0];
-
-            // Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentConditional_True()
-        {
-            //Arrange
-            Expression<Func<int, int>> first = i1 => i1 == 1 ? 1 : 0;
-            Expression<Func<int, int>> second = i2 => i2 == 1 ? 1 : 0;
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentConditional_Test_False()
-        {
-            //Arrange
-            Expression<Func<int, int>> first = i1 => i1 == 1 ? 1 : 0;
-            Expression<Func<int, int>> second = i2 => i2 == 2 ? 1 : 0;
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentConditional_IfTrue_False()
-        {
-            //Arrange
-            Expression<Func<int, int>> first = i1 => i1 == 1 ? 1 : 0;
-            Expression<Func<int, int>> second = i2 => i2 == 1 ? 2 : 0;
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentConditional_IfFalse_False()
-        {
-            //Arrange
-            Expression<Func<int, int>> first = i1 => i1 == 1 ? 1 : 0;
-            Expression<Func<int, int>> second = i2 => i2 == 1 ? 1 : 2;
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentBinary_True()
-        {
-            //Arrange
-            Expression<Func<int, int, bool>> first = (i1, i2) => i1 == i2;
-            Expression<Func<int, int, bool>> second = (ii1, ii2) => ii1 == ii2;
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_TwoNonEquivalentBinary_False()
-        {
-            //Arrange
-            Expression<Func<int, int, bool>> first = (i1, i2) => i1 == i2;
-            Expression<Func<int, int, bool>> second = (ii1, ii2) => ii1 != ii2;
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentUnary_True()
-        {
-            //Arrange
-            Expression<Func<int, int>> first = i => -i;
-            Expression<Func<int, int>> second = i => -i;
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentMember_True()
-        {
-            //Arrange
-            Expression<Func<DateTime, DayOfWeek>> first = d => d.DayOfWeek;
-            Expression<Func<DateTime, DayOfWeek>> second = d => d.DayOfWeek;
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentMethodCall_True()
-        {
-            //Arrange
-            Expression<Func<DateTime, DateTime>> first = d => d.ToLocalTime();
-            Expression<Func<DateTime, DateTime>> second = d => d.ToLocalTime();
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentStaticField_True()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => f.Value == StaticField;
-            Expression<Func<SomeFact, bool>> second = f => f.Value == StaticField;
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_StaticFieldVsCapturedVariable_False()
-        {
-            //Arrange
-            var variable = StaticField;
-            Expression<Func<SomeFact, bool>> first = f => f.Value == variable;
-            Expression<Func<SomeFact, bool>> second = f => f.Value == StaticField;
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_CapturedVariablesPointingToSameValue_True()
-        {
-            //Arrange
-            var variable1 = 1;
-            var variable2 = 1;
-            Expression<Func<SomeFact, bool>> first = f => f.Value == variable1;
-            Expression<Func<SomeFact, bool>> second = f => f.Value == variable2;
-
-            //Act - Assert
-            AssertEqual(second, first);
-        }
-
-        [Fact]
-        public void AreEqual_CapturedVariablesPointingToDifferentValues_True()
-        {
-            //Arrange
-            var variable1 = 1;
-            var variable2 = 2;
-            Expression<Func<SomeFact, bool>> first = f => f.Value == variable1;
-            Expression<Func<SomeFact, bool>> second = f => f.Value == variable2;
-
-            //Act - Assert
-            AssertNotEqual(second, first);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentStaticProperty_True()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => f.Value == StaticProperty;
-            Expression<Func<SomeFact, bool>> second = f => f.Value == StaticProperty;
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentStaticMethod_True()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod();
-            Expression<Func<SomeFact, bool>> second = f => f.Value == StaticMethod();
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentMethodWithArguments_True()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod("one");
-            Expression<Func<SomeFact, bool>> second = f => f.Value == StaticMethod("one");
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentMethodWithArguments_False()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod("one");
-            Expression<Func<SomeFact, bool>> second = f => f.Value == StaticMethod("two");
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentMethods_False()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod("one");
-            Expression<Func<SomeFact, bool>> second = f => f.Value == OtherStaticMethod("one");
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentMemberAccessExtension_True()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => f.Child.Values.Contains("sdlkjf");
-            Expression<Func<SomeFact, bool>> second = f => f.Child.Values.Contains("sdlkjf");
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentMemberAccessExtension_False()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => f.Child.Values.Contains("abcdef");
-            Expression<Func<SomeFact, bool>> second = f => f.Child.Values.Contains("sdlkjf");
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentMemberAccess_True()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => f.Child.Values.GetLength(0) == 0;
-            Expression<Func<SomeFact, bool>> second = f => f.Child.Values.GetLength(0) == 0;
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentMemberAccess_False()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => f.Child.Values.GetLength(0) == 0;
-            Expression<Func<SomeFact, bool>> second = f => f.Child.Values.GetLength(1) == 0;
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentMemberAccessConvert_True()
-        {
-            //Arrange
-            int value = 1;
-
-            Expression<Func<SomeOtherFact, bool>> first = f => ((ISomeFact)f).Value.Equals(value);
-            Expression<Func<SomeOtherFact, bool>> second = f => ((ISomeFact)f).Value.Equals(value);
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentMemberAccessConvert_False()
-        {
-            //Arrange
-            int value1 = 1;
-            int value2 = 2;
-
-            Expression<Func<SomeOtherFact, bool>> first = f => ((ISomeFact)f).Value.Equals(value1);
-            Expression<Func<SomeOtherFact, bool>> second = f => ((ISomeFact)f).Value.Equals(value2);
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentMemberAccessIndexer_True()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => f.Child.Values[0] == "1";
-            Expression<Func<SomeFact, bool>> second = f => f.Child.Values[0] == "1";
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentMemberAccessIndexer_False()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => f.Child.Values[0] == "1";
-            Expression<Func<SomeFact, bool>> second = f => f.Child.Values[1] == "1";
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentNew_True()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => new Tuple<int>(1).Item1 == f.Value;
-            Expression<Func<SomeFact, bool>> second = f => new Tuple<int>(1).Item1 == f.Value;
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentNew_False()
-        {
-            //Arrange
-            Expression<Func<SomeFact, bool>> first = f => new Tuple<int>(1).Item1 == f.Value;
-            Expression<Func<SomeFact, bool>> second = f => new Tuple<int>(2).Item1 == f.Value;
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentMemberCall_True()
-        {
-            //Arrange
-            Expression<Func<SomeClass, bool>> first = x => x.NestedValue1().Values == null;
-            Expression<Func<SomeClass, bool>> second = y => y.NestedValue1().Values == null;
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentMemberCall_False()
-        {
-            //Arrange
-            Expression<Func<SomeClass, bool>> first = x => x.NestedValue1().Values == null;
-            Expression<Func<SomeClass, bool>> second = x => x.NestedValue2().Values == null;
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentTypeBinaryExpression_True()
-        {
-            //Arrange
-            Expression<Func<SomeClass, bool>> first = x => x is SomeClass;
-            Expression<Func<SomeClass, bool>> second = x => x is SomeClass;
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentTypeBinaryExpression_False()
-        {
-            //Arrange
-            Expression<Func<SomeClass, bool>> first = x => x is SomeClass;
-            Expression<Func<SomeClass, bool>> second = x => x is object;
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentInvocationExpression_True()
-        {
-            //Arrange
-            var methodInfo = GetType().GetMethods()
-                .First(info => info.IsStatic && info.Name == "StaticMethod"
-                               && info.GetParameters().Length == 1);
-
-            var staticMethodDelegate = (Func<string, int>) methodInfo.CreateDelegate(typeof(Func<string, int>));
-
-            Expression<Func<string, int>> first = data => staticMethodDelegate(data);
-            Expression<Func<string, int>> second = data => staticMethodDelegate(data);
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentInvocationExpression_False()
-        {
-            //Arrange
-            var methodInfos = GetType().GetMethods();
-
-            var methodInfoWithArg = methodInfos
-                .First(info => info.IsStatic && info.Name == "StaticMethod"
-                               && info.GetParameters().Length == 1);
-
-            var methodInfoWithoutArg = methodInfos
-                .First(info => info.IsStatic && info.Name == "StaticMethod"
-                               && !info.GetParameters().Any());
-
-            var staticMethodWithArgDelegate =
-                (Func<string, int>) methodInfoWithArg.CreateDelegate(typeof(Func<string, int>));
-            var staticMethodWithoutArgDelegate = (Func<int>) methodInfoWithoutArg.CreateDelegate(typeof(Func<int>));
-
-            Expression<Func<string, int>> first = data => staticMethodWithArgDelegate(data);
-            Expression<Func<int>> second = () => staticMethodWithoutArgDelegate();
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentInvocationExpressionWithSimilarSignature_False()
-        {
-            //Arrange
-            var methodInfos = GetType().GetMethods();
-
-            var methodInfoWithArg = methodInfos
-                .First(info => info.IsStatic && info.Name == "StaticMethod"
-                               && info.GetParameters().Length == 1);
-
-            var otherMethodInfoWithArg = methodInfos
-                .First(info => info.IsStatic && info.Name == "OtherStaticMethod"
-                               && info.GetParameters().Length == 1);
-
-            var staticMethodWithArgDelegate =
-                (Func<string, int>) methodInfoWithArg.CreateDelegate(typeof(Func<string, int>));
-            var otherStaticMethodWithArgDelegate =
-                (Func<string, int>) otherMethodInfoWithArg.CreateDelegate(typeof(Func<string, int>));
-
-            Expression<Func<string, int>> first = data => staticMethodWithArgDelegate(data);
-            Expression<Func<string, int>> second = data => otherStaticMethodWithArgDelegate(data);
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentMemberAssignment_True()
-        {
-            //Arrange
-            Expression<Func<SomeClassWithProperty>> first = () => new SomeClassWithProperty { Value = "A" };
-            Expression<Func<SomeClassWithProperty>> second = () => new SomeClassWithProperty { Value = "A" };
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentMemberAssignment_False()
-        {
-            //Arrange
-            Expression<Func<SomeClassWithProperty>> first = () => new SomeClassWithProperty { Value = "A" };
-            Expression<Func<SomeClassWithProperty>> second = () => new SomeClassWithProperty { Value = "B" };
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentListInitExpression_True()
-        {
-            //Arrange
-            Expression<Func<IEnumerable<string>>> first = () => new List<string> { "A" };
-            Expression<Func<IEnumerable<string>>> second = () => new List<string> { "A" };
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentListInitExpression_False()
-        {
-            //Arrange
-            Expression<Func<IEnumerable<string>>> first = () => new List<string> { "A" };
-            Expression<Func<IEnumerable<string>>> second = () => new List<string> { "B" };
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentMemberListBinding_True()
-        {
-            //Arrange
-            Expression<Func<SomeClassWithListProperty>> first = () => new SomeClassWithListProperty() { List = { "A" } };
-            Expression<Func<SomeClassWithListProperty>> second = () => new SomeClassWithListProperty { List = { "A" } };
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentMemberListBinding_False()
-        {
-            //Arrange
-            Expression<Func<SomeClassWithListProperty>> first = () => new SomeClassWithListProperty() { List = { "A" } };
-            Expression<Func<SomeClassWithListProperty>> second = () => new SomeClassWithListProperty { List = { "B" } };
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentMemberMemberBinding_True()
-        {
-            //Arrange
-            Expression<Func<SomeClassWithComplexProperty>> first = () => new SomeClassWithComplexProperty { Value = { Value = "A" } };
-            Expression<Func<SomeClassWithComplexProperty>> second = () => new SomeClassWithComplexProperty { Value = { Value = "A" } };
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentMemberMemberBinding_False()
-        {
-            //Arrange
-            Expression<Func<SomeClassWithComplexProperty>> first = () => new SomeClassWithComplexProperty { Value = { Value = "A" } };
-            Expression<Func<SomeClassWithComplexProperty>> second = () => new SomeClassWithComplexProperty { Value = { Value = "B" } };
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentSubtractMemberBinding_True()
-        {
-            //Arrange
-            Expression<Func<ISomeFact, int>> first = x => (x.Value1 - x.Value2).Day;
-            Expression<Func<ISomeFact, int>> second = x => (x.Value1 - x.Value2).Day;
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentSubtractMemberBinding_False()
-        {
-            //Arrange
-            Expression<Func<ISomeFact, int>> first = x => (x.Value1 - x.Value2).Day;
-            Expression<Func<ISomeFact, int>> second = x => (x.Value1 - x.Value2).Year;
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentAddMemberBinding_True()
-        {
-            //Arrange
-            Expression<Func<ISomeFact, int>> first = x => (x.Value1 + x.Value2).Day;
-            Expression<Func<ISomeFact, int>> second = x => (x.Value1 + x.Value2).Day;
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentAddMemberBinding_False()
-        {
-            //Arrange
-            Expression<Func<ISomeFact, int>> first = x => (x.Value1 + x.Value2).Day;
-            Expression<Func<ISomeFact, int>> second = x => (x.Value1 + x.Value2).Year;
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_EquivalentTernaryMemberBinding_True()
-        {
-            //Arrange
-            Expression<Func<ISomeFact, int>> first = x => (x.Value > 0 ? (x.Value1 - x.Value2) : x.Value1).Year;
-            Expression<Func<ISomeFact, int>> second = x => (x.Value > 0 ? (x.Value1 - x.Value2) : x.Value1).Year;
-
-            //Act - Assert
-            AssertEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_NonEquivalentTernaryMemberBinding_False()
-        {
-            //Arrange
-            Expression<Func<ISomeFact, int>> first = x => (x.Value > 0 ? (x.Value1 - x.Value2) : x.Value1).Year;
-            Expression<Func<ISomeFact, int>> second = x => (x.Value > 0 ? (x.Value1 - x.Value2) : x.Value1).Day;
-
-            //Act - Assert
-            AssertNotEqual(first, second);
-        }
-
-        [Fact]
-        public void AreEqual_UnsupportedExpressionOptionIsFailFast_Throws()
-        {
-            //Arrange
-            Expression<Action> first = Expression.Lambda<Action>(Expression.Block(Expression.Empty()));
-            Expression<Action> second = Expression.Lambda<Action>(Expression.Block(Expression.Empty()));
-
-            //Act - Assert
-            Assert.Throws<NotImplementedException>(() => AssertNotEqual(first, second, throwOnUnsupported: true));
-        }
-        
-        [Fact]
-        public void AreEqual_UnsupportedExpressionOptionIsTreatAsNotEqual_False()
-        {
-            //Arrange
-            Expression<Action> first = Expression.Lambda<Action>(Expression.Block(Expression.Empty()));
-            Expression<Action> second = Expression.Lambda<Action>(Expression.Block(Expression.Empty()));
-
-            //Act - Assert
-            AssertNotEqual(first, second, throwOnUnsupported: false);
-        }
-
-        private void AssertEqual(Expression first, Expression second)
-        {
-            //Act
-            var target = CreateTarget();
-            bool result = target.AreEqual(first, second);
-
-            //Assert
-            Assert.True(result);
-        }
-
-        private void AssertNotEqual(Expression first, Expression second, bool throwOnUnsupported = true)
-        {
-            //Act
-            var target = CreateTarget(throwOnUnsupported);
-            bool result = target.AreEqual(first, second);
-
-            //Assert
-            Assert.False(result);
-        }
-
-        public static readonly int StaticField = 1;
-
-        public static int StaticProperty => 1;
-
-        public static int StaticMethod()
-        {
-            return 1;
-        }
-
-        public static int StaticMethod(string param1)
-        {
-            return param1.GetHashCode();
-        }
-
-        public static int OtherStaticMethod(string param1)
-        {
-            return param1.GetHashCode();
-        }
-
-        public class SomeFact
-        {
-            public int Value = 1;
-
-            public readonly SomeClass Child = new();
-        }
-
-        public interface ISomeFact
-        {
-            int Value { get; set; }
-            DateTime Value1 { get; set; }
-            TimeSpan Value2 { get; set; }
-        }
-
-        public class SomeOtherFact : ISomeFact
-        {
-            int ISomeFact.Value { get; set; }
-            public DateTime Value1 { get; set; }
-            public TimeSpan Value2 { get; set; }
-        }
-
-        public class SomeClass
-        {
-            public readonly string[] Values = {"blop"};
-
-            public SomeClass NestedValue1()
-            {
-                return new SomeClass();
-            }
-
-            public SomeClass NestedValue2()
-            {
-                return new SomeClass();
-            }
-        }
-
-        public class SomeClassWithProperty
-        {
-            public string Value { get; set; }
-        }
-
-        public class SomeClassWithListProperty
-        {
-            public List<string> List { get; set; } = new();
-        }
-
-        public class SomeClassWithComplexProperty
-        {
-            public SomeClassWithProperty Value { get; set; } = new();
-        }
-
-        private ExpressionComparer CreateTarget(bool throwOnUnsupported = true)
-        {
-            var options = new RuleCompilerOptions
-            {
-                UnsupportedExpressionHandling = throwOnUnsupported
-                    ? RuleCompilerUnsupportedExpressionsHandling.FailFast
-                    : RuleCompilerUnsupportedExpressionsHandling.TreatAsNotEqual
-            };
-            return new ExpressionComparer(options);
-        }
+        AssertEqual(null, null);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentNewArray_True()
+    {
+        // Arrange
+        Expression<Func<IEnumerable<string>>> first = () => new[] {"string1", "string2"};
+        Expression<Func<IEnumerable<string>>> second = () => new[] {"string1", "string2"};
+
+        // Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentNewArray_False()
+    {
+        // Arrange
+        Expression<Func<IEnumerable<string>>> first = () => new[] {"string1", "string2", "string3"};
+        Expression<Func<IEnumerable<string>>> second = () => new[] {"string1", "string2"};
+
+        // Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentConditionalArray_True()
+    {
+        // Arrange
+        var strings = new[] {"string1", "string2"};
+        Expression<Func<IEnumerable<string>>> first = () => strings.Length > 1 ? new string[0] : strings;
+        Expression<Func<IEnumerable<string>>> second = () => strings.Length > 1 ? new string[0] : strings;
+
+        // Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentConditionalArray_False()
+    {
+        // Arrange
+        var strings = new[] {"string1", "string2"};
+        Expression<Func<IEnumerable<string>>> first = () => strings.Length > 1 ? new string[0] : strings;
+        Expression<Func<IEnumerable<string>>> second = () => strings.Length > 1 ? strings : new string[0];
+
+        // Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentConditional_True()
+    {
+        //Arrange
+        Expression<Func<int, int>> first = i1 => i1 == 1 ? 1 : 0;
+        Expression<Func<int, int>> second = i2 => i2 == 1 ? 1 : 0;
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentConditional_Test_False()
+    {
+        //Arrange
+        Expression<Func<int, int>> first = i1 => i1 == 1 ? 1 : 0;
+        Expression<Func<int, int>> second = i2 => i2 == 2 ? 1 : 0;
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentConditional_IfTrue_False()
+    {
+        //Arrange
+        Expression<Func<int, int>> first = i1 => i1 == 1 ? 1 : 0;
+        Expression<Func<int, int>> second = i2 => i2 == 1 ? 2 : 0;
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentConditional_IfFalse_False()
+    {
+        //Arrange
+        Expression<Func<int, int>> first = i1 => i1 == 1 ? 1 : 0;
+        Expression<Func<int, int>> second = i2 => i2 == 1 ? 1 : 2;
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentBinary_True()
+    {
+        //Arrange
+        Expression<Func<int, int, bool>> first = (i1, i2) => i1 == i2;
+        Expression<Func<int, int, bool>> second = (ii1, ii2) => ii1 == ii2;
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_TwoNonEquivalentBinary_False()
+    {
+        //Arrange
+        Expression<Func<int, int, bool>> first = (i1, i2) => i1 == i2;
+        Expression<Func<int, int, bool>> second = (ii1, ii2) => ii1 != ii2;
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentUnary_True()
+    {
+        //Arrange
+        Expression<Func<int, int>> first = i => -i;
+        Expression<Func<int, int>> second = i => -i;
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentMember_True()
+    {
+        //Arrange
+        Expression<Func<DateTime, DayOfWeek>> first = d => d.DayOfWeek;
+        Expression<Func<DateTime, DayOfWeek>> second = d => d.DayOfWeek;
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentMethodCall_True()
+    {
+        //Arrange
+        Expression<Func<DateTime, DateTime>> first = d => d.ToLocalTime();
+        Expression<Func<DateTime, DateTime>> second = d => d.ToLocalTime();
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentStaticField_True()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => f.Value == StaticField;
+        Expression<Func<SomeFact, bool>> second = f => f.Value == StaticField;
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_StaticFieldVsCapturedVariable_False()
+    {
+        //Arrange
+        var variable = StaticField;
+        Expression<Func<SomeFact, bool>> first = f => f.Value == variable;
+        Expression<Func<SomeFact, bool>> second = f => f.Value == StaticField;
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_CapturedVariablesPointingToSameValue_True()
+    {
+        //Arrange
+        var variable1 = 1;
+        var variable2 = 1;
+        Expression<Func<SomeFact, bool>> first = f => f.Value == variable1;
+        Expression<Func<SomeFact, bool>> second = f => f.Value == variable2;
+
+        //Act - Assert
+        AssertEqual(second, first);
+    }
+
+    [Fact]
+    public void AreEqual_CapturedVariablesPointingToDifferentValues_True()
+    {
+        //Arrange
+        var variable1 = 1;
+        var variable2 = 2;
+        Expression<Func<SomeFact, bool>> first = f => f.Value == variable1;
+        Expression<Func<SomeFact, bool>> second = f => f.Value == variable2;
+
+        //Act - Assert
+        AssertNotEqual(second, first);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentStaticProperty_True()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => f.Value == StaticProperty;
+        Expression<Func<SomeFact, bool>> second = f => f.Value == StaticProperty;
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentStaticMethod_True()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod();
+        Expression<Func<SomeFact, bool>> second = f => f.Value == StaticMethod();
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentMethodWithArguments_True()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod("one");
+        Expression<Func<SomeFact, bool>> second = f => f.Value == StaticMethod("one");
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentMethodWithArguments_False()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod("one");
+        Expression<Func<SomeFact, bool>> second = f => f.Value == StaticMethod("two");
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentMethods_False()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => f.Value == StaticMethod("one");
+        Expression<Func<SomeFact, bool>> second = f => f.Value == OtherStaticMethod("one");
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentMemberAccessExtension_True()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => f.Child.Values.Contains("sdlkjf");
+        Expression<Func<SomeFact, bool>> second = f => f.Child.Values.Contains("sdlkjf");
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentMemberAccessExtension_False()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => f.Child.Values.Contains("abcdef");
+        Expression<Func<SomeFact, bool>> second = f => f.Child.Values.Contains("sdlkjf");
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentMemberAccess_True()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => f.Child.Values.GetLength(0) == 0;
+        Expression<Func<SomeFact, bool>> second = f => f.Child.Values.GetLength(0) == 0;
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentMemberAccess_False()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => f.Child.Values.GetLength(0) == 0;
+        Expression<Func<SomeFact, bool>> second = f => f.Child.Values.GetLength(1) == 0;
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentMemberAccessConvert_True()
+    {
+        //Arrange
+        int value = 1;
+
+        Expression<Func<SomeOtherFact, bool>> first = f => ((ISomeFact)f).Value.Equals(value);
+        Expression<Func<SomeOtherFact, bool>> second = f => ((ISomeFact)f).Value.Equals(value);
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentMemberAccessConvert_False()
+    {
+        //Arrange
+        int value1 = 1;
+        int value2 = 2;
+
+        Expression<Func<SomeOtherFact, bool>> first = f => ((ISomeFact)f).Value.Equals(value1);
+        Expression<Func<SomeOtherFact, bool>> second = f => ((ISomeFact)f).Value.Equals(value2);
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentMemberAccessIndexer_True()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => f.Child.Values[0] == "1";
+        Expression<Func<SomeFact, bool>> second = f => f.Child.Values[0] == "1";
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentMemberAccessIndexer_False()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => f.Child.Values[0] == "1";
+        Expression<Func<SomeFact, bool>> second = f => f.Child.Values[1] == "1";
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentNew_True()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => new Tuple<int>(1).Item1 == f.Value;
+        Expression<Func<SomeFact, bool>> second = f => new Tuple<int>(1).Item1 == f.Value;
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentNew_False()
+    {
+        //Arrange
+        Expression<Func<SomeFact, bool>> first = f => new Tuple<int>(1).Item1 == f.Value;
+        Expression<Func<SomeFact, bool>> second = f => new Tuple<int>(2).Item1 == f.Value;
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentMemberCall_True()
+    {
+        //Arrange
+        Expression<Func<SomeClass, bool>> first = x => x.NestedValue1().Values == null;
+        Expression<Func<SomeClass, bool>> second = y => y.NestedValue1().Values == null;
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentMemberCall_False()
+    {
+        //Arrange
+        Expression<Func<SomeClass, bool>> first = x => x.NestedValue1().Values == null;
+        Expression<Func<SomeClass, bool>> second = x => x.NestedValue2().Values == null;
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentTypeBinaryExpression_True()
+    {
+        //Arrange
+        Expression<Func<SomeClass, bool>> first = x => x is SomeClass;
+        Expression<Func<SomeClass, bool>> second = x => x is SomeClass;
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentTypeBinaryExpression_False()
+    {
+        //Arrange
+        Expression<Func<SomeClass, bool>> first = x => x is SomeClass;
+        Expression<Func<SomeClass, bool>> second = x => x is object;
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentInvocationExpression_True()
+    {
+        //Arrange
+        var methodInfo = GetType().GetMethods()
+            .First(info => info.IsStatic && info.Name == "StaticMethod"
+                           && info.GetParameters().Length == 1);
+
+        var staticMethodDelegate = (Func<string, int>) methodInfo.CreateDelegate(typeof(Func<string, int>));
+
+        Expression<Func<string, int>> first = data => staticMethodDelegate(data);
+        Expression<Func<string, int>> second = data => staticMethodDelegate(data);
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentInvocationExpression_False()
+    {
+        //Arrange
+        var methodInfos = GetType().GetMethods();
+
+        var methodInfoWithArg = methodInfos
+            .First(info => info.IsStatic && info.Name == "StaticMethod"
+                           && info.GetParameters().Length == 1);
+
+        var methodInfoWithoutArg = methodInfos
+            .First(info => info.IsStatic && info.Name == "StaticMethod"
+                           && !info.GetParameters().Any());
+
+        var staticMethodWithArgDelegate =
+            (Func<string, int>) methodInfoWithArg.CreateDelegate(typeof(Func<string, int>));
+        var staticMethodWithoutArgDelegate = (Func<int>) methodInfoWithoutArg.CreateDelegate(typeof(Func<int>));
+
+        Expression<Func<string, int>> first = data => staticMethodWithArgDelegate(data);
+        Expression<Func<int>> second = () => staticMethodWithoutArgDelegate();
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentInvocationExpressionWithSimilarSignature_False()
+    {
+        //Arrange
+        var methodInfos = GetType().GetMethods();
+
+        var methodInfoWithArg = methodInfos
+            .First(info => info.IsStatic && info.Name == "StaticMethod"
+                           && info.GetParameters().Length == 1);
+
+        var otherMethodInfoWithArg = methodInfos
+            .First(info => info.IsStatic && info.Name == "OtherStaticMethod"
+                           && info.GetParameters().Length == 1);
+
+        var staticMethodWithArgDelegate =
+            (Func<string, int>) methodInfoWithArg.CreateDelegate(typeof(Func<string, int>));
+        var otherStaticMethodWithArgDelegate =
+            (Func<string, int>) otherMethodInfoWithArg.CreateDelegate(typeof(Func<string, int>));
+
+        Expression<Func<string, int>> first = data => staticMethodWithArgDelegate(data);
+        Expression<Func<string, int>> second = data => otherStaticMethodWithArgDelegate(data);
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentMemberAssignment_True()
+    {
+        //Arrange
+        Expression<Func<SomeClassWithProperty>> first = () => new SomeClassWithProperty { Value = "A" };
+        Expression<Func<SomeClassWithProperty>> second = () => new SomeClassWithProperty { Value = "A" };
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentMemberAssignment_False()
+    {
+        //Arrange
+        Expression<Func<SomeClassWithProperty>> first = () => new SomeClassWithProperty { Value = "A" };
+        Expression<Func<SomeClassWithProperty>> second = () => new SomeClassWithProperty { Value = "B" };
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentListInitExpression_True()
+    {
+        //Arrange
+        Expression<Func<IEnumerable<string>>> first = () => new List<string> { "A" };
+        Expression<Func<IEnumerable<string>>> second = () => new List<string> { "A" };
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentListInitExpression_False()
+    {
+        //Arrange
+        Expression<Func<IEnumerable<string>>> first = () => new List<string> { "A" };
+        Expression<Func<IEnumerable<string>>> second = () => new List<string> { "B" };
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentMemberListBinding_True()
+    {
+        //Arrange
+        Expression<Func<SomeClassWithListProperty>> first = () => new SomeClassWithListProperty() { List = { "A" } };
+        Expression<Func<SomeClassWithListProperty>> second = () => new SomeClassWithListProperty { List = { "A" } };
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentMemberListBinding_False()
+    {
+        //Arrange
+        Expression<Func<SomeClassWithListProperty>> first = () => new SomeClassWithListProperty() { List = { "A" } };
+        Expression<Func<SomeClassWithListProperty>> second = () => new SomeClassWithListProperty { List = { "B" } };
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentMemberMemberBinding_True()
+    {
+        //Arrange
+        Expression<Func<SomeClassWithComplexProperty>> first = () => new SomeClassWithComplexProperty { Value = { Value = "A" } };
+        Expression<Func<SomeClassWithComplexProperty>> second = () => new SomeClassWithComplexProperty { Value = { Value = "A" } };
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentMemberMemberBinding_False()
+    {
+        //Arrange
+        Expression<Func<SomeClassWithComplexProperty>> first = () => new SomeClassWithComplexProperty { Value = { Value = "A" } };
+        Expression<Func<SomeClassWithComplexProperty>> second = () => new SomeClassWithComplexProperty { Value = { Value = "B" } };
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentSubtractMemberBinding_True()
+    {
+        //Arrange
+        Expression<Func<ISomeFact, int>> first = x => (x.Value1 - x.Value2).Day;
+        Expression<Func<ISomeFact, int>> second = x => (x.Value1 - x.Value2).Day;
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentSubtractMemberBinding_False()
+    {
+        //Arrange
+        Expression<Func<ISomeFact, int>> first = x => (x.Value1 - x.Value2).Day;
+        Expression<Func<ISomeFact, int>> second = x => (x.Value1 - x.Value2).Year;
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentAddMemberBinding_True()
+    {
+        //Arrange
+        Expression<Func<ISomeFact, int>> first = x => (x.Value1 + x.Value2).Day;
+        Expression<Func<ISomeFact, int>> second = x => (x.Value1 + x.Value2).Day;
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentAddMemberBinding_False()
+    {
+        //Arrange
+        Expression<Func<ISomeFact, int>> first = x => (x.Value1 + x.Value2).Day;
+        Expression<Func<ISomeFact, int>> second = x => (x.Value1 + x.Value2).Year;
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_EquivalentTernaryMemberBinding_True()
+    {
+        //Arrange
+        Expression<Func<ISomeFact, int>> first = x => (x.Value > 0 ? (x.Value1 - x.Value2) : x.Value1).Year;
+        Expression<Func<ISomeFact, int>> second = x => (x.Value > 0 ? (x.Value1 - x.Value2) : x.Value1).Year;
+
+        //Act - Assert
+        AssertEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_NonEquivalentTernaryMemberBinding_False()
+    {
+        //Arrange
+        Expression<Func<ISomeFact, int>> first = x => (x.Value > 0 ? (x.Value1 - x.Value2) : x.Value1).Year;
+        Expression<Func<ISomeFact, int>> second = x => (x.Value > 0 ? (x.Value1 - x.Value2) : x.Value1).Day;
+
+        //Act - Assert
+        AssertNotEqual(first, second);
+    }
+
+    [Fact]
+    public void AreEqual_UnsupportedExpressionOptionIsFailFast_Throws()
+    {
+        //Arrange
+        Expression<Action> first = Expression.Lambda<Action>(Expression.Block(Expression.Empty()));
+        Expression<Action> second = Expression.Lambda<Action>(Expression.Block(Expression.Empty()));
+
+        //Act - Assert
+        Assert.Throws<NotImplementedException>(() => AssertNotEqual(first, second, throwOnUnsupported: true));
+    }
+    
+    [Fact]
+    public void AreEqual_UnsupportedExpressionOptionIsTreatAsNotEqual_False()
+    {
+        //Arrange
+        Expression<Action> first = Expression.Lambda<Action>(Expression.Block(Expression.Empty()));
+        Expression<Action> second = Expression.Lambda<Action>(Expression.Block(Expression.Empty()));
+
+        //Act - Assert
+        AssertNotEqual(first, second, throwOnUnsupported: false);
+    }
+
+    private void AssertEqual(Expression first, Expression second)
+    {
+        //Act
+        var target = CreateTarget();
+        bool result = target.AreEqual(first, second);
+
+        //Assert
+        Assert.True(result);
+    }
+
+    private void AssertNotEqual(Expression first, Expression second, bool throwOnUnsupported = true)
+    {
+        //Act
+        var target = CreateTarget(throwOnUnsupported);
+        bool result = target.AreEqual(first, second);
+
+        //Assert
+        Assert.False(result);
+    }
+
+    public static readonly int StaticField = 1;
+
+    public static int StaticProperty => 1;
+
+    public static int StaticMethod()
+    {
+        return 1;
+    }
+
+    public static int StaticMethod(string param1)
+    {
+        return param1.GetHashCode();
+    }
+
+    public static int OtherStaticMethod(string param1)
+    {
+        return param1.GetHashCode();
+    }
+
+    public class SomeFact
+    {
+        public int Value = 1;
+
+        public readonly SomeClass Child = new();
+    }
+
+    public interface ISomeFact
+    {
+        int Value { get; set; }
+        DateTime Value1 { get; set; }
+        TimeSpan Value2 { get; set; }
+    }
+
+    public class SomeOtherFact : ISomeFact
+    {
+        int ISomeFact.Value { get; set; }
+        public DateTime Value1 { get; set; }
+        public TimeSpan Value2 { get; set; }
+    }
+
+    public class SomeClass
+    {
+        public readonly string[] Values = {"blop"};
+
+        public SomeClass NestedValue1()
+        {
+            return new SomeClass();
+        }
+
+        public SomeClass NestedValue2()
+        {
+            return new SomeClass();
+        }
+    }
+
+    public class SomeClassWithProperty
+    {
+        public string Value { get; set; }
+    }
+
+    public class SomeClassWithListProperty
+    {
+        public List<string> List { get; set; } = new();
+    }
+
+    public class SomeClassWithComplexProperty
+    {
+        public SomeClassWithProperty Value { get; set; } = new();
+    }
+
+    private ExpressionComparer CreateTarget(bool throwOnUnsupported = true)
+    {
+        var options = new RuleCompilerOptions
+        {
+            UnsupportedExpressionHandling = throwOnUnsupported
+                ? RuleCompilerUnsupportedExpressionsHandling.FailFast
+                : RuleCompilerUnsupportedExpressionsHandling.TreatAsNotEqual
+        };
+        return new ExpressionComparer(options);
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Utilities/ExpressionElementComparerTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Utilities/ExpressionElementComparerTest.cs
@@ -6,124 +6,123 @@ using NRules.RuleModel.Builders;
 using NRules.Utilities;
 using Xunit;
 
-namespace NRules.Tests.Utilities
+namespace NRules.Tests.Utilities;
+
+public class ExpressionElementComparerTest
 {
-    public class ExpressionElementComparerTest
+    [Fact]
+    public void AreEqual_SameNameSameExpression_True()
     {
-        [Fact]
-        public void AreEqual_SameNameSameExpression_True()
-        {
-            Expression<Func<string, string>> lambda1 = s => s;
-            Expression<Func<string, string>> lambda2 = s => s;
-            AssertEqual(Element.Expression("Name", lambda1), Element.Expression("Name", lambda2));
-        }
-        
-        [Fact]
-        public void AreEqual_DifferentNamesSameExpression_False()
-        {
-            Expression<Func<string, string>> lambda1 = s => s;
-            Expression<Func<string, string>> lambda2 = s => s;
-            AssertNotEqual(Element.Expression("Name1", lambda1), Element.Expression("Name2", lambda2));
-        }
-        
-        [Fact]
-        public void AreEqual_SameNameDifferentExpressions_False()
-        {
-            Expression<Func<string, string>> lambda1 = s => s.ToUpper();
-            Expression<Func<string, string>> lambda2 = s => s.ToLower();
-            AssertNotEqual(Element.Expression("Name", lambda1), Element.Expression("Name", lambda2));
-        }
+        Expression<Func<string, string>> lambda1 = s => s;
+        Expression<Func<string, string>> lambda2 = s => s;
+        AssertEqual(Element.Expression("Name", lambda1), Element.Expression("Name", lambda2));
+    }
+    
+    [Fact]
+    public void AreEqual_DifferentNamesSameExpression_False()
+    {
+        Expression<Func<string, string>> lambda1 = s => s;
+        Expression<Func<string, string>> lambda2 = s => s;
+        AssertNotEqual(Element.Expression("Name1", lambda1), Element.Expression("Name2", lambda2));
+    }
+    
+    [Fact]
+    public void AreEqual_SameNameDifferentExpressions_False()
+    {
+        Expression<Func<string, string>> lambda1 = s => s.ToUpper();
+        Expression<Func<string, string>> lambda2 = s => s.ToLower();
+        AssertNotEqual(Element.Expression("Name", lambda1), Element.Expression("Name", lambda2));
+    }
 
-        [Fact]
-        public void AreEqual_ListsOfEqualNamedExpressions_True()
-        {
-            Expression<Func<string, string>> lambda1 = s => s;
-            Expression<Func<string, string>> lambda2 = s => s;
-            AssertEqual(
-                new List<Declaration>{Element.Declaration(typeof(string), "s")},
-                new []{Element.Expression("Name", lambda1)},
-                new List<Declaration>{Element.Declaration(typeof(string), "s")},
-                new []{Element.Expression("Name", lambda2)});
-        }
+    [Fact]
+    public void AreEqual_ListsOfEqualNamedExpressions_True()
+    {
+        Expression<Func<string, string>> lambda1 = s => s;
+        Expression<Func<string, string>> lambda2 = s => s;
+        AssertEqual(
+            new List<Declaration>{Element.Declaration(typeof(string), "s")},
+            new []{Element.Expression("Name", lambda1)},
+            new List<Declaration>{Element.Declaration(typeof(string), "s")},
+            new []{Element.Expression("Name", lambda2)});
+    }
 
-        [Fact]
-        public void AreEqual_ListsOfNonEqualNamedExpressions_False()
-        {
-            Expression<Func<string, string>> lambda1 = s => s.ToUpper();
-            Expression<Func<string, string>> lambda2 = s => s.ToLower();
-            AssertNotEqual(
-                new List<Declaration>{Element.Declaration(typeof(string), "s")},
-                new []{Element.Expression("Name", lambda1)},
-                new List<Declaration>{Element.Declaration(typeof(string), "s")},
-                new []{Element.Expression("Name", lambda2)});
-        }
+    [Fact]
+    public void AreEqual_ListsOfNonEqualNamedExpressions_False()
+    {
+        Expression<Func<string, string>> lambda1 = s => s.ToUpper();
+        Expression<Func<string, string>> lambda2 = s => s.ToLower();
+        AssertNotEqual(
+            new List<Declaration>{Element.Declaration(typeof(string), "s")},
+            new []{Element.Expression("Name", lambda1)},
+            new List<Declaration>{Element.Declaration(typeof(string), "s")},
+            new []{Element.Expression("Name", lambda2)});
+    }
 
-        [Fact]
-        public void AreEqual_ListsOfNamedExpressionsFirstEmpty_False()
-        {
-            Expression<Func<string, string>> lambda2 = s => s;
-            AssertNotEqual(
-                new List<Declaration>(),
-                Array.Empty<NamedExpressionElement>(),
-                new List<Declaration>{Element.Declaration(typeof(string), "s")},
-                new []{Element.Expression("Name", lambda2)});
-        }
+    [Fact]
+    public void AreEqual_ListsOfNamedExpressionsFirstEmpty_False()
+    {
+        Expression<Func<string, string>> lambda2 = s => s;
+        AssertNotEqual(
+            new List<Declaration>(),
+            Array.Empty<NamedExpressionElement>(),
+            new List<Declaration>{Element.Declaration(typeof(string), "s")},
+            new []{Element.Expression("Name", lambda2)});
+    }
 
-        [Fact]
-        public void AreEqual_ListsOfNamedExpressionsSecondEmpty_False()
-        {
-            Expression<Func<string, string>> lambda1 = s => s;
-            AssertNotEqual(
-                new List<Declaration>{Element.Declaration(typeof(string), "s")},
-                new []{Element.Expression("Name", lambda1)},
-                new List<Declaration>(),
-                Array.Empty<NamedExpressionElement>());
-        }
+    [Fact]
+    public void AreEqual_ListsOfNamedExpressionsSecondEmpty_False()
+    {
+        Expression<Func<string, string>> lambda1 = s => s;
+        AssertNotEqual(
+            new List<Declaration>{Element.Declaration(typeof(string), "s")},
+            new []{Element.Expression("Name", lambda1)},
+            new List<Declaration>(),
+            Array.Empty<NamedExpressionElement>());
+    }
 
-        private void AssertEqual(NamedExpressionElement first, NamedExpressionElement second)
-        {
-            //Act
-            var target = CreateTarget();
-            bool result = target.AreEqual(first, second);
+    private void AssertEqual(NamedExpressionElement first, NamedExpressionElement second)
+    {
+        //Act
+        var target = CreateTarget();
+        bool result = target.AreEqual(first, second);
 
-            //Assert
-            Assert.True(result);
-        }
+        //Assert
+        Assert.True(result);
+    }
 
-        private void AssertNotEqual(NamedExpressionElement first, NamedExpressionElement second)
-        {
-            //Act
-            var target = CreateTarget();
-            bool result = target.AreEqual(first, second);
+    private void AssertNotEqual(NamedExpressionElement first, NamedExpressionElement second)
+    {
+        //Act
+        var target = CreateTarget();
+        bool result = target.AreEqual(first, second);
 
-            //Assert
-            Assert.False(result);
-        }
+        //Assert
+        Assert.False(result);
+    }
 
-        private void AssertEqual(List<Declaration> declarationsFirst, IEnumerable<NamedExpressionElement> first, List<Declaration> declarationsSecond, IEnumerable<NamedExpressionElement> second)
-        {
-            //Act
-            var target = CreateTarget();
-            bool result = target.AreEqual(declarationsFirst, first, declarationsSecond, second);
+    private void AssertEqual(List<Declaration> declarationsFirst, IEnumerable<NamedExpressionElement> first, List<Declaration> declarationsSecond, IEnumerable<NamedExpressionElement> second)
+    {
+        //Act
+        var target = CreateTarget();
+        bool result = target.AreEqual(declarationsFirst, first, declarationsSecond, second);
 
-            //Assert
-            Assert.True(result);
-        }
+        //Assert
+        Assert.True(result);
+    }
 
-        private void AssertNotEqual(List<Declaration> declarationsFirst, IEnumerable<NamedExpressionElement> first, List<Declaration> declarationsSecond, IEnumerable<NamedExpressionElement> second)
-        {
-            //Act
-            var target = CreateTarget();
-            bool result = target.AreEqual(declarationsFirst, first, declarationsSecond, second);
+    private void AssertNotEqual(List<Declaration> declarationsFirst, IEnumerable<NamedExpressionElement> first, List<Declaration> declarationsSecond, IEnumerable<NamedExpressionElement> second)
+    {
+        //Act
+        var target = CreateTarget();
+        bool result = target.AreEqual(declarationsFirst, first, declarationsSecond, second);
 
-            //Assert
-            Assert.False(result);
-        }
+        //Assert
+        Assert.False(result);
+    }
 
-        private ExpressionElementComparer CreateTarget()
-        {
-            var options = new RuleCompilerOptions();
-            return new ExpressionElementComparer(options);
-        }
+    private ExpressionElementComparer CreateTarget()
+    {
+        var options = new RuleCompilerOptions();
+        return new ExpressionElementComparer(options);
     }
 }

--- a/src/NRules/Tests/NRules.Tests/Utilities/ReverseComparerTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Utilities/ReverseComparerTest.cs
@@ -2,192 +2,191 @@
 using NRules.Utilities;
 using Xunit;
 
-namespace NRules.Tests.Utilities
+namespace NRules.Tests.Utilities;
+
+public class ReverseComparerTest
 {
-    public class ReverseComparerTest
+    [Fact]
+    public void ReverseDefaultIntegerComparer_LessThan()
     {
-        [Fact]
-        public void ReverseDefaultIntegerComparer_LessThan()
+        // Arrange
+        var comparer = Comparer<int>.Default;
+        var reversedComparer = new ReverseComparer<int>(comparer);
+
+        // Act-Assert (Precondition)
+        Assert.Equal(-1, comparer.Compare(1, 2));
+
+        // Act-Assert
+        Assert.Equal(1, reversedComparer.Compare(1, 2));
+    }
+
+    [Fact]
+    public void ReverseDefaultIntegerComparer_Equal()
+    {
+        // Arrange
+        var comparer = Comparer<int>.Default;
+        var reversedComparer = new ReverseComparer<int>(comparer);
+
+        // Act-Assert (Precondition)
+        Assert.Equal(0, comparer.Compare(1, 1));
+
+        // Act-Assert
+        Assert.Equal(0, reversedComparer.Compare(1, 1));
+    }
+
+    [Fact]
+    public void ReverseDefaultIntegerComparer_GreaterThan()
+    {
+        // Arrange
+        var comparer = Comparer<int>.Default;
+        var reversedComparer = new ReverseComparer<int>(comparer);
+
+        // Act-Assert (Precondition)
+        Assert.Equal(1, comparer.Compare(2, 1));
+
+        // Act-Assert
+        Assert.Equal(-1, reversedComparer.Compare(2, 1));
+    }
+
+    [Fact]
+    public void ReverseDefaultStringComparer_WithNull_LessThan()
+    {
+        // Arrange
+        var comparer = Comparer<string>.Default;
+        var reversedComparer = new ReverseComparer<string>(comparer);
+
+        // Act-Assert (Precondition)
+        Assert.Equal(-1, comparer.Compare(null, "A"));
+
+        // Act-Assert
+        Assert.Equal(1, reversedComparer.Compare(null, "A"));
+    }
+
+    [Fact]
+    public void ReverseDefaultStringComparer_WithNull_LessEqual()
+    {
+        // Arrange
+        var comparer = Comparer<string>.Default;
+        var reversedComparer = new ReverseComparer<string>(comparer);
+
+        // Act-Assert (Precondition)
+        Assert.Equal(0, comparer.Compare(null, null));
+
+        // Act-Assert
+        Assert.Equal(0, reversedComparer.Compare(null, null));
+    }
+
+    [Fact]
+    public void ReverseDefaultStringComparer_WithNull_GreaterThan()
+    {
+        // Arrange
+        var comparer = Comparer<string>.Default;
+        var reversedComparer = new ReverseComparer<string>(comparer);
+
+        // Act-Assert (Precondition)
+        Assert.Equal(1, comparer.Compare("A", null));
+
+        // Act-Assert
+        Assert.Equal(-1, reversedComparer.Compare("A", null));
+    }
+
+    [Fact]
+    public void CustomComparer_LessThan()
+    {
+        // Arrange
+        var comparer = new CustomIntComparer();
+        var reversedComparer = new ReverseComparer<int>(comparer);
+
+        // Act-Assert (Precondition)
+        Assert.Equal(-2, comparer.Compare(1, 2));
+
+        // Act-Assert
+        Assert.Equal(2, reversedComparer.Compare(1, 2));
+    }
+
+    [Fact]
+    public void CustomComparer_Equal()
+    {
+        // Arrange
+        var comparer = new CustomIntComparer();
+        var reversedComparer = new ReverseComparer<int>(comparer);
+
+        // Act-Assert (Precondition)
+        Assert.Equal(0, comparer.Compare(1, 1));
+
+        // Act-Assert
+        Assert.Equal(0, reversedComparer.Compare(1, 1));
+    }
+
+    [Fact]
+    public void CustomComparer_GreaterThan()
+    {
+        // Arrange
+        var comparer = new CustomIntComparer();
+        var reversedComparer = new ReverseComparer<int>(comparer);
+
+        // Act-Assert (Precondition)
+        Assert.Equal(2, comparer.Compare(2, 1));
+
+        // Act-Assert
+        Assert.Equal(-2, reversedComparer.Compare(2, 1));
+    }
+
+    [Fact]
+    public void CustomComparer_Limits_LessThan()
+    {
+        // Arrange
+        var comparer = new CustomIntComparerLimits();
+        var reversedComparer = new ReverseComparer<int>(comparer);
+
+        // Act-Assert (Precondition)
+        Assert.Equal(int.MinValue, comparer.Compare(1, 2));
+
+        // Act-Assert
+        Assert.Equal(int.MaxValue, reversedComparer.Compare(1, 2));
+    }
+
+    [Fact]
+    public void CustomComparer_Limits_GreaterThan()
+    {
+        // Arrange
+        var comparer = new CustomIntComparerLimits();
+        var reversedComparer = new ReverseComparer<int>(comparer);
+
+        // Act-Assert (Precondition)
+        Assert.Equal(int.MaxValue, comparer.Compare(2, 1));
+
+        // Act-Assert
+        Assert.Equal(int.MinValue, reversedComparer.Compare(2, 1));
+    }
+
+    class CustomIntComparer : IComparer<int>
+    {
+        public int Compare(int x, int y)
         {
-            // Arrange
-            var comparer = Comparer<int>.Default;
-            var reversedComparer = new ReverseComparer<int>(comparer);
+            var result = 0;
 
-            // Act-Assert (Precondition)
-            Assert.Equal(-1, comparer.Compare(1, 2));
-
-            // Act-Assert
-            Assert.Equal(1, reversedComparer.Compare(1, 2));
-        }
-
-        [Fact]
-        public void ReverseDefaultIntegerComparer_Equal()
-        {
-            // Arrange
-            var comparer = Comparer<int>.Default;
-            var reversedComparer = new ReverseComparer<int>(comparer);
-
-            // Act-Assert (Precondition)
-            Assert.Equal(0, comparer.Compare(1, 1));
-
-            // Act-Assert
-            Assert.Equal(0, reversedComparer.Compare(1, 1));
-        }
-
-        [Fact]
-        public void ReverseDefaultIntegerComparer_GreaterThan()
-        {
-            // Arrange
-            var comparer = Comparer<int>.Default;
-            var reversedComparer = new ReverseComparer<int>(comparer);
-
-            // Act-Assert (Precondition)
-            Assert.Equal(1, comparer.Compare(2, 1));
-
-            // Act-Assert
-            Assert.Equal(-1, reversedComparer.Compare(2, 1));
-        }
-
-        [Fact]
-        public void ReverseDefaultStringComparer_WithNull_LessThan()
-        {
-            // Arrange
-            var comparer = Comparer<string>.Default;
-            var reversedComparer = new ReverseComparer<string>(comparer);
-
-            // Act-Assert (Precondition)
-            Assert.Equal(-1, comparer.Compare(null, "A"));
-
-            // Act-Assert
-            Assert.Equal(1, reversedComparer.Compare(null, "A"));
-        }
-
-        [Fact]
-        public void ReverseDefaultStringComparer_WithNull_LessEqual()
-        {
-            // Arrange
-            var comparer = Comparer<string>.Default;
-            var reversedComparer = new ReverseComparer<string>(comparer);
-
-            // Act-Assert (Precondition)
-            Assert.Equal(0, comparer.Compare(null, null));
-
-            // Act-Assert
-            Assert.Equal(0, reversedComparer.Compare(null, null));
-        }
-
-        [Fact]
-        public void ReverseDefaultStringComparer_WithNull_GreaterThan()
-        {
-            // Arrange
-            var comparer = Comparer<string>.Default;
-            var reversedComparer = new ReverseComparer<string>(comparer);
-
-            // Act-Assert (Precondition)
-            Assert.Equal(1, comparer.Compare("A", null));
-
-            // Act-Assert
-            Assert.Equal(-1, reversedComparer.Compare("A", null));
-        }
-
-        [Fact]
-        public void CustomComparer_LessThan()
-        {
-            // Arrange
-            var comparer = new CustomIntComparer();
-            var reversedComparer = new ReverseComparer<int>(comparer);
-
-            // Act-Assert (Precondition)
-            Assert.Equal(-2, comparer.Compare(1, 2));
-
-            // Act-Assert
-            Assert.Equal(2, reversedComparer.Compare(1, 2));
-        }
-
-        [Fact]
-        public void CustomComparer_Equal()
-        {
-            // Arrange
-            var comparer = new CustomIntComparer();
-            var reversedComparer = new ReverseComparer<int>(comparer);
-
-            // Act-Assert (Precondition)
-            Assert.Equal(0, comparer.Compare(1, 1));
-
-            // Act-Assert
-            Assert.Equal(0, reversedComparer.Compare(1, 1));
-        }
-
-        [Fact]
-        public void CustomComparer_GreaterThan()
-        {
-            // Arrange
-            var comparer = new CustomIntComparer();
-            var reversedComparer = new ReverseComparer<int>(comparer);
-
-            // Act-Assert (Precondition)
-            Assert.Equal(2, comparer.Compare(2, 1));
-
-            // Act-Assert
-            Assert.Equal(-2, reversedComparer.Compare(2, 1));
-        }
-
-        [Fact]
-        public void CustomComparer_Limits_LessThan()
-        {
-            // Arrange
-            var comparer = new CustomIntComparerLimits();
-            var reversedComparer = new ReverseComparer<int>(comparer);
-
-            // Act-Assert (Precondition)
-            Assert.Equal(int.MinValue, comparer.Compare(1, 2));
-
-            // Act-Assert
-            Assert.Equal(int.MaxValue, reversedComparer.Compare(1, 2));
-        }
-
-        [Fact]
-        public void CustomComparer_Limits_GreaterThan()
-        {
-            // Arrange
-            var comparer = new CustomIntComparerLimits();
-            var reversedComparer = new ReverseComparer<int>(comparer);
-
-            // Act-Assert (Precondition)
-            Assert.Equal(int.MaxValue, comparer.Compare(2, 1));
-
-            // Act-Assert
-            Assert.Equal(int.MinValue, reversedComparer.Compare(2, 1));
-        }
-
-        class CustomIntComparer : IComparer<int>
-        {
-            public int Compare(int x, int y)
+            if (x != y)
             {
-                var result = 0;
-
-                if (x != y)
-                {
-                    result = x > y ? 2 : -2;
-                }
-
-                return result;
+                result = x > y ? 2 : -2;
             }
+
+            return result;
         }
+    }
 
-        class CustomIntComparerLimits : IComparer<int>
+    class CustomIntComparerLimits : IComparer<int>
+    {
+        public int Compare(int x, int y)
         {
-            public int Compare(int x, int y)
+            var result = 0;
+
+            if (x != y)
             {
-                var result = 0;
-
-                if (x != y)
-                {
-                    result = x > y ? int.MaxValue : int.MinValue;
-                }
-
-                return result;
+                result = x > y ? int.MaxValue : int.MinValue;
             }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
Update to latest language version will not break any compatibility.
As stated in contributing guide we have to use latest VS 2022 that supports C# 11 as of today.

File-scoped namespaces reduces number of indents in file and reduces its size. See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/file-scoped-namespaces