### PR TITLE
Fix alias replacement in expressions

### DIFF
--- a/src/NRules/NRules.Fluent/Expressions/ExpressionRewriter.cs
+++ b/src/NRules/NRules.Fluent/Expressions/ExpressionRewriter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using NRules.RuleModel;
 
 namespace NRules.Fluent.Expressions;
@@ -27,24 +28,41 @@ internal class ExpressionRewriter(ISymbolLookup symbolLookup) : ExpressionVisito
 
     protected override Expression VisitMember(MemberExpression node)
     {
-        if (node.Expression is ConstantExpression &&
-            SymbolLookup.TryGetValue(node.Member.Name, out var declaration))
+        switch (node)
         {
-            ParameterExpression? parameter = Parameters.FirstOrDefault(p => p.Name == declaration.Name);
-            if (parameter == null)
-            {
-                parameter = declaration.ToParameterExpression();
-                Parameters.Add(parameter);
-            }
-            
-            if (parameter.Type != declaration.Type)
-            {
-                throw new ArgumentException(
-                    $"Expression parameter type mismatch. Name={declaration.Name}, ExpectedType={declaration.Type}, FoundType={parameter.Type}");
-            }
-            return parameter;
+            case { Expression: ConstantExpression}:
+                if (SymbolLookup.TryGetValue(node.Member.Name, out var declaration1))
+                    return ReplaceWithParameter(declaration1);
+                break;
+            case { Expression: MemberExpression, Member: PropertyInfo pi }:
+                if (SymbolLookup.TryGetValue(node.Member.Name, out var declaration2) &&
+                    declaration2.Type.IsAssignableFrom(pi.PropertyType))
+                    return ReplaceWithParameter(declaration2);
+                break;
+            case { Expression: MemberExpression, Member: FieldInfo fi }:
+                if (SymbolLookup.TryGetValue(node.Member.Name, out var declaration3) &&
+                    declaration3.Type.IsAssignableFrom(fi.FieldType))
+                    return ReplaceWithParameter(declaration3);
+                break;
         }
-
+        
         return base.VisitMember(node);
+    }
+
+    private Expression ReplaceWithParameter(Declaration declaration)
+    {
+        ParameterExpression? parameter = Parameters.FirstOrDefault(p => p.Name == declaration.Name);
+        if (parameter == null)
+        {
+            parameter = declaration.ToParameterExpression();
+            Parameters.Add(parameter);
+        }
+        else if (parameter.Type != declaration.Type)
+        {
+            throw new ArgumentException(
+                $"Expression parameter type mismatch. Name={declaration.Name}, ExpectedType={declaration.Type}, FoundType={parameter.Type}");
+        }
+        
+        return parameter;
     }
 }


### PR DESCRIPTION
- Rewrite aliases in expressions when using properties and fields as binding variables