### PR TITLE
Upgrade .NET SDK and Test Targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-NRules is an open-source cross-platform production rules engine for .NET, based on the Rete matching algorithm. Rules are authored in C# using a fluent DSL. The core libraries target netstandard2.0/netstandard2.1; tests target net6/net8.
+NRules is an open-source cross-platform production rules engine for .NET, based on the Rete matching algorithm. Rules are authored in C# using a fluent DSL. The core libraries target netstandard2.0/netstandard2.1; tests target net8.0/net10.0.
 
 ## Build Commands
 

--- a/bench/NRules.Benchmark/NRules.Benchmark/NRules.Benchmark.csproj
+++ b/bench/NRules.Benchmark/NRules.Benchmark/NRules.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6;net8</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
     <Nullable>enable</Nullable>

--- a/build.ps1
+++ b/build.ps1
@@ -158,21 +158,21 @@ $components = @{
         solution_file = 'bench\NRules.Benchmark\NRules.Benchmark.sln'
         package = @{
             bin = @{
-                artifacts = @('net6', 'net8')
-                'net6' = @{
+                artifacts = @('net8.0', 'net10.0')
+                'net8.0' = @{
                     include = @(
-                        "NRules.Benchmark\bin\$configuration\net6"
+                        "NRules.Benchmark\bin\$configuration\net8.0"
                     )
                 }
-                'net8' = @{
+                'net10.0' = @{
                     include = @(
-                        "NRules.Benchmark\bin\$configuration\net8"
+                        "NRules.Benchmark\bin\$configuration\net10.0"
                     )
                 }
             }
         }
         bench = @{
-            frameworks = @('net8')
+            frameworks = @('net8.0')
             runner = 'NRules.Benchmark'
             categories = @('Micro')
         }

--- a/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/NRules.Integration.Autofac.Tests.csproj
+++ b/src/NRules.Integration/NRules.Integration.Autofac/NRules.Integration.Autofac.Tests/NRules.Integration.Autofac.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6;net8</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
     <LangVersion>latest</LangVersion>

--- a/src/NRules.Integration/NRules.Integration.DependencyInjection/NRules.Integration.DependencyInjection.Tests/NRules.Integration.DependencyInjection.Tests.csproj
+++ b/src/NRules.Integration/NRules.Integration.DependencyInjection/NRules.Integration.DependencyInjection.Tests/NRules.Integration.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6;net8</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
     <LangVersion>latest</LangVersion>

--- a/src/NRules.Integration/NRules.Integration.SimpleInjector/NRules.Integration.SimpleInjector.Tests/NRules.Integration.SimpleInjector.Tests.csproj
+++ b/src/NRules.Integration/NRules.Integration.SimpleInjector/NRules.Integration.SimpleInjector.Tests/NRules.Integration.SimpleInjector.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
     <LangVersion>latest</LangVersion>

--- a/src/NRules/Tests/NRules.IntegrationTests/NRules.IntegrationTests.csproj
+++ b/src/NRules/Tests/NRules.IntegrationTests/NRules.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6;net8</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
     <LangVersion>latest</LangVersion>

--- a/src/NRules/Tests/NRules.Json.Tests/NRules.Json.Tests.csproj
+++ b/src/NRules/Tests/NRules.Json.Tests/NRules.Json.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6;net8</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
     <LangVersion>latest</LangVersion>

--- a/src/NRules/Tests/NRules.Tests/NRules.Tests.csproj
+++ b/src/NRules/Tests/NRules.Tests/NRules.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6;net8</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\SigningKey.snk</AssemblyOriginatorKeyFile>
     <LangVersion>latest</LangVersion>

--- a/tools/build/psakefile.ps1
+++ b/tools/build/psakefile.ps1
@@ -4,8 +4,8 @@ param (
 
 properties {
     $version = $null
-    $sdkVersion = "8.0.404"
-    $sdkRuntimes = @("8.0.0", "6.0.0")
+    $sdkVersion = "10.0.201"
+    $sdkRuntimes = @("8.0.0", "10.0.0")
     $configuration = "Release"
     $baseDir = $null
 }


### PR DESCRIPTION
This pull request updates the project's target frameworks and build configuration to focus on .NET 8.0 and .NET 10.0, removing support for .NET 6.0. The changes ensure that all relevant projects, benchmarks, and build scripts are aligned with these newer frameworks.

Framework and Project Updates:

* Updated all test projects to target only `net8.0` and `net10.0`
* Updated the benchmark project (`NRules.Benchmark.csproj`) to target `net8.0` and `net10.0` only.

Build and Packaging Script Adjustments:

* Modified `build.ps1` and `psakefile.ps1` to reference only `net8.0` and `net10.0`, and updated SDK/runtime versions accordingly. 

Documentation:

* Updated `CLAUDE.md` to reflect the new test target frameworks (`net8.0/net10.0`) in the project overview section.