### PR TITLE
Extending RuleTypeScanner with a Where filtering function. 

### DIFF
--- a/src/NRules/NRules.Fluent/RuleTypeScanner.cs
+++ b/src/NRules/NRules.Fluent/RuleTypeScanner.cs
@@ -54,6 +54,13 @@ public interface IRuleTypeScanner
     /// <param name="types">Types to scan.</param>
     /// <returns>Rule type scanner to continue scanning specification.</returns>
     IRuleTypeScanner Type(params Type[] types);
+   
+    /// <summary>
+    /// Filters rule types using a predicate.
+    /// </summary>
+    /// <param name="predicate">The filter to use.</param>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    IRuleTypeScanner Where(Func<Type, bool> predicate);
 }
 
 /// <summary>
@@ -131,6 +138,19 @@ public class RuleTypeScanner : IRuleTypeScanner
         var ruleTypes = types
             .Where(IsRuleType);
         _ruleTypes.AddRange(ruleTypes);
+        return this;
+    }
+
+    /// <summary>
+    /// Filters rule types using a predicate.
+    /// </summary>
+    /// <param name="predicate">The filter to use.</param>
+    /// <returns>Rule type scanner to continue scanning specification.</returns>
+    public IRuleTypeScanner Where(Func<Type, bool> predicate)
+    {
+        var ruleTypesToKeep = _ruleTypes.Where(predicate);
+        var ruleTypesToRemove = _ruleTypes.Except(ruleTypesToKeep);
+        _ruleTypes.RemoveAll(x => ruleTypesToRemove.Contains(x));
         return this;
     }
 

--- a/src/NRules/NRules.Fluent/RuleTypeScanner.cs
+++ b/src/NRules/NRules.Fluent/RuleTypeScanner.cs
@@ -71,7 +71,8 @@ public class RuleTypeScanner : IRuleTypeScanner
     private readonly List<Type> _ruleTypes = new();
     private bool _nestedTypes = false;
     private bool _privateTypes = false;
-
+    private Func<Type, bool>? _filterFunc = null;
+    
     /// <summary>
     /// Enables/disables discovery of private rule classes.
     /// Default is off.
@@ -148,9 +149,7 @@ public class RuleTypeScanner : IRuleTypeScanner
     /// <returns>Rule type scanner to continue scanning specification.</returns>
     public IRuleTypeScanner Where(Func<Type, bool> predicate)
     {
-        var ruleTypesToKeep = _ruleTypes.Where(predicate);
-        var ruleTypesToRemove = _ruleTypes.Except(ruleTypesToKeep);
-        _ruleTypes.RemoveAll(x => ruleTypesToRemove.Contains(x));
+        _filterFunc = predicate;
         return this;
     }
 
@@ -163,6 +162,10 @@ public class RuleTypeScanner : IRuleTypeScanner
         var ruleTypes = _ruleTypes
             .Where(t => _privateTypes || !t.IsNotPublic)
             .Where(t => _nestedTypes || !t.IsNested);
+        if (_filterFunc != null)
+        {
+            ruleTypes = ruleTypes.Where(_filterFunc);
+        }
         return ruleTypes.ToArray();
     }
 

--- a/src/NRules/Tests/NRules.Tests/Fluent/RuleTypeScannerTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Fluent/RuleTypeScannerTest.cs
@@ -17,12 +17,13 @@ namespace NRules.Tests.Fluent
             //Act
             var scanner02 = new RuleTypeScanner();
             scanner02.AssemblyOf<RuleTypeScannerTest>()
-                .Where(ruleType => ruleType.Namespace == "NRules.Tests.Fluent.SubNsA");
+                .Where(ruleType => ruleType.Namespace!.StartsWith("NRules.Tests.Fluent.SubNsA"));
             var subNsARules = scanner02.GetRuleTypes();
            
             //Assert
-            Assert.Equal(3, allRules.Length);
-            Assert.Single(subNsARules);
+            Assert.Equal(4, allRules.Length);
+            Assert.Equal(2, subNsARules.Length);
+            Assert.Contains(subNsARules, ruleType => ruleType.FullName == "NRules.Tests.Fluent.SubNsA.SubNsAa.TestRule002");
         }
     }
 
@@ -39,6 +40,16 @@ namespace NRules.Tests.Fluent
         {
             public override void Define()
             {
+            }
+        }
+
+        namespace SubNsAa
+        {
+            public class TestRule002 : Rule
+            {
+                public override void Define()
+                {
+                }
             }
         }
     }

--- a/src/NRules/Tests/NRules.Tests/Fluent/RuleTypeScannerTest.cs
+++ b/src/NRules/Tests/NRules.Tests/Fluent/RuleTypeScannerTest.cs
@@ -1,0 +1,55 @@
+using NRules.Fluent;
+using NRules.Fluent.Dsl;
+using Xunit;
+
+namespace NRules.Tests.Fluent
+{
+    public class RuleTypeScannerTest
+    {
+        [Fact]
+        public void Where_FilterOnNamespacePrefix_FiltersCorrectly()
+        {
+            //Arrange
+            var scanner01 = new RuleTypeScanner();
+            scanner01.AssemblyOf<RuleTypeScannerTest>();
+            var allRules = scanner01.GetRuleTypes();
+           
+            //Act
+            var scanner02 = new RuleTypeScanner();
+            scanner02.AssemblyOf<RuleTypeScannerTest>()
+                .Where(ruleType => ruleType.Namespace == "NRules.Tests.Fluent.SubNsA");
+            var subNsARules = scanner02.GetRuleTypes();
+           
+            //Assert
+            Assert.Equal(3, allRules.Length);
+            Assert.Single(subNsARules);
+        }
+    }
+
+    public class TestRule001 : Rule
+    {
+        public override void Define()
+        {
+        }
+    }
+
+    namespace SubNsA
+    {
+        public class TestRule001 : Rule
+        {
+            public override void Define()
+            {
+            }
+        }
+    }
+
+    namespace SubNsB
+    {
+        public class TestRule002 : Rule
+        {
+            public override void Define()
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
This in order to support scanning on namespace prefix.

We have a big assembly per product of which multiple disciplenes (variations) are present. Per discipline 20 to 100 rules.
Would be nice if the RuleTypeScanner supports namespace prefixing out of the box.