### PR TITLE
Add ability to customize fact identity comparison

### DIFF
--- a/bench/NRules.Benchmark/NRules.Benchmark/Micro/BenchmarkEqualityComparerBase.cs
+++ b/bench/NRules.Benchmark/NRules.Benchmark/Micro/BenchmarkEqualityComparerBase.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using NRules.RuleModel;
+
+namespace NRules.Benchmark.Micro;
+
+[MemoryDiagnoser]
+public abstract class BenchmarkEqualityComparerBase
+{
+    protected readonly IEqualityComparer<object> DefaultEqualityComparer = EqualityComparer<object>.Default;
+    protected readonly IEqualityComparer<object> IdentityEqualityComparer;
+    protected readonly IEqualityComparer<IdentityFactType> IdentityTypedEqualityComparer;
+    protected readonly IEqualityComparer<object> CustomEqualityComparer;
+    protected readonly IEqualityComparer<FactType> CustomTypedEqualityComparer;
+    
+    protected readonly FactType FactType1 = new("value1");
+    protected readonly FactType FactType2 = new("value2");    
+    protected readonly EquatableFactType EquatableFactType1 = new("value1");
+    protected readonly EquatableFactType EquatableFactType2 = new("value2");
+    protected readonly IdentityFactType IdentityFactType1 = new("value1");
+    protected readonly IdentityFactType IdentityFactType2 = new("value2");
+    
+    protected BenchmarkEqualityComparerBase()
+    {
+        var comparerRegistry = new FactIdentityComparerRegistry();
+        
+        var identityEqualityComparer = new FactIdentityComparer(
+            comparerRegistry.DefaultFactIdentityComparer,
+            comparerRegistry.GetComparers());
+        IdentityEqualityComparer = identityEqualityComparer;
+        IdentityTypedEqualityComparer = identityEqualityComparer.GetComparer<IdentityFactType>();
+        
+        comparerRegistry.RegisterComparer(new FactTypeEqualityComparer());
+        var customEqualityComparer = new FactIdentityComparer(
+            comparerRegistry.DefaultFactIdentityComparer,
+            comparerRegistry.GetComparers());
+        CustomEqualityComparer = customEqualityComparer;
+        CustomTypedEqualityComparer = customEqualityComparer.GetComparer<FactType>();
+    }
+    
+    public class FactType(string value)
+    {
+        public string Value { get; } = value;
+    }
+    
+    public class FactTypeEqualityComparer : IEqualityComparer<FactType>
+    {
+        public bool Equals(FactType? x, FactType? y)
+        {
+            return x?.Value == y?.Value;
+        }
+
+        public int GetHashCode(FactType obj)
+        {
+            return obj.Value.GetHashCode();
+        }
+    }
+    
+    public class EquatableFactType(string value) : IEquatable<EquatableFactType>
+    {
+        public string Value { get; } = value;
+
+        public bool Equals(EquatableFactType? other)
+        {
+            return Value == other?.Value;
+        }
+        
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+    }
+    
+    public class IdentityFactType(string value) : IIdentityProvider
+    {
+        public string Value { get; } = value;
+
+        public object GetIdentity()
+        {
+            return Value;
+        }
+    }
+}

--- a/bench/NRules.Benchmark/NRules.Benchmark/Micro/BenchmarkEqualityComparerEquals.cs
+++ b/bench/NRules.Benchmark/NRules.Benchmark/Micro/BenchmarkEqualityComparerEquals.cs
@@ -1,0 +1,67 @@
+using BenchmarkDotNet.Attributes;
+
+namespace NRules.Benchmark.Micro;
+
+[BenchmarkCategory("Micro", "Equality")]
+public class BenchmarkEqualityComparerEquals : BenchmarkEqualityComparerBase
+{
+    [Benchmark(Baseline = true)]
+    public bool DotnetDefault()
+    {
+        return DefaultEqualityComparer.Equals(FactType1, FactType2);
+    }
+    
+    [Benchmark]
+    public bool DotnetDefaultEquatable()
+    {
+        return DefaultEqualityComparer.Equals(EquatableFactType1, EquatableFactType2);
+    }
+    
+    [Benchmark]
+    public bool FactDefault()
+    {
+        return IdentityEqualityComparer.Equals(FactType1, FactType2);
+    }
+    
+    [Benchmark]
+    public bool FactDefaultEquatable()
+    {
+        return IdentityEqualityComparer.Equals(EquatableFactType1, EquatableFactType2);
+    }
+    
+    [Benchmark]
+    public bool FactDefaultIdentity()
+    {
+        return IdentityEqualityComparer.Equals(IdentityFactType1, IdentityFactType2);
+    }
+    
+    [Benchmark]
+    public bool FactDefaultTypedIdentity()
+    {
+        return IdentityTypedEqualityComparer.Equals(IdentityFactType1, IdentityFactType2);
+    }
+    
+    [Benchmark]
+    public bool FactCustom()
+    {
+        return CustomEqualityComparer.Equals(FactType1, FactType2);
+    }
+    
+    [Benchmark]
+    public bool FactCustomEquatable()
+    {
+        return CustomEqualityComparer.Equals(EquatableFactType1, EquatableFactType2);
+    }
+    
+    [Benchmark]
+    public bool FactCustomIdentity()
+    {
+        return CustomEqualityComparer.Equals(IdentityFactType1, IdentityFactType2);
+    }
+    
+    [Benchmark]
+    public bool FactCustomTyped()
+    {
+        return CustomTypedEqualityComparer.Equals(FactType1, FactType2);
+    }
+}

--- a/bench/NRules.Benchmark/NRules.Benchmark/Micro/BenchmarkEqualityComparerHashCode.cs
+++ b/bench/NRules.Benchmark/NRules.Benchmark/Micro/BenchmarkEqualityComparerHashCode.cs
@@ -1,0 +1,67 @@
+using BenchmarkDotNet.Attributes;
+
+namespace NRules.Benchmark.Micro;
+
+[BenchmarkCategory("Micro", "Equality")]
+public class BenchmarkEqualityComparerHashCode : BenchmarkEqualityComparerBase
+{
+    [Benchmark(Baseline = true)]
+    public int DotnetDefault()
+    {
+        return DefaultEqualityComparer.GetHashCode(FactType1);
+    }
+    
+    [Benchmark]
+    public int DotnetDefaultEquatable()
+    {
+        return DefaultEqualityComparer.GetHashCode(EquatableFactType1);
+    }
+    
+    [Benchmark]
+    public int FactDefault()
+    {
+        return IdentityEqualityComparer.GetHashCode(FactType1);
+    }
+    
+    [Benchmark]
+    public int FactDefaultEquatable()
+    {
+        return IdentityEqualityComparer.GetHashCode(EquatableFactType1);
+    }
+    
+    [Benchmark]
+    public int FactDefaultIdentity()
+    {
+        return IdentityEqualityComparer.GetHashCode(IdentityFactType1);
+    }
+    
+    [Benchmark]
+    public int FactDefaultTypedIdentity()
+    {
+        return IdentityTypedEqualityComparer.GetHashCode(IdentityFactType1);
+    }
+    
+    [Benchmark]
+    public int FactCustom()
+    {
+        return CustomEqualityComparer.GetHashCode(FactType1);
+    }
+    
+    [Benchmark]
+    public int FactCustomEquatable()
+    {
+        return CustomEqualityComparer.GetHashCode(EquatableFactType1);
+    }
+    
+    [Benchmark]
+    public int FactCustomIdentity()
+    {
+        return CustomEqualityComparer.GetHashCode(IdentityFactType1);
+    }
+    
+    [Benchmark]
+    public int FactCustomTyped()
+    {
+        return CustomTypedEqualityComparer.GetHashCode(FactType1);
+    }
+}

--- a/bench/NRules.Benchmark/NRules.Benchmark/NRules.Benchmark.csproj
+++ b/bench/NRules.Benchmark/NRules.Benchmark/NRules.Benchmark.csproj
@@ -6,6 +6,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/articles/fact-equality-and-identity.md
+++ b/docs/articles/fact-equality-and-identity.md
@@ -1,0 +1,101 @@
+# Fact Equality and Identity
+
+In NRules, it is crucial for the engine to be able to determine which facts are the same and which are different when inserting, updating, or retracting them within the rules session. By default, NRules uses the standard .NET equality comparison to achieve this, essentially treating fact equality and fact identity the same way. This works well for the majority of cases, such as when mutating the existing fact objects or where equality comparison only uses the identity fields. However, there are scenarios where the default equality comparison is insufficient. For instance, if a fact already defines its own structural equality comparison or when using record types to define facts, which inherently use structural equality comparison under the hood.
+
+To address these scenarios, NRules provides mechanisms to customize fact identity comparison.
+
+NRules engine uses the following rules for fact identity comparison:
+* If both facts are the same reference, they are considered identical.
+* If either fact is `null` (though this should not be possible), they are considered not identical.
+* If facts are of different types, they are considered not identical.
+* If custom comparer is registered for the fact type, it is used to compare the identity of the facts.
+* In all other cases default comparer is used to compare the identity of the facts.
+
+The default comparer compares fact identity as follows:
+* If facts implement [IIdentityProvider](xref:NRules.RuleModel.IIdentityProvider), it compares the identity objects.
+* Otherwise, the facts are compared using their equality.
+
+## Explicitly Defining Fact Identity
+
+As noted earlier, one customization mechanism for identity comparison is the [IIdentityProvider](xref:NRules.RuleModel.IIdentityProvider) interface. By implementing this interface, a fact can explicitly define its identity, which NRules will use to compare facts. This is particularly useful when the default equality comparison does not align with the desired behavior for fact comparison within the rules session.
+
+Here is an example of how to implement the [IIdentityProvider](xref:NRules.RuleModel.IIdentityProvider) interface:
+
+```c#
+public record FactType(int Id, string TestProperty) : IIdentityProvider
+{
+    public object GetIdentity() => Id;
+}
+```
+
+In this case the following code that updates the rules session will work as expected:
+
+```c#
+Session.Insert(new FactType(1, "Original Value"));
+Session.Update(new FactType(1, "New Value"));
+```
+
+## Custom Equality Comparer
+
+Additionally, NRules allows the use of custom [IEqualityComparer&lt;T&gt;](xref:System.Collections.Generic.IEqualityComparer`1) implementations for given fact types. This approach provides even more flexibility in defining how facts are compared for identity.
+
+Below is an example of a custom [IEqualityComparer&lt;T&gt;](xref:System.Collections.Generic.IEqualityComparer`1) implementation. While normally, equality comparers must handle special cases of `null` arguments and equality by reference, these are checked by NRules before giving control to the equality comparer, so the arguments can be assumed not `null` and not equal by reference.
+
+```c#
+public class FactTypeIdentityComparer : IEqualityComparer<FactType>
+{
+    public bool Equals(FactType? obj1, FactType? obj2)
+    {
+        return obj1!.Id == obj2!.Id;
+    }
+
+    public int GetHashCode(FactType obj)
+    {
+        return obj.Id;
+    }
+}
+```
+
+Custom equality comparers must be registered with the engine at the time of rules compilation like this:
+
+```c#
+var compiler = new RuleCompiler();
+compiler.FactIdentityComparerRegistry.RegisterComparer(new FactTypeIdentityComparer());
+```
+
+## Customizing Default Identity Comparer
+
+In some cases the default identity comparer in NRules may be insufficient. As noted before, it uses [IIdentityProvider](xref:NRules.RuleModel.IIdentityProvider) interface, if it's implemented by the fact type, or default equality comparison otherwise. It may be desirable for fact types to not depend on any framework code or implement any infrastructure interfaces, when subscribing to the POCO paradigm for the domain model. In this case, one can define a custom implementation of the default comparer, like so:
+
+```c#
+public interface IMyIdentityProvider
+{
+    int GetIdentity();
+}
+
+internal class MyDefaultFactIdentityComparer : IEqualityComparer<object>
+{
+    bool IEqualityComparer<object>.Equals(object? obj1, object? obj2)
+    {
+        if (obj1 is IMyIdentityProvider provider1 && obj2 is IMyIdentityProvider provider2)
+            return provider1.GetIdentity() == provider2.GetIdentity();
+
+        return Equals(obj1, obj2);
+    }
+
+    int IEqualityComparer<object>.GetHashCode(object obj)
+    {
+        if (obj is IMyIdentityProvider provider)
+            return provider.GetIdentity();
+
+        return obj.GetHashCode();
+    }
+}
+```
+
+Custom version of the default equality comparer is then registered with the engine at the time of rules compilation like this:
+
+```c#
+var compiler = new RuleCompiler();
+compiler.FactIdentityComparerRegistry.DefaultFactIdentityComparer = new MyDefaultFactIdentityComparer();
+```

--- a/docs/articles/fact-equality-and-identity.md
+++ b/docs/articles/fact-equality-and-identity.md
@@ -6,7 +6,6 @@ To address these scenarios, NRules provides mechanisms to customize fact identit
 
 NRules engine uses the following rules for fact identity comparison:
 * If both facts are the same reference, they are considered identical.
-* If either fact is `null` (though this should not be possible), they are considered not identical.
 * If facts are of different types, they are considered not identical.
 * If custom comparer is registered for the fact type, it is used to compare the identity of the facts.
 * In all other cases default comparer is used to compare the identity of the facts.
@@ -37,7 +36,7 @@ Session.Update(new FactType(1, "New Value"));
 
 ## Custom Equality Comparer
 
-Additionally, NRules allows the use of custom [IEqualityComparer&lt;T&gt;](xref:System.Collections.Generic.IEqualityComparer`1) implementations for given fact types. This approach provides even more flexibility in defining how facts are compared for identity.
+Additionally, NRules allows the use of custom [IEqualityComparer&lt;T&gt;](xref:System.Collections.Generic.IEqualityComparer`1) implementations for given fact types. There is a slight performance penalty for using custom fact comparers, as the engine has to find the correct comparer by type.
 
 Below is an example of a custom [IEqualityComparer&lt;T&gt;](xref:System.Collections.Generic.IEqualityComparer`1) implementation. While normally, equality comparers must handle special cases of `null` arguments and equality by reference, these are checked by NRules before giving control to the equality comparer, so the arguments can be assumed not `null` and not equal by reference.
 

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -14,6 +14,8 @@
   href: forward-chaining.md
 - name: Agenda Filters
   href: agenda-filters.md
+- name: Fact Equality and Identity
+  href: fact-equality-and-identity.md
 - name: Unit Testing Rules
   href: unit-testing-rules.md
 - name: Diagnostics

--- a/src/NRules/NRules.RuleModel/IIdentityProvider.cs
+++ b/src/NRules/NRules.RuleModel/IIdentityProvider.cs
@@ -1,0 +1,15 @@
+namespace NRules.RuleModel;
+
+/// <summary>
+/// Interface for facts that provide custom identity.
+/// </summary>
+public interface IIdentityProvider
+{
+    /// <summary>
+    /// Retrieves the identity of the fact.
+    /// Equality of the identity objects is used to compare facts for the purpose of
+    /// inserting, updating and removing them within the rule session.
+    /// </summary>
+    /// <returns>Fact identity.</returns>
+    object GetIdentity();
+}

--- a/src/NRules/NRules/Aggregators/AggregationContext.cs
+++ b/src/NRules/NRules/Aggregators/AggregationContext.cs
@@ -7,6 +7,11 @@ namespace NRules.Aggregators;
 /// </summary>
 public class AggregationContext
 {
+    /// <summary>
+    /// Identity comparer for aggregated facts.
+    /// </summary>
+    public IFactIdentityComparer FactIdentityComparer => ExecutionContext.FactIdentityComparer;
+    
     internal IExecutionContext ExecutionContext { get; }
     internal NodeInfo NodeInfo { get; }
 

--- a/src/NRules/NRules/Aggregators/CollectionAggregatorFactory.cs
+++ b/src/NRules/NRules/Aggregators/CollectionAggregatorFactory.cs
@@ -46,7 +46,7 @@ internal class CollectionAggregatorFactory : IAggregatorFactory
         }
     }
 
-    public IAggregator Create()
+    public IAggregator Create(AggregationContext context)
     {
         return _factory!();
     }

--- a/src/NRules/NRules/Aggregators/GroupByAggregatorFactory.cs
+++ b/src/NRules/NRules/Aggregators/GroupByAggregatorFactory.cs
@@ -33,7 +33,7 @@ internal class GroupByAggregatorFactory : IAggregatorFactory
         _factory = factoryExpression.Compile();
     }
 
-    public IAggregator Create()
+    public IAggregator Create(AggregationContext context)
     {
         return _factory!();
     }

--- a/src/NRules/NRules/Aggregators/IAggregatorFactory.cs
+++ b/src/NRules/NRules/Aggregators/IAggregatorFactory.cs
@@ -25,6 +25,7 @@ public interface IAggregatorFactory
     /// This method is called by the engine for each new combination of preceding partial matches, 
     /// so that a new instance of the aggregator is created to accumulate the results.
     /// </summary>
+    /// <param name="context">Aggregation context.</param>
     /// <returns>Aggregator instance.</returns>
-    IAggregator Create();
+    IAggregator Create(AggregationContext context);
 }

--- a/src/NRules/NRules/Aggregators/ProjectionAggregatorFactory.cs
+++ b/src/NRules/NRules/Aggregators/ProjectionAggregatorFactory.cs
@@ -29,7 +29,7 @@ internal class ProjectionAggregatorFactory : IAggregatorFactory
         _factory = factoryExpression.Compile();
     }
 
-    public IAggregator Create()
+    public IAggregator Create(AggregationContext context)
     {
         return _factory!();
     }

--- a/src/NRules/NRules/ExecutionContext.cs
+++ b/src/NRules/NRules/ExecutionContext.cs
@@ -11,6 +11,7 @@ internal interface IExecutionContext
     IEventAggregator EventAggregator { get; }
     IMetricsAggregator MetricsAggregator { get; }
     IIdGenerator IdGenerator { get; }
+    IFactIdentityComparer FactIdentityComparer { get; }
 }
 
 internal class ExecutionContext : IExecutionContext
@@ -37,5 +38,6 @@ internal class ExecutionContext : IExecutionContext
     public IEventAggregator EventAggregator { get; }
     public IMetricsAggregator MetricsAggregator { get; }
     public IIdGenerator IdGenerator { get; }
+    public IFactIdentityComparer FactIdentityComparer => WorkingMemory.FactIdentityComparer;
     public Queue<Activation> UnlinkQueue { get; }
 }

--- a/src/NRules/NRules/FactIdentityComparer.cs
+++ b/src/NRules/NRules/FactIdentityComparer.cs
@@ -25,7 +25,7 @@ namespace NRules;
 public interface IFactIdentityComparer : IEqualityComparer<object>
 {
     /// <summary>
-    /// Strongly typed fact identity comparer for a specific fact type.
+    /// Retrieves a strongly typed fact identity comparer for a specific fact type.
     /// </summary>
     /// <typeparam name="TFact">Type of fact to get an identity comparer for.</typeparam>
     /// <returns>Strongly typed fact identity comparer.</returns>

--- a/src/NRules/NRules/FactIdentityComparer.cs
+++ b/src/NRules/NRules/FactIdentityComparer.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NRules.RuleModel;
+
+namespace NRules;
+
+/// <summary>
+/// Equality comparer used to compare fact identity, when inserting, updating, removing
+/// facts within the rules session.
+/// </summary>
+/// <remarks>
+/// The comparer uses the following rules to compare identity of the facts:
+/// <list type="bullet">
+/// <item>If both facts are the same reference, they are considered identical.</item>
+/// <item>If facts are of different types, they are considered not identical.</item>
+/// <item>If custom comparer is registered for the fact type in <see cref="RuleCompiler.FactIdentityComparerRegistry"/>,
+/// it is used to compare the identity of the facts.</item>
+/// <item><see cref="RuleCompiler.DefaultFactIdentityComparer"/> is used to compare the identity of the facts.
+/// Built-in implementation compares returned identity objects if facts implement <see cref="IIdentityProvider"/>.</item>
+/// <item>Otherwise, the objects are compared using their equality.</item>
+/// </list>
+/// </remarks>
+public interface IFactIdentityComparer : IEqualityComparer<object>
+{
+    /// <summary>
+    /// Strongly typed fact identity comparer for a specific fact type.
+    /// </summary>
+    /// <typeparam name="TFact">Type of fact to get an identity comparer for.</typeparam>
+    /// <returns>Strongly typed fact identity comparer.</returns>
+    IEqualityComparer<TFact> GetComparer<TFact>();
+}
+
+internal class FactIdentityComparer : IFactIdentityComparer
+{
+    private readonly IEqualityComparer<object> _defaultComparer;
+    private readonly Dictionary<Type, (object Comparer, IEqualityComparer<object> WrappedComparer)>? _customComparers;
+    private readonly Dictionary<Type, object> _typedComparers = new();
+    
+    public FactIdentityComparer(IEqualityComparer<object> defaultComparer,
+        IReadOnlyCollection<FactIdentityComparerRegistry.Entry> customComparers)
+    {
+        _defaultComparer = defaultComparer;
+        if (customComparers.Any())
+            _customComparers = customComparers.ToDictionary(x => x.FactType, x => (x.Comparer, x.WrappedComparer));
+    }
+    
+    public IEqualityComparer<TFact> GetComparer<TFact>()
+    {
+        IEqualityComparer<TFact> typedComparer;
+
+        if (_typedComparers.TryGetValue(typeof(TFact), out var comparer))
+        {
+            typedComparer = (IEqualityComparer<TFact>)comparer;
+        }
+        else
+        {
+            if (_customComparers != null && _customComparers.TryGetValue(typeof(TFact), out var item))
+                typedComparer = new SpecificComparerWrapper<TFact>((IEqualityComparer<TFact>)item.Comparer);
+            else
+                typedComparer = new DefaultComparerWrapper<TFact>(_defaultComparer);
+            _typedComparers[typeof(TFact)] = typedComparer;
+        }
+
+        return typedComparer;
+    }
+
+    bool IEqualityComparer<object>.Equals(object? obj1, object? obj2)
+    {
+        if (ReferenceEquals(obj1, obj2))
+            return true;
+        if (obj1 is null || obj2 is null)
+            return false;
+        if (obj1.GetType() != obj2.GetType())
+            return false;
+        if (_customComparers != null && _customComparers.TryGetValue(obj1.GetType(), out var item))
+            return item.WrappedComparer.Equals(obj1, obj2);
+        return _defaultComparer.Equals(obj1, obj2);
+    }
+
+    int IEqualityComparer<object>.GetHashCode(object? obj)
+    {
+        if (obj == null)
+            return 0;
+        if (_customComparers != null && _customComparers.TryGetValue(obj.GetType(), out var item))
+            return item.WrappedComparer.GetHashCode(obj);
+        return _defaultComparer.GetHashCode(obj);
+    }
+
+    private class DefaultComparerWrapper<TFact> : IEqualityComparer<TFact>
+    {
+        private readonly IEqualityComparer<object> _comparer;
+
+        public DefaultComparerWrapper(IEqualityComparer<object> comparer)
+        {
+            _comparer = comparer;
+        }
+
+        public bool Equals(TFact obj1, TFact obj2)
+        {
+            if (ReferenceEquals(obj1, obj2))
+                return true;
+            if (obj1 is null || obj2 is null)
+                return false;
+            if (obj1.GetType() != obj2.GetType())
+                return false;
+            return _comparer.Equals(obj1, obj2);
+        }
+
+        public int GetHashCode(TFact obj)
+        {
+            if (obj == null)
+                return 0;
+            return _comparer.GetHashCode(obj);
+        }
+    }
+    
+    private class SpecificComparerWrapper<TFact> : IEqualityComparer<TFact>
+    {
+        private readonly IEqualityComparer<TFact> _comparer;
+
+        public SpecificComparerWrapper(IEqualityComparer<TFact> comparer)
+        {
+            _comparer = comparer;
+        }
+
+        public bool Equals(TFact obj1, TFact obj2)
+        {
+            if (ReferenceEquals(obj1, obj2))
+                return true;
+            if (obj1 is null || obj2 is null)
+                return false;
+            if (obj1.GetType() != obj2.GetType())
+                return false;
+            return _comparer.Equals(obj1, obj2);
+        }
+
+        public int GetHashCode(TFact obj)
+        {
+            if (obj == null)
+                return 0;
+            return _comparer.GetHashCode(obj);
+        }
+    }
+}
+
+internal class DefaultFactIdentityComparer : IEqualityComparer<object>
+{
+    bool IEqualityComparer<object>.Equals(object? obj1, object? obj2)
+    {
+        if (obj1 is IIdentityProvider provider1 && obj2 is IIdentityProvider provider2)
+            return Equals(provider1.GetIdentity(), provider2.GetIdentity());
+
+        return Equals(obj1, obj2);
+    }
+
+    int IEqualityComparer<object>.GetHashCode(object obj)
+    {
+        if (obj is IIdentityProvider provider)
+            return provider.GetIdentity().GetHashCode();
+
+        return obj.GetHashCode();
+    }
+}

--- a/src/NRules/NRules/FactIdentityComparer.cs
+++ b/src/NRules/NRules/FactIdentityComparer.cs
@@ -14,11 +14,12 @@ namespace NRules;
 /// <list type="bullet">
 /// <item>If both facts are the same reference, they are considered identical.</item>
 /// <item>If facts are of different types, they are considered not identical.</item>
-/// <item>If custom comparer is registered for the fact type in <see cref="RuleCompiler.FactIdentityComparerRegistry"/>,
+/// <item>If custom comparer is registered for the fact type in <see cref="FactIdentityComparerRegistry"/>,
 /// it is used to compare the identity of the facts.</item>
-/// <item><see cref="RuleCompiler.DefaultFactIdentityComparer"/> is used to compare the identity of the facts.
-/// Built-in implementation compares returned identity objects if facts implement <see cref="IIdentityProvider"/>.</item>
-/// <item>Otherwise, the objects are compared using their equality.</item>
+/// <item>In all other cases <see cref="FactIdentityComparerRegistry.DefaultFactIdentityComparer"/> is used
+/// to compare the identity of the facts.
+/// It checks if facts implement <see cref="IIdentityProvider"/> and compares the identity objects in this case.
+/// Otherwise, the facts are compared using their equality.</item>
 /// </list>
 /// </remarks>
 public interface IFactIdentityComparer : IEqualityComparer<object>

--- a/src/NRules/NRules/FactIdentityComparer.cs
+++ b/src/NRules/NRules/FactIdentityComparer.cs
@@ -43,7 +43,10 @@ internal class FactIdentityComparer : IFactIdentityComparer
     {
         _defaultComparer = defaultComparer;
         if (customComparers.Any())
-            _customComparers = customComparers.ToDictionary(x => x.FactType, x => (x.Comparer, x.WrappedComparer));
+        {
+            var comparers = customComparers.ToDictionary(x => x.FactType, x => (x.Comparer, x.WrappedComparer));
+            _customComparers = new(comparers, TypeEqualityComparer.Instance);
+        }
     }
     
     public IEqualityComparer<TFact> GetComparer<TFact>()
@@ -141,6 +144,21 @@ internal class FactIdentityComparer : IFactIdentityComparer
             if (obj == null)
                 return 0;
             return _comparer.GetHashCode(obj);
+        }
+    }
+    
+    private class TypeEqualityComparer : IEqualityComparer<Type>
+    {
+        public static TypeEqualityComparer Instance { get; } = new();
+        
+        public bool Equals(Type x, Type y)
+        {
+            return x == y;
+        }
+
+        public int GetHashCode(Type obj)
+        {
+            return obj.GetHashCode();
         }
     }
 }

--- a/src/NRules/NRules/FactIdentityComparerRegistry.cs
+++ b/src/NRules/NRules/FactIdentityComparerRegistry.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+namespace NRules;
+
+/// <summary>
+/// Registry of custom equality comparers for specific fact types.
+/// </summary>
+public class FactIdentityComparerRegistry
+{
+    private readonly Dictionary<Type, Entry> _comparers = new();
+
+    /// <summary>
+    /// Register a custom fact identity comparer for a specific fact type.
+    /// </summary>
+    /// <param name="comparer">Custom fact identity comparer.</param>
+    /// <typeparam name="TFact">Type of fact for which identity comparer is registered.</typeparam>
+    public void RegisterComparer<TFact>(IEqualityComparer<TFact> comparer)
+    {
+        var wrappedComparer = new SpecificComparerWrapper<TFact>(comparer);
+        _comparers[typeof(TFact)] = new Entry(typeof(TFact), comparer, wrappedComparer);
+    }
+    
+    internal IReadOnlyCollection<Entry> GetComparers()
+    {
+        return _comparers.Values;
+    }
+
+    internal class Entry(Type factType, object comparer, IEqualityComparer<object> wrappedComparer)
+    {
+        public Type FactType { get; } = factType;
+        public object Comparer { get; } = comparer;
+        public IEqualityComparer<object> WrappedComparer { get; } = wrappedComparer;
+    }
+
+    private class SpecificComparerWrapper<TFact> : IEqualityComparer<object>
+    {
+        private readonly IEqualityComparer<TFact> _comparer;
+
+        public SpecificComparerWrapper(IEqualityComparer<TFact> comparer)
+        {
+            _comparer = comparer;
+        }
+
+        bool IEqualityComparer<object>.Equals(object x, object y)
+        {
+            return _comparer.Equals((TFact)x, (TFact)y);
+        }
+
+        int IEqualityComparer<object>.GetHashCode(object obj)
+        {
+            return _comparer.GetHashCode((TFact)obj);
+        }
+    }
+}

--- a/src/NRules/NRules/FactIdentityComparerRegistry.cs
+++ b/src/NRules/NRules/FactIdentityComparerRegistry.cs
@@ -1,20 +1,37 @@
 using System;
 using System.Collections.Generic;
+using NRules.RuleModel;
 
 namespace NRules;
 
 /// <summary>
-/// Registry of custom equality comparers for specific fact types.
+/// Registry of custom equality comparers for specific fact types used by
+/// <see cref="IFactIdentityComparer"/> when managing facts in the rules session.
 /// </summary>
 public class FactIdentityComparerRegistry
 {
     private readonly Dictionary<Type, Entry> _comparers = new();
 
     /// <summary>
+    /// Default equality comparer used to compare fact identity, when inserting, updating, removing
+    /// facts within the rules session.
+    /// Used by <see cref="IFactIdentityComparer"/> when no custom comparer is registered for the fact type.
+    /// </summary>
+    /// <remarks>
+    /// Built-in implementation uses <see cref="IIdentityProvider"/> if implemented by the fact,
+    /// to compare fact identity. Otherwise, it uses the fact's equality for identity comparison.
+    /// </remarks>
+    public IEqualityComparer<object> DefaultFactIdentityComparer { get; set; } = new DefaultFactIdentityComparer();
+
+    /// <summary>
     /// Register a custom fact identity comparer for a specific fact type.
+    /// Used by <see cref="IFactIdentityComparer"/> to compare identity of facts of the specified type.
     /// </summary>
     /// <param name="comparer">Custom fact identity comparer.</param>
     /// <typeparam name="TFact">Type of fact for which identity comparer is registered.</typeparam>
+    /// <remarks>
+    /// Custom comparers are not polymorphic. They are used only for the exact type they are registered for.
+    /// </remarks>
     public void RegisterComparer<TFact>(IEqualityComparer<TFact> comparer)
     {
         var wrappedComparer = new SpecificComparerWrapper<TFact>(comparer);

--- a/src/NRules/NRules/Rete/AggregateNode.cs
+++ b/src/NRules/NRules/Rete/AggregateNode.cs
@@ -40,7 +40,7 @@ internal class AggregateNode : BinaryBetaNode
             var joinedSets = JoinedSets(context, tuples);
             foreach (var set in joinedSets)
             {
-                IFactAggregator aggregator = CreateFactAggregator(context, set.Tuple);
+                IFactAggregator aggregator = CreateFactAggregator(aggregationContext, set.Tuple);
                 AddToAggregate(aggregationContext, aggregator, aggregation, set.Tuple, set.Facts);
             }
 
@@ -74,7 +74,7 @@ internal class AggregateNode : BinaryBetaNode
                 else
                 {
                     var matchingFacts = set.Facts;
-                    aggregator = CreateFactAggregator(context, set.Tuple);
+                    aggregator = CreateFactAggregator(aggregationContext, set.Tuple);
                     AddToAggregate(aggregationContext, aggregator, aggregation, set.Tuple, matchingFacts);
                 }
             }
@@ -121,7 +121,7 @@ internal class AggregateNode : BinaryBetaNode
                 IFactAggregator? aggregator = GetFactAggregator(context, set.Tuple);
                 if (aggregator == null)
                 {
-                    aggregator = CreateFactAggregator(context, set.Tuple);
+                    aggregator = CreateFactAggregator(aggregationContext, set.Tuple);
 
                     var originalSet = JoinedSet(context, set.Tuple);
                     var matchingOriginalFacts = originalSet.Facts;
@@ -157,7 +157,7 @@ internal class AggregateNode : BinaryBetaNode
                 else
                 {
                     var fullSet = JoinedSet(context, set.Tuple);
-                    aggregator = CreateFactAggregator(context, fullSet.Tuple);
+                    aggregator = CreateFactAggregator(aggregationContext, fullSet.Tuple);
                     AddToAggregate(aggregationContext, aggregator, aggregation, fullSet.Tuple, fullSet.Facts);
                 }
             }
@@ -277,11 +277,11 @@ internal class AggregateNode : BinaryBetaNode
         }
     }
 
-    private IFactAggregator CreateFactAggregator(IExecutionContext context, Tuple tuple)
+    private IFactAggregator CreateFactAggregator(AggregationContext context, Tuple tuple)
     {
-        var aggregator = _aggregatorFactory.Create();
-        var factAggregator = new FactAggregator(aggregator);
-        context.WorkingMemory.SetState(this, tuple, factAggregator);
+        var aggregator = _aggregatorFactory.Create(context);
+        var factAggregator = new FactAggregator(aggregator, context);
+        context.ExecutionContext.WorkingMemory.SetState(this, tuple, factAggregator);
         return factAggregator;
     }
 

--- a/src/NRules/NRules/Rete/FactAggregator.cs
+++ b/src/NRules/NRules/Rete/FactAggregator.cs
@@ -16,11 +16,12 @@ internal interface IFactAggregator
 internal class FactAggregator : IFactAggregator
 {
     private readonly IAggregator _aggregator;
-    private readonly OrderedDictionary<object, Fact> _aggregateFactMap = new();
+    private readonly OrderedDictionary<object, Fact> _aggregateFactMap;
 
-    public FactAggregator(IAggregator aggregator)
+    public FactAggregator(IAggregator aggregator, AggregationContext context)
     {
         _aggregator = aggregator;
+        _aggregateFactMap = new OrderedDictionary<object, Fact>(context.FactIdentityComparer);
     }
 
     public IReadOnlyCollection<Fact> AggregateFacts => _aggregateFactMap.Values;

--- a/src/NRules/NRules/RuleCompiler.cs
+++ b/src/NRules/NRules/RuleCompiler.cs
@@ -25,7 +25,7 @@ public class RuleCompiler
     /// using the default <see cref="RuleCompilerOptions"/>.
     /// </summary>
     public RuleCompiler()
-        : this(new RuleCompilerOptions())
+        : this(RuleCompilerOptions.Default)
     {
     }
 
@@ -33,11 +33,27 @@ public class RuleCompiler
     /// Initializes a new instance of the <see cref="RuleCompiler"/> class
     /// using the specified <see cref="RuleCompilerOptions"/>.
     /// </summary>
-    /// <param name="options"></param>
+    /// <param name="options">Compiler options to use.</param>
     public RuleCompiler(RuleCompilerOptions options)
     {
         _options = options;
     }
+    
+    /// <summary>
+    /// Default equality comparer used to compare fact identity, when inserting, updating, removing
+    /// facts within the rules session.
+    /// </summary>
+    /// <remarks>
+    /// Built-in implementation uses <see cref="IIdentityProvider"/> if implemented by the fact,
+    /// to determine fact identity.
+    /// </remarks>
+    public IEqualityComparer<object> DefaultFactIdentityComparer { get; set; } = new DefaultFactIdentityComparer();
+    
+    /// <summary>
+    /// Equality comparers for specific fact types, used to compare fact identity, when inserting, updating, removing
+    /// facts within the rules session.
+    /// </summary>
+    public FactIdentityComparerRegistry FactIdentityComparerRegistry { get; } = new();
 
     /// <summary>
     /// Registry of custom aggregator factories.
@@ -98,7 +114,8 @@ public class RuleCompiler
         }
 
         INetwork network = reteBuilder.Build();
-        var factory = new SessionFactory(network, compiledRules);
+        var factIdentityComparer = new FactIdentityComparer(DefaultFactIdentityComparer, FactIdentityComparerRegistry.GetComparers());
+        var factory = new SessionFactory(network, compiledRules, factIdentityComparer);
         return factory;
     }
 

--- a/src/NRules/NRules/RuleCompiler.cs
+++ b/src/NRules/NRules/RuleCompiler.cs
@@ -40,16 +40,6 @@ public class RuleCompiler
     }
     
     /// <summary>
-    /// Default equality comparer used to compare fact identity, when inserting, updating, removing
-    /// facts within the rules session.
-    /// </summary>
-    /// <remarks>
-    /// Built-in implementation uses <see cref="IIdentityProvider"/> if implemented by the fact,
-    /// to determine fact identity.
-    /// </remarks>
-    public IEqualityComparer<object> DefaultFactIdentityComparer { get; set; } = new DefaultFactIdentityComparer();
-    
-    /// <summary>
     /// Equality comparers for specific fact types, used to compare fact identity, when inserting, updating, removing
     /// facts within the rules session.
     /// </summary>
@@ -114,7 +104,9 @@ public class RuleCompiler
         }
 
         INetwork network = reteBuilder.Build();
-        var factIdentityComparer = new FactIdentityComparer(DefaultFactIdentityComparer, FactIdentityComparerRegistry.GetComparers());
+        var factIdentityComparer = new FactIdentityComparer(
+            FactIdentityComparerRegistry.DefaultFactIdentityComparer,
+            FactIdentityComparerRegistry.GetComparers());
         var factory = new SessionFactory(network, compiledRules, factIdentityComparer);
         return factory;
     }

--- a/src/NRules/NRules/RuleCompilerOptions.cs
+++ b/src/NRules/NRules/RuleCompilerOptions.cs
@@ -25,6 +25,11 @@ public enum RuleCompilerUnsupportedExpressionsHandling
 public class RuleCompilerOptions
 {
     /// <summary>
+    /// Default options for the rule compiler.
+    /// </summary>
+    public static RuleCompilerOptions Default => new();
+    
+    /// <summary>
     /// Determines compiler behavior when it finds an unsupported type of lambda expressions
     /// while comparing them for the purpose of node sharing in the Rete graph.
     /// </summary>

--- a/src/NRules/NRules/SessionFactory.cs
+++ b/src/NRules/NRules/SessionFactory.cs
@@ -77,12 +77,15 @@ public interface ISessionFactory : ISessionSchemaProvider
 internal sealed class SessionFactory : ISessionFactory
 {
     private readonly INetwork _network;
+    private readonly IFactIdentityComparer _factIdentityComparer;
     private readonly List<ICompiledRule> _compiledRules;
     private readonly IEventAggregator _eventAggregator = new EventAggregator();
 
-    public SessionFactory(INetwork network, IEnumerable<ICompiledRule> compiledRules)
+    public SessionFactory(INetwork network, IEnumerable<ICompiledRule> compiledRules,
+        IFactIdentityComparer factIdentityComparer)
     {
         _network = network;
+        _factIdentityComparer = factIdentityComparer;
         _compiledRules = new List<ICompiledRule>(compiledRules);
         DependencyResolver = new DependencyResolver();
     }
@@ -99,7 +102,7 @@ internal sealed class SessionFactory : ISessionFactory
     public ISession CreateSession(Action<ISession>? initializationAction)
     {
         var agenda = CreateAgenda();
-        var workingMemory = new WorkingMemory();
+        var workingMemory = new WorkingMemory(_factIdentityComparer);
         var eventAggregator = new EventAggregator(_eventAggregator);
         var metricsAggregator = new MetricsAggregator();
         var actionExecutor = new ActionExecutor();

--- a/src/NRules/NRules/WorkingMemory.cs
+++ b/src/NRules/NRules/WorkingMemory.cs
@@ -7,6 +7,7 @@ namespace NRules;
 
 internal interface IWorkingMemory
 {
+    IFactIdentityComparer FactIdentityComparer { get; }
     IEnumerable<Fact> Facts { get; }
 
     Fact? GetFact(object factObject);
@@ -32,7 +33,7 @@ internal interface IWorkingMemory
 
 internal class WorkingMemory : IWorkingMemory
 {
-    private readonly Dictionary<object, Fact> _factMap = new();
+    private readonly Dictionary<object, Fact> _factMap;
     private readonly Dictionary<Activation, Dictionary<object, Fact>> _linkedFactMap = new();
     private readonly Dictionary<TupleStateKey, object> _tupleStateMap = new();
 
@@ -40,8 +41,15 @@ internal class WorkingMemory : IWorkingMemory
 
     private readonly Dictionary<IBetaMemoryNode, IBetaMemory> _betaMap = new();
 
+    public WorkingMemory(IFactIdentityComparer factIdentityComparer)
+    {
+        FactIdentityComparer = factIdentityComparer;
+        _factMap = new Dictionary<object, Fact>(factIdentityComparer);
+    }
+
     private static readonly object[] EmptyObjectList = Array.Empty<object>();
 
+    public IFactIdentityComparer FactIdentityComparer { get; }
     public IEnumerable<Fact> Facts => _factMap.Values;
 
     public Fact? GetFact(object factObject)

--- a/src/NRules/Tests/NRules.IntegrationTests/CustomFirstAggregatorTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/CustomFirstAggregatorTest.cs
@@ -103,7 +103,7 @@ public static class FirstQueryExtensions
 {
     public static IQuery<TSource> First<TSource>(this IQuery<IEnumerable<TSource>> source)
     {
-        var expressions = new List<KeyValuePair<string, LambdaExpression>>();
+        var expressions = Array.Empty<KeyValuePair<string, LambdaExpression>>();
         source.Builder.Aggregate<IEnumerable<TSource>, TSource>("First", expressions, typeof(CustomFirstAggregatorFactory));
         return new QueryExpression<TSource>(source.Builder);
     }
@@ -111,7 +111,7 @@ public static class FirstQueryExtensions
 
 internal class CustomFirstAggregatorFactory : IAggregatorFactory
 {
-    private Func<IAggregator> _factory = null!;
+    private Func<IAggregator>? _factory;
     
     public void Compile(AggregateElement element, IReadOnlyCollection<IAggregateExpression> compiledExpressions)
     {
@@ -121,9 +121,9 @@ internal class CustomFirstAggregatorFactory : IAggregatorFactory
         _factory = factoryExpression.Compile();
     }
 
-    public IAggregator Create()
+    public IAggregator Create(AggregationContext context)
     {
-        return _factory();
+        return _factory!();
     }
 }
 

--- a/src/NRules/Tests/NRules.IntegrationTests/CustomSelectAggregatorTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/CustomSelectAggregatorTest.cs
@@ -156,7 +156,7 @@ internal class CustomSelectAggregateFactory : IAggregatorFactory
         _factory = factoryExpression.Compile();
     }
 
-    public IAggregator Create()
+    public IAggregator Create(AggregationContext context)
     {
         return _factory!();
     }

--- a/src/NRules/Tests/NRules.IntegrationTests/OneFactOneGroupByFlattenWithEquatableRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneFactOneGroupByFlattenWithEquatableRuleTest.cs
@@ -4,13 +4,12 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using NRules.Fluent.Dsl;
 using NRules.IntegrationTests.TestAssets;
-using NRules.RuleModel;
 using NRules.Testing;
 using Xunit;
 
 namespace NRules.IntegrationTests;
 
-public class OneFactOneGroupByFlattenWithIdentityRuleTest : BaseRulesTestFixture
+public class OneFactOneGroupByFlattenWithEquatableRuleTest : BaseRulesTestFixture
 {
     [Fact]
     public void Fire_UpdatesWithSameIdButDifferentCount_FiresWithNewCount2()
@@ -52,7 +51,7 @@ public class OneFactOneGroupByFlattenWithIdentityRuleTest : BaseRulesTestFixture
         setup.Rule<TestRule>();
     }
 
-    public class FactType : IIdentityProvider
+    public class FactType : IEquatable<FactType>
     {
         public long Id { get; set; }
         public int TestCount { get; set; }
@@ -61,7 +60,30 @@ public class OneFactOneGroupByFlattenWithIdentityRuleTest : BaseRulesTestFixture
         [NotNull]
         public string? GroupingProperty2 { get; set; }
 
-        public object GetIdentity() => Id;
+        public bool Equals(FactType? other)
+        {
+            if (other is null)
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return Id == other.Id;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is null)
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != GetType())
+                return false;
+            return Equals((FactType)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
     }
 
     public class TestRule : Rule

--- a/src/NRules/Tests/NRules.IntegrationTests/OneIdentityFactRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneIdentityFactRuleTest.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using NRules.Fluent.Dsl;
+using NRules.IntegrationTests.TestAssets;
+using NRules.RuleModel;
+using NRules.Testing;
+using Xunit;
+
+namespace NRules.IntegrationTests;
+
+public class OneIdentityFactRuleTest : BaseRulesTestFixture
+{
+    [Fact]
+    public void Fire_OneMatchingFact_FiresOnce()
+    {
+        //Arrange
+        var fact = new FactType(1) { TestProperty = "Valid Value 1" };
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFacts_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType(2) { TestProperty = "Valid Value 2" };
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired(Times.Twice));
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType(1) { TestProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired(Times.Never));
+    }
+
+    [Fact]
+    public void Fire_OneFactUpdatedFromInvalidToMatching_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Invalid Value 1" };
+        var fact2 = new FactType(1) { TestProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired());
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndRetractedAndAssertedAgain_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact3 = new FactType(1) { TestProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Retract(fact2);
+        Session.Insert(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired());
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndUpdatedToInvalid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType(1) { TestProperty = "Invalid Value 1" };
+        Session.Insert(fact1);
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired(Times.Never));
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndModifiedAndRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType(1) { TestProperty = "Invalid Value 1" };
+        Session.Insert(fact1);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired(Times.Never));
+    }
+
+    [Fact]
+    public void Fire_DuplicateInsert_Throws()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType(1) { TestProperty = "Valid Value 2" };
+
+        //Act - Assert
+        Session.Insert(fact1);
+        Assert.Throws<ArgumentException>(() => Session.Insert(fact2));
+    }
+
+    protected override void SetUpRules(IRulesTestSetup setup)
+    {
+        setup.Rule<TestRule>();
+    }
+
+    public class FactType : IEquatable<FactType>, IIdentityProvider
+    {
+        public FactType(int id)
+        {
+            Id = id;
+        }
+
+        public int Id { get; }
+        [NotNull]
+        public string? TestProperty { get; set; }
+
+        public bool Equals(FactType? other)
+        {
+            if (other is null)
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return TestProperty == other.TestProperty;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is null)
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != GetType())
+                return false;
+            return Equals((FactType)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Id;
+        }
+
+        public object GetIdentity()
+        {
+            return Id;
+        }
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
+        {
+            FactType fact = null!;
+
+            When()
+                .Match(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
+        }
+    }
+}

--- a/src/NRules/Tests/NRules.IntegrationTests/OneRecordFactRuleTest.cs
+++ b/src/NRules/Tests/NRules.IntegrationTests/OneRecordFactRuleTest.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using NRules.Fluent.Dsl;
+using NRules.IntegrationTests.TestAssets;
+using NRules.RuleModel;
+using NRules.Testing;
+using Xunit;
+
+namespace NRules.IntegrationTests;
+
+public class OneRecordFactRuleTest : BaseRulesTestFixture
+{
+    [Fact]
+    public void Fire_OneMatchingFact_FiresOnce()
+    {
+        //Arrange
+        var fact = new FactType(1) { TestProperty = "Valid Value 1" };
+        Session.Insert(fact);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired());
+    }
+
+    [Fact]
+    public void Fire_TwoMatchingFacts_FiresTwice()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType(2) { TestProperty = "Valid Value 2" };
+        var facts = new[] { fact1, fact2 };
+        Session.InsertAll(facts);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired(Times.Twice));
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType(1) { TestProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired(Times.Never));
+    }
+
+    [Fact]
+    public void Fire_OneFactUpdatedFromInvalidToMatching_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Invalid Value 1" };
+        var fact2 = new FactType(1) { TestProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired());
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndRetractedAndAssertedAgain_FiresOnce()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact3 = new FactType(1) { TestProperty = "Valid Value 1" };
+        Session.Insert(fact1);
+        Session.Retract(fact2);
+        Session.Insert(fact3);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired());
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndUpdatedToInvalid_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType(1) { TestProperty = "Invalid Value 1" };
+        Session.Insert(fact1);
+        Session.Update(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired(Times.Never));
+    }
+
+    [Fact]
+    public void Fire_OneMatchingFactAssertedAndModifiedAndRetracted_DoesNotFire()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType(1) { TestProperty = "Invalid Value 1" };
+        Session.Insert(fact1);
+        Session.Retract(fact2);
+
+        //Act
+        Session.Fire();
+
+        //Assert
+        Verify(x => x.Rule().Fired(Times.Never));
+    }
+
+    [Fact]
+    public void Fire_DuplicateInsert_Throws()
+    {
+        //Arrange
+        var fact1 = new FactType(1) { TestProperty = "Valid Value 1" };
+        var fact2 = new FactType(1) { TestProperty = "Valid Value 2" };
+
+        //Act - Assert
+        Session.Insert(fact1);
+        Assert.Throws<ArgumentException>(() => Session.Insert(fact2));
+    }
+
+    protected override void SetUpRules(IRulesTestSetup setup)
+    {
+        setup.Rule<TestRule>();
+    }
+
+    public record FactType : IIdentityProvider
+    {
+        public FactType(int id)
+        {
+            Id = id;
+        }
+
+        public int Id { get; }
+        [NotNull]
+        public string? TestProperty { get; set; }
+
+        public object GetIdentity() => Id;
+    }
+
+    public class TestRule : Rule
+    {
+        public override void Define()
+        {
+            FactType fact = null!;
+
+            When()
+                .Match(() => fact, f => f.TestProperty.StartsWith("Valid"));
+            Then()
+                .Do(ctx => ctx.NoOp());
+        }
+    }
+}

--- a/src/NRules/Tests/NRules.Tests/Aggregators/FlatteningAggregatorTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Aggregators/FlatteningAggregatorTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Moq;
 using NRules.Aggregators;
 using NRules.Diagnostics;
+using NRules.RuleModel;
 using Xunit;
 
 namespace NRules.Tests.Aggregators;
@@ -18,19 +19,19 @@ public class FlatteningAggregatorTest : AggregatorTest
         var target = CreateTarget();
 
         //Act
-        var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
+        var facts = AsFact(new TestFact1(1, "value11", "value12"), new TestFact1(2, "value21", "value22"));
         var result = target.Add(context, EmptyTuple(), facts).ToArray();
 
         //Assert
         Assert.Equal(4, result.Length);
         Assert.Equal(AggregationAction.Added, result[0].Action);
-        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal("value11", ((TestFact2)result[0].Aggregate).Value);
         Assert.Equal(AggregationAction.Added, result[1].Action);
-        Assert.Equal("value12", result[1].Aggregate);
+        Assert.Equal("value12", ((TestFact2)result[1].Aggregate).Value);
         Assert.Equal(AggregationAction.Added, result[2].Action);
-        Assert.Equal("value21", result[2].Aggregate);
+        Assert.Equal("value21", ((TestFact2)result[2].Aggregate).Value);
         Assert.Equal(AggregationAction.Added, result[3].Action);
-        Assert.Equal("value22", result[3].Aggregate);
+        Assert.Equal("value22", ((TestFact2)result[3].Aggregate).Value);
     }
 
     [Fact]
@@ -41,21 +42,21 @@ public class FlatteningAggregatorTest : AggregatorTest
         var target = CreateTarget();
 
         //Act
-        var facts = AsFact(new TestFact(1, "value11", "value12", "value12", "valuex"), new TestFact(2, "value21", "value21", "value22", "valuex"));
+        var facts = AsFact(new TestFact1(1, "value11", "value12", "value12", "valuex"), new TestFact1(2, "value21", "value21", "value22", "valuex"));
         var result = target.Add(context, EmptyTuple(), facts).ToArray();
 
         //Assert
         Assert.Equal(5, result.Length);
         Assert.Equal(AggregationAction.Added, result[0].Action);
-        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal("value11", ((TestFact2)result[0].Aggregate).Value);
         Assert.Equal(AggregationAction.Added, result[1].Action);
-        Assert.Equal("value12", result[1].Aggregate);
+        Assert.Equal("value12", ((TestFact2)result[1].Aggregate).Value);
         Assert.Equal(AggregationAction.Added, result[2].Action);
-        Assert.Equal("valuex", result[2].Aggregate);
+        Assert.Equal("valuex", ((TestFact2)result[2].Aggregate).Value);
         Assert.Equal(AggregationAction.Added, result[3].Action);
-        Assert.Equal("value21", result[3].Aggregate);
+        Assert.Equal("value21", ((TestFact2)result[3].Aggregate).Value);
         Assert.Equal(AggregationAction.Added, result[4].Action);
-        Assert.Equal("value22", result[4].Aggregate);
+        Assert.Equal("value22", ((TestFact2)result[4].Aggregate).Value);
     }
 
     [Fact]
@@ -66,7 +67,7 @@ public class FlatteningAggregatorTest : AggregatorTest
         var target = CreateTarget();
 
         //Act
-        var facts = AsFact(Array.Empty<TestFact>());
+        var facts = AsFact(Array.Empty<TestFact1>());
         var result = target.Add(context, EmptyTuple(), facts).ToArray();
 
         //Assert
@@ -79,19 +80,20 @@ public class FlatteningAggregatorTest : AggregatorTest
         //Arrange
         var context = GetContext();
         var target = CreateTarget();
-        var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
+        var facts = AsFact(new TestFact1(1, "value11", "value12"), new TestFact1(2, "value21", "value22"));
         target.Add(context, EmptyTuple(), facts);
 
         //Act
-        var toUpdate = facts.Take(1).ToArray();
+        var toUpdate = new []{facts[0]};
+        facts[0].Value = new TestFact1(1, "value11", "value12");
         var result = target.Modify(context, EmptyTuple(), toUpdate).ToArray();
 
         //Assert
         Assert.Equal(2, result.Length);
         Assert.Equal(AggregationAction.Modified, result[0].Action);
-        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal("value11", ((TestFact2)result[0].Aggregate).Value);
         Assert.Equal(AggregationAction.Modified, result[1].Action);
-        Assert.Equal("value12", result[1].Aggregate);
+        Assert.Equal("value12", ((TestFact2)result[1].Aggregate).Value);
     }
 
     [Fact]
@@ -100,24 +102,24 @@ public class FlatteningAggregatorTest : AggregatorTest
         //Arrange
         var context = GetContext();
         var target = CreateTarget();
-        var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
+        var facts = AsFact(new TestFact1(1, "value11", "value12"), new TestFact1(2, "value21", "value22"));
         target.Add(context, EmptyTuple(), facts);
 
         //Act
-        facts[0].Value = new TestFact(3, "value31", "value32");
+        facts[0].Value = new TestFact1(3, "value31", "value32");
         var toUpdate = facts.Take(1).ToArray();
         var result = target.Modify(context, EmptyTuple(), toUpdate).ToArray();
 
         //Assert
         Assert.Equal(4, result.Length);
         Assert.Equal(AggregationAction.Removed, result[0].Action);
-        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal("value11", ((TestFact2)result[0].Aggregate).Value);
         Assert.Equal(AggregationAction.Removed, result[1].Action);
-        Assert.Equal("value12", result[1].Aggregate);
+        Assert.Equal("value12", ((TestFact2)result[1].Aggregate).Value);
         Assert.Equal(AggregationAction.Added, result[2].Action);
-        Assert.Equal("value31", result[2].Aggregate);
+        Assert.Equal("value31", ((TestFact2)result[2].Aggregate).Value);
         Assert.Equal(AggregationAction.Added, result[3].Action);
-        Assert.Equal("value32", result[3].Aggregate);
+        Assert.Equal("value32", ((TestFact2)result[3].Aggregate).Value);
     }
 
     [Fact]
@@ -126,22 +128,22 @@ public class FlatteningAggregatorTest : AggregatorTest
         //Arrange
         var context = GetContext();
         var target = CreateTarget();
-        var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
+        var facts = AsFact(new TestFact1(1, "value11", "value12"), new TestFact1(2, "value21", "value22"));
         target.Add(context, EmptyTuple(), facts);
 
         //Act
-        facts[0].Value = new TestFact(2, "value12", "value13");
+        facts[0].Value = new TestFact1(2, "value12", "value13");
         var toUpdate = facts.Take(1).ToArray();
         var result = target.Modify(context, EmptyTuple(), toUpdate).ToArray();
 
         //Assert
         Assert.Equal(3, result.Length);
         Assert.Equal(AggregationAction.Removed, result[0].Action);
-        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal("value11", ((TestFact2)result[0].Aggregate).Value);
         Assert.Equal(AggregationAction.Modified, result[1].Action);
-        Assert.Equal("value12", result[1].Aggregate);
+        Assert.Equal("value12", ((TestFact2)result[1].Aggregate).Value);
         Assert.Equal(AggregationAction.Added, result[2].Action);
-        Assert.Equal("value13", result[2].Aggregate);
+        Assert.Equal("value13", ((TestFact2)result[2].Aggregate).Value);
     }
 
     [Fact]
@@ -151,22 +153,22 @@ public class FlatteningAggregatorTest : AggregatorTest
         var context = GetContext();
         var target = CreateTarget();
 
-        var facts = AsFact(new TestFact(1, "value11", "value12", "value12", "valuex"), new TestFact(2, "value21", "value21", "value22", "valuex"));
+        var facts = AsFact(new TestFact1(1, "value11", "value12", "value12", "valuex"), new TestFact1(2, "value21", "value21", "value22", "valuex"));
         target.Add(context, EmptyTuple(), facts);
 
         //Act
-        facts[0].Value = new TestFact(2, "value12", "value13");
+        facts[0].Value = new TestFact1(2, "value12", "value13");
         var toUpdate = facts.Take(1).ToArray();
         var result = target.Modify(context, EmptyTuple(), toUpdate).ToArray();
 
         //Assert
         Assert.Equal(3, result.Length);
         Assert.Equal(AggregationAction.Removed, result[0].Action);
-        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal("value11", ((TestFact2)result[0].Aggregate).Value);
         Assert.Equal(AggregationAction.Modified, result[1].Action);
-        Assert.Equal("value12", result[1].Aggregate);
+        Assert.Equal("value12", ((TestFact2)result[1].Aggregate).Value);
         Assert.Equal(AggregationAction.Added, result[2].Action);
-        Assert.Equal("value13", result[2].Aggregate);
+        Assert.Equal("value13", ((TestFact2)result[2].Aggregate).Value);
     }
 
     [Fact]
@@ -178,7 +180,7 @@ public class FlatteningAggregatorTest : AggregatorTest
 
         //Act - Assert
         Assert.Throws<KeyNotFoundException>(
-            () => target.Modify(context, EmptyTuple(), AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"))));
+            () => target.Modify(context, EmptyTuple(), AsFact(new TestFact1(1, "value11", "value12"), new TestFact1(2, "value21", "value22"))));
     }
 
     [Fact]
@@ -187,7 +189,7 @@ public class FlatteningAggregatorTest : AggregatorTest
         //Arrange
         var context = GetContext();
         var target = CreateTarget();
-        var facts = AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"));
+        var facts = AsFact(new TestFact1(1, "value11", "value12"), new TestFact1(2, "value21", "value22"));
         target.Add(context, EmptyTuple(), facts);
 
         //Act
@@ -197,9 +199,9 @@ public class FlatteningAggregatorTest : AggregatorTest
         //Assert
         Assert.Equal(2, result.Length);
         Assert.Equal(AggregationAction.Removed, result[0].Action);
-        Assert.Equal("value11", result[0].Aggregate);
+        Assert.Equal("value11", ((TestFact2)result[0].Aggregate).Value);
         Assert.Equal(AggregationAction.Removed, result[1].Action);
-        Assert.Equal("value12", result[1].Aggregate);
+        Assert.Equal("value12", ((TestFact2)result[1].Aggregate).Value);
     }
 
     [Fact]
@@ -209,7 +211,7 @@ public class FlatteningAggregatorTest : AggregatorTest
         var context = GetContext();
         var target = CreateTarget();
 
-        var facts = AsFact(new TestFact(1, "value11", "value12", "value12", "valuex"), new TestFact(2, "value21", "value21", "value22", "valuex"));
+        var facts = AsFact(new TestFact1(1, "value11", "value12", "value12", "valuex"), new TestFact1(2, "value21", "value21", "value22", "valuex"));
         target.Add(context, EmptyTuple(), facts);
 
         //Act - I
@@ -219,9 +221,9 @@ public class FlatteningAggregatorTest : AggregatorTest
         //Assert - I
         Assert.Equal(2, result1.Length);
         Assert.Equal(AggregationAction.Removed, result1[0].Action);
-        Assert.Equal("value11", result1[0].Aggregate);
+        Assert.Equal("value11", ((TestFact2)result1[0].Aggregate).Value);
         Assert.Equal(AggregationAction.Removed, result1[1].Action);
-        Assert.Equal("value12", result1[1].Aggregate);
+        Assert.Equal("value12", ((TestFact2)result1[1].Aggregate).Value);
 
         //Act - II
         var toRemove2 = facts.Skip(1).Take(1).ToArray();
@@ -230,11 +232,11 @@ public class FlatteningAggregatorTest : AggregatorTest
         //Assert - II
         Assert.Equal(3, result2.Length);
         Assert.Equal(AggregationAction.Removed, result2[0].Action);
-        Assert.Equal("value21", result2[0].Aggregate);
+        Assert.Equal("value21", ((TestFact2)result2[0].Aggregate).Value);
         Assert.Equal(AggregationAction.Removed, result2[1].Action);
-        Assert.Equal("value22", result2[1].Aggregate);
+        Assert.Equal("value22", ((TestFact2)result2[1].Aggregate).Value);
         Assert.Equal(AggregationAction.Removed, result2[2].Action);
-        Assert.Equal("valuex", result2[2].Aggregate);
+        Assert.Equal("valuex", ((TestFact2)result2[2].Aggregate).Value);
     }
 
     [Fact]
@@ -246,7 +248,7 @@ public class FlatteningAggregatorTest : AggregatorTest
 
         //Act - Assert
         Assert.Throws<KeyNotFoundException>(
-            () => target.Remove(context, EmptyTuple(), AsFact(new TestFact(1, "value11", "value12"), new TestFact(2, "value21", "value22"))));
+            () => target.Remove(context, EmptyTuple(), AsFact(new TestFact1(1, "value11", "value12"), new TestFact1(2, "value21", "value22"))));
     }
 
     private static AggregationContext GetContext()
@@ -255,41 +257,56 @@ public class FlatteningAggregatorTest : AggregatorTest
         return new AggregationContext(mockExecutionContext.Object, new NodeInfo());
     }
     
-    private FlatteningAggregator<TestFact, string> CreateTarget()
+    private FlatteningAggregator<TestFact1, TestFact2> CreateTarget()
     {
-        var expression = new FactExpression<TestFact, IEnumerable<string>>(x => x.Values);
-        return new FlatteningAggregator<TestFact, string>(expression);
+        var identityComparer = new FactIdentityComparer(
+            new DefaultFactIdentityComparer(), Array.Empty<FactIdentityComparerRegistry.Entry>());
+        var expression = new FactExpression<TestFact1, IEnumerable<TestFact2>>(x => x.Values);
+        var aggregator = new FlatteningAggregator<TestFact1, TestFact2>(identityComparer, expression);
+        return aggregator;
     }
 
-    private class TestFact : IEquatable<TestFact>
+    private class TestFact1 : IEquatable<TestFact1>
     {
-        public TestFact(int id, params string[] values)
+        public TestFact1(int id, params string[] values)
         {
             Id = id;
-            Values = values;
+            Values = values.Select(v => new TestFact2(v)).ToArray();
         }
 
         public int Id { get; }
-        public string[] Values { get; }
+        public TestFact2[] Values { get; }
 
-        public bool Equals(TestFact? other)
+        public bool Equals(TestFact1? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return Id == other.Id;
         }
-
+        
         public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != this.GetType()) return false;
-            return Equals((TestFact) obj);
+            return Equals((TestFact1) obj);
         }
-
+        
         public override int GetHashCode()
         {
             return Id;
         }
+    }
+
+    private class TestFact2 : IIdentityProvider
+    {
+        public string Value { get; }
+
+        public TestFact2(string value)
+        {
+            Value = value;
+        }
+        
+        public object GetIdentity() => Value;
     }
 }

--- a/src/NRules/Tests/NRules.Tests/FactIdentityComparerTest.cs
+++ b/src/NRules/Tests/NRules.Tests/FactIdentityComparerTest.cs
@@ -299,7 +299,7 @@ public class FactIdentityComparerTest
     public void Equals_CustomDefaultComparer_CustomWithSameIdentityDifferentEquality_True()
     {
         // Arrange
-        var target = CreateTarget(new CustomFactIdentityComparer());
+        var target = CreateTarget(x => x.DefaultFactIdentityComparer = new CustomFactIdentityComparer());
 
         // Act
         var result = target.Equals(new FactWithCustomIdentity(1, "20"), new FactWithCustomIdentity(1, "21"));
@@ -312,7 +312,7 @@ public class FactIdentityComparerTest
     public void Equals_CustomDefaultComparer_CustomWithDifferentIdentitySameEquality_False()
     {
         // Arrange
-        var target = CreateTarget(new CustomFactIdentityComparer());
+        var target = CreateTarget(x => x.DefaultFactIdentityComparer = new CustomFactIdentityComparer());
 
         // Act
         var result = target.Equals(new FactWithCustomIdentity(1, "20"), new FactWithCustomIdentity(2, "20"));
@@ -325,7 +325,8 @@ public class FactIdentityComparerTest
     public void Equals_StronglyTypedCustomDefaultComparer_CustomWithSameIdentityDifferentEquality_True()
     {
         // Arrange
-        var target = CreateTarget(new CustomFactIdentityComparer()).GetComparer<FactWithCustomIdentity>();
+        var target = CreateTarget(x => x.DefaultFactIdentityComparer = new CustomFactIdentityComparer())
+            .GetComparer<FactWithCustomIdentity>();
 
         // Act
         var result = target.Equals(new FactWithCustomIdentity(1, "20"), new FactWithCustomIdentity(1, "21"));
@@ -338,7 +339,8 @@ public class FactIdentityComparerTest
     public void Equals_StronglyTypedCustomDefaultComparer_CustomWithDifferentIdentitySameEquality_False()
     {
         // Arrange
-        var target = CreateTarget(new CustomFactIdentityComparer()).GetComparer<FactWithCustomIdentity>();
+        var target = CreateTarget(x => x.DefaultFactIdentityComparer = new CustomFactIdentityComparer())
+            .GetComparer<FactWithCustomIdentity>();
 
         // Act
         var result = target.Equals(new FactWithCustomIdentity(1, "20"), new FactWithCustomIdentity(2, "20"));
@@ -364,7 +366,7 @@ public class FactIdentityComparerTest
     public void Equals_DefaultComparerPlusCustomFactComparer_FactsWithSameOpaqueIdentity_True()
     {
         // Arrange
-        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer());
+        var target = CreateTarget(x => x.RegisterComparer(new FactWithOpaqueIdentityComparer()));
 
         // Act
         var result = target.Equals(new FactWithOpaqueIdentity(1), new FactWithOpaqueIdentity(1));
@@ -377,7 +379,7 @@ public class FactIdentityComparerTest
     public void Equals_DefaultComparerPlusCustomFactComparer_FactsWithDifferentOpaqueIdentity_False()
     {
         // Arrange
-        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer());
+        var target = CreateTarget(x => x.RegisterComparer(new FactWithOpaqueIdentityComparer()));
 
         // Act
         var result = target.Equals(new FactWithOpaqueIdentity(1), new FactWithOpaqueIdentity(2));
@@ -390,7 +392,7 @@ public class FactIdentityComparerTest
     public void Equals_StronglyTypedCustomFactComparer_Nulls_True()
     {
         // Arrange
-        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+        var target = CreateTarget(x => x.RegisterComparer(new FactWithOpaqueIdentityComparer()))
             .GetComparer<FactWithOpaqueIdentity>();
 
         // Act
@@ -404,7 +406,7 @@ public class FactIdentityComparerTest
     public void Equals_StronglyTypedCustomFactComparer_NullAndObject_False()
     {
         // Arrange
-        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+        var target = CreateTarget(x => x.RegisterComparer(new FactWithOpaqueIdentityComparer()))
             .GetComparer<FactWithOpaqueIdentity>();
 
         // Act
@@ -418,7 +420,7 @@ public class FactIdentityComparerTest
     public void Equals_StronglyTypedCustomFactComparer_ObjectAndNull_False()
     {
         // Arrange
-        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+        var target = CreateTarget(x => x.RegisterComparer(new FactWithOpaqueIdentityComparer()))
             .GetComparer<FactWithOpaqueIdentity>();
 
         // Act
@@ -432,7 +434,7 @@ public class FactIdentityComparerTest
     public void Equals_StronglyTypedCustomFactComparer_DifferentTypesInOneOrder_False()
     {
         // Arrange
-        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+        var target = CreateTarget(x => x.RegisterComparer(new FactWithOpaqueIdentityComparer()))
             .GetComparer<FactWithOpaqueIdentity>();
 
         // Act
@@ -446,7 +448,7 @@ public class FactIdentityComparerTest
     public void Equals_StronglyTypedCustomFactComparer_DifferentTypesInAnotherOrder_False()
     {
         // Arrange
-        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+        var target = CreateTarget(x => x.RegisterComparer(new FactWithOpaqueIdentityComparer()))
             .GetComparer<FactWithOpaqueIdentity>();
 
         // Act
@@ -460,7 +462,7 @@ public class FactIdentityComparerTest
     public void Equals_StronglyTypedCustomFactComparer_FactsWithSameOpaqueIdentity_True()
     {
         // Arrange
-        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+        var target = CreateTarget(x => x.RegisterComparer(new FactWithOpaqueIdentityComparer()))
             .GetComparer<FactWithOpaqueIdentity>();
 
         // Act
@@ -474,7 +476,7 @@ public class FactIdentityComparerTest
     public void Equals_StronglyTypedCustomFactComparer_FactsWithDifferentOpaqueIdentity_False()
     {
         // Arrange
-        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+        var target = CreateTarget(x => x.RegisterComparer(new FactWithOpaqueIdentityComparer()))
             .GetComparer<FactWithOpaqueIdentity>();
 
         // Act
@@ -484,20 +486,13 @@ public class FactIdentityComparerTest
         Assert.False(result);
     }
 
-    private static IFactIdentityComparer CreateTarget(IEqualityComparer<object>? defaultComparer = null, 
-        IReadOnlyCollection<FactIdentityComparerRegistry.Entry>? customComparers = null)
-    {
-        var target = new FactIdentityComparer(
-            defaultComparer ?? new DefaultFactIdentityComparer(),
-            customComparers ?? []);
-        return target;
-    }
-    
-    private static IFactIdentityComparer CreateTargetWithCustomComparer<T>(IEqualityComparer<T> comparer)
+    private static IFactIdentityComparer CreateTarget(Action<FactIdentityComparerRegistry>? action = default)
     {
         var registry = new FactIdentityComparerRegistry();
-        registry.RegisterComparer(comparer);
-        var target = CreateTarget(customComparers: registry.GetComparers());
+        action?.Invoke(registry);
+        var target = new FactIdentityComparer(
+            registry.DefaultFactIdentityComparer,
+            registry.GetComparers());
         return target;
     }
 
@@ -598,7 +593,7 @@ public class FactIdentityComparerTest
             if (obj1 is IHaveCustomIdentity provider1 && obj2 is IHaveCustomIdentity provider2)
                 return provider1.GetIdentity() == provider2.GetIdentity();
 
-            return object.Equals(obj1, obj2);
+            return Equals(obj1, obj2);
         }
 
         int IEqualityComparer<object>.GetHashCode(object? obj)

--- a/src/NRules/Tests/NRules.Tests/FactIdentityComparerTest.cs
+++ b/src/NRules/Tests/NRules.Tests/FactIdentityComparerTest.cs
@@ -1,0 +1,634 @@
+using System;
+using System.Collections.Generic;
+using NRules.RuleModel;
+using Xunit;
+
+namespace NRules.Tests;
+
+public class FactIdentityComparerTest
+{
+    [Fact]
+    public void Equals_DefaultComparer_Nulls_True()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var result = target.Equals(null, null);
+
+        // Assert
+        Assert.True(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedDefaultComparer_Nulls_True()
+    {
+        // Arrange
+        var target = CreateTarget().GetComparer<FactEquatable>();
+
+        // Act
+        var result = target.Equals(null, null);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Equals_DefaultComparer_NullAndObject_False()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var result = target.Equals(null, new FactEquatable("1"));
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_DefaultComparer_ObjectAndNull_False()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var result = target.Equals(new FactEquatable("1"), null);
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedDefaultComparer_NullAndObject_False()
+    {
+        // Arrange
+        var target = CreateTarget().GetComparer<FactEquatable>();
+
+        // Act
+        var result = target.Equals(null, new FactEquatable("1"));
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Equals_DefaultComparer_DifferentTypesInOneOrder_False()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var result = target.Equals(new FactWithIdentity("1"), new FactEquatable("1"));
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_DefaultComparer_DifferentTypesInAnotherOrder_False()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var result = target.Equals(new FactEquatable("1"), new FactWithIdentity("1"));
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedDefaultComparer_DifferentTypesInOneOrder_False()
+    {
+        // Arrange
+        var target = CreateTarget().GetComparer<FactWithIdentity>();
+
+        // Act
+        var result = target.Equals(new FactWithIdentity("1"), new FactWithIdentityEquatable("1", "1"));
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Equals_StronglyTypedDefaultComparer_DifferentTypesInAnotherOrder_False()
+    {
+        // Arrange
+        var target = CreateTarget().GetComparer<FactWithIdentity>();
+
+        // Act
+        var result = target.Equals(new FactWithIdentityEquatable("1", "1"), new FactWithIdentity("1"));
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Equals_DefaultComparer_SameObject_True()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var fact = new FactEquatable("1");
+        var result = target.Equals(fact, fact);
+
+        // Assert
+        Assert.True(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedDefaultComparer_SameObject_True()
+    {
+        // Arrange
+        var target = CreateTarget().GetComparer<FactEquatable>();
+
+        // Act
+        var fact = new FactEquatable("1");
+        var result = target.Equals(fact, fact);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Equals_DefaultComparer_EqualObjectsWithEquatable_True()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var result = target.Equals(new FactEquatable("1"), new FactEquatable("1"));
+
+        // Assert
+        Assert.True(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedDefaultComparer_EqualObjectsWithEquatable_True()
+    {
+        // Arrange
+        var target = CreateTarget().GetComparer<FactEquatable>();
+
+        // Act
+        var result = target.Equals(new FactEquatable("1"), new FactEquatable("1"));
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Equals_DefaultComparer_NonEqualObjectsWithEquatable_False()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var result = target.Equals(new FactEquatable("1"), new FactEquatable("2"));
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedDefaultComparer_NonEqualObjectsWithEquatable_False()
+    {
+        // Arrange
+        var target = CreateTarget().GetComparer<FactEquatable>();
+
+        // Act
+        var result = target.Equals(new FactEquatable("1"), new FactEquatable("2"));
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Equals_DefaultComparer_EqualObjectsWithIdentity_True()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var result = target.Equals(new FactWithIdentity("1"), new FactWithIdentity("1"));
+
+        // Assert
+        Assert.True(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedDefaultComparer_EqualObjectsWithIdentity_True()
+    {
+        // Arrange
+        var target = CreateTarget().GetComparer<FactWithIdentity>();
+
+        // Act
+        var result = target.Equals(new FactWithIdentity("1"), new FactWithIdentity("1"));
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Equals_DefaultComparer_NonEqualObjectsWithIdentity_False()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var result = target.Equals(new FactWithIdentity("1"), new FactWithIdentity("2"));
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Equals_StronglyTypedDefaultComparer_NonEqualObjectsWithIdentity_False()
+    {
+        // Arrange
+        var target = CreateTarget().GetComparer<FactWithIdentity>();
+
+        // Act
+        var result = target.Equals(new FactWithIdentity("1"), new FactWithIdentity("2"));
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Equals_DefaultComparer_EqualObjectsWithSameIdentityAndDifferentEquality_True()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var result = target.Equals(new FactWithIdentityEquatable("1", "20"), new FactWithIdentityEquatable("1", "21"));
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Equals_DefaultComparer_NonEqualObjectsWithDifferentIdentityAndSameEquality_False()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var result = target.Equals(new FactWithIdentityEquatable("1", "20"), new FactWithIdentityEquatable("2", "20"));
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_DefaultComparer_CustomWithSameIdentityDifferentEquality_False()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var result = target.Equals(new FactWithCustomIdentity(1, "20"), new FactWithCustomIdentity(1, "21"));
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_CustomDefaultComparer_CustomWithSameIdentityDifferentEquality_True()
+    {
+        // Arrange
+        var target = CreateTarget(new CustomFactIdentityComparer());
+
+        // Act
+        var result = target.Equals(new FactWithCustomIdentity(1, "20"), new FactWithCustomIdentity(1, "21"));
+
+        // Assert
+        Assert.True(result);
+    }
+    
+    [Fact]
+    public void Equals_CustomDefaultComparer_CustomWithDifferentIdentitySameEquality_False()
+    {
+        // Arrange
+        var target = CreateTarget(new CustomFactIdentityComparer());
+
+        // Act
+        var result = target.Equals(new FactWithCustomIdentity(1, "20"), new FactWithCustomIdentity(2, "20"));
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedCustomDefaultComparer_CustomWithSameIdentityDifferentEquality_True()
+    {
+        // Arrange
+        var target = CreateTarget(new CustomFactIdentityComparer()).GetComparer<FactWithCustomIdentity>();
+
+        // Act
+        var result = target.Equals(new FactWithCustomIdentity(1, "20"), new FactWithCustomIdentity(1, "21"));
+
+        // Assert
+        Assert.True(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedCustomDefaultComparer_CustomWithDifferentIdentitySameEquality_False()
+    {
+        // Arrange
+        var target = CreateTarget(new CustomFactIdentityComparer()).GetComparer<FactWithCustomIdentity>();
+
+        // Act
+        var result = target.Equals(new FactWithCustomIdentity(1, "20"), new FactWithCustomIdentity(2, "20"));
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_DefaultComparer_FactsWithSameOpaqueIdentity_False()
+    {
+        // Arrange
+        var target = CreateTarget();
+
+        // Act
+        var result = target.Equals(new FactWithOpaqueIdentity(1), new FactWithOpaqueIdentity(1));
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_DefaultComparerPlusCustomFactComparer_FactsWithSameOpaqueIdentity_True()
+    {
+        // Arrange
+        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer());
+
+        // Act
+        var result = target.Equals(new FactWithOpaqueIdentity(1), new FactWithOpaqueIdentity(1));
+
+        // Assert
+        Assert.True(result);
+    }
+    
+    [Fact]
+    public void Equals_DefaultComparerPlusCustomFactComparer_FactsWithDifferentOpaqueIdentity_False()
+    {
+        // Arrange
+        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer());
+
+        // Act
+        var result = target.Equals(new FactWithOpaqueIdentity(1), new FactWithOpaqueIdentity(2));
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedCustomFactComparer_Nulls_True()
+    {
+        // Arrange
+        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+            .GetComparer<FactWithOpaqueIdentity>();
+
+        // Act
+        var result = target.Equals(null, null);
+
+        // Assert
+        Assert.True(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedCustomFactComparer_NullAndObject_False()
+    {
+        // Arrange
+        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+            .GetComparer<FactWithOpaqueIdentity>();
+
+        // Act
+        var result = target.Equals(null, new FactWithOpaqueIdentity(1));
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedCustomFactComparer_ObjectAndNull_False()
+    {
+        // Arrange
+        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+            .GetComparer<FactWithOpaqueIdentity>();
+
+        // Act
+        var result = target.Equals(new FactWithOpaqueIdentity(1), null);
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedCustomFactComparer_DifferentTypesInOneOrder_False()
+    {
+        // Arrange
+        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+            .GetComparer<FactWithOpaqueIdentity>();
+
+        // Act
+        var result = target.Equals(new FactWithOpaqueIdentity(1), new FactChildWithOpaqueIdentity(1));
+
+        // Assert
+        Assert.False(result);
+    }
+        
+    [Fact]
+    public void Equals_StronglyTypedCustomFactComparer_DifferentTypesInAnotherOrder_False()
+    {
+        // Arrange
+        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+            .GetComparer<FactWithOpaqueIdentity>();
+
+        // Act
+        var result = target.Equals(new FactChildWithOpaqueIdentity(1), new FactWithOpaqueIdentity(1));
+
+        // Assert
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedCustomFactComparer_FactsWithSameOpaqueIdentity_True()
+    {
+        // Arrange
+        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+            .GetComparer<FactWithOpaqueIdentity>();
+
+        // Act
+        var result = target.Equals(new FactWithOpaqueIdentity(1), new FactWithOpaqueIdentity(1));
+
+        // Assert
+        Assert.True(result);
+    }
+    
+    [Fact]
+    public void Equals_StronglyTypedCustomFactComparer_FactsWithDifferentOpaqueIdentity_False()
+    {
+        // Arrange
+        var target = CreateTargetWithCustomComparer(new FactWithOpaqueIdentityComparer())
+            .GetComparer<FactWithOpaqueIdentity>();
+
+        // Act
+        var result = target.Equals(new FactWithOpaqueIdentity(1), new FactWithOpaqueIdentity(2));
+
+        // Assert
+        Assert.False(result);
+    }
+
+    private static IFactIdentityComparer CreateTarget(IEqualityComparer<object>? defaultComparer = null, 
+        IReadOnlyCollection<FactIdentityComparerRegistry.Entry>? customComparers = null)
+    {
+        var target = new FactIdentityComparer(
+            defaultComparer ?? new DefaultFactIdentityComparer(),
+            customComparers ?? []);
+        return target;
+    }
+    
+    private static IFactIdentityComparer CreateTargetWithCustomComparer<T>(IEqualityComparer<T> comparer)
+    {
+        var registry = new FactIdentityComparerRegistry();
+        registry.RegisterComparer(comparer);
+        var target = CreateTarget(customComparers: registry.GetComparers());
+        return target;
+    }
+
+    public class FactWithIdentity(string id) : IIdentityProvider
+    {
+        public string Id { get; } = id;
+        public object GetIdentity() => Id;
+    }
+
+    public class FactEquatable(string id) : IEquatable<FactEquatable>
+    {
+        public string Id { get; } = id;
+
+        public bool Equals(FactEquatable? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Id == other.Id;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((FactEquatable)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+    }
+
+    public class FactWithIdentityEquatable(string id, string value)
+        : FactWithIdentity(id), IEquatable<FactWithIdentityEquatable>
+    {
+        public string Value { get; } = value;
+
+        public bool Equals(FactWithIdentityEquatable? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((FactWithIdentityEquatable)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+    }
+    
+    public interface IHaveCustomIdentity
+    {
+        int GetIdentity();
+    }
+    
+    public class FactWithCustomIdentity(int id, string value) : IHaveCustomIdentity, IEquatable<FactWithCustomIdentity>
+    {
+        public int Id { get; } = id;
+        public string Value { get; } = value;
+
+        public int GetIdentity() => Id;
+
+        public bool Equals(FactWithCustomIdentity? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((FactWithCustomIdentity)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+    }
+    
+    public class CustomFactIdentityComparer : IEqualityComparer<object>
+    {
+        bool IEqualityComparer<object>.Equals(object? obj1, object? obj2)
+        {
+            if (obj1 is IHaveCustomIdentity provider1 && obj2 is IHaveCustomIdentity provider2)
+                return provider1.GetIdentity() == provider2.GetIdentity();
+
+            return object.Equals(obj1, obj2);
+        }
+
+        int IEqualityComparer<object>.GetHashCode(object? obj)
+        {
+            if (obj is IHaveCustomIdentity provider)
+                return provider.GetIdentity().GetHashCode();
+            
+            return obj?.GetHashCode() ?? 0;
+        }
+    }
+    
+    public class FactWithOpaqueIdentity(int id)
+    {
+        public int Id { get; } = id;
+    }
+    
+    public class FactChildWithOpaqueIdentity(int id) : FactWithOpaqueIdentity(id)
+    {
+    }
+
+    public class FactWithOpaqueIdentityComparer : IEqualityComparer<FactWithOpaqueIdentity>
+    {
+        public bool Equals(FactWithOpaqueIdentity? obj1, FactWithOpaqueIdentity? obj2)
+        {
+            return obj1!.Id == obj2!.Id;
+        }
+
+        public int GetHashCode(FactWithOpaqueIdentity obj)
+        {
+            return obj.Id;
+        }
+    }
+}


### PR DESCRIPTION
Detailed description in the docs (docs/articles/fact-equality-and-identity.md).

Ability to compare fact identity by implementing an interface or defining a custom equality comparer. Or completely taking over by redefining default comparer.

Closes #336 